### PR TITLE
Redirect logged-in users to dashboard and show current user info

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,11 +1,19 @@
-'use client';
 import { Suspense } from 'react';
+import { redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
 import LoginForm from '@/components/LoginForm';
 
-export default function LoginPage() {
+export default async function LoginPage() {
+  const supabase = createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (user) redirect('/dashboard');
+
   return (
     <Suspense fallback={null}>
       <LoginForm />
     </Suspense>
   );
 }
+

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import { useState } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { supabase } from '@/lib/supabase/client';
 
 export default function LoginForm() {
   const params = useSearchParams();
+  const router = useRouter();
 
   const [email, setEmail] = useState(params.get('email') || '');
   const [password, setPassword] = useState('');
@@ -19,8 +20,8 @@ export default function LoginForm() {
     try {
       const { error } = await supabase.auth.signInWithPassword({ email, password });
       if (error) throw error;
-      // Use a full page reload so server components can pick up the new session.
-      window.location.href = '/dashboard';
+      router.replace('/dashboard');
+      router.refresh();
     } catch (e: any) {
       setErr(e?.message || 'Sign in failed');
     } finally {

--- a/components/LogoutButton.tsx
+++ b/components/LogoutButton.tsx
@@ -1,30 +1,40 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import type { User } from '@supabase/supabase-js'
 import { supabase } from '@/lib/supabase/client'
 
 export default function LogoutButton() {
-  const [hasUser, setHasUser] = useState(false)
+  const [user, setUser] = useState<User | null>(null)
 
   useEffect(() => {
     let mounted = true
     supabase.auth.getUser().then(({ data: { user } }) => {
-      if (mounted) setHasUser(!!user)
+      if (mounted) setUser(user)
     })
-    const { data: sub } = supabase.auth.onAuthStateChange((_e, s) => {
-      setHasUser(!!s?.user)
+    const { data: sub } = supabase.auth.onAuthStateChange((_e, session) => {
+      setUser(session?.user ?? null)
     })
-    return () => sub.subscription.unsubscribe()
+    return () => {
+      mounted = false
+      sub.subscription.unsubscribe()
+    }
   }, [])
 
-  if (!hasUser) return null
+  if (!user) return null
 
   return (
-    <button
-      className="w-full rounded bg-gray-800 px-3 py-2 text-white"
-      onClick={async () => { await supabase.auth.signOut(); window.location.href = '/login' }}
-    >
-      Log out
-    </button>
+    <div>
+      <p className="mb-2 text-sm text-gray-700">Logged in as {user.email}</p>
+      <button
+        className="w-full rounded bg-gray-800 px-3 py-2 text-white"
+        onClick={async () => {
+          await supabase.auth.signOut()
+          window.location.href = '/login'
+        }}
+      >
+        Log out
+      </button>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- Redirect authenticated visitors to the dashboard instead of showing the login page
- Navigate to the dashboard after login using the Next.js router
- Display the current user's email above the logout button

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c10bcb9c448324bf3821b5664c75fd