### PR TITLE
Add calendar link to sidebar navigation

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -9,6 +9,7 @@ const nav = [
   { href: '/dashboard', label: 'Dashboard' },
   { href: '/clients', label: 'Clients' },
   { href: '/employees', label: 'Employees' },
+  { href: '/calendar', label: 'Calendar' },
   { href: '/book', label: 'Book Appointment' },
   { href: '/reports', label: 'Reports' },
   { href: '/settings', label: 'Settings' },


### PR DESCRIPTION
## Summary
- add Calendar link to sidebar so users can access the appointments calendar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c10f2b30a48324a4f6325fffa29588