### PR TITLE
Style login page and display user email

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -4,8 +4,22 @@ import LoginForm from '@/components/LoginForm';
 
 export default function LoginPage() {
   return (
-    <Suspense fallback={null}>
-      <LoginForm />
-    </Suspense>
+    <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-blue-800 to-blue-400 text-white">
+      <h1 className="mb-1 text-5xl font-extrabold drop-shadow-md">
+        <span className="text-white">Scruffy</span>{' '}
+        <span className="text-pink-500">Butts</span>
+      </h1>
+      <p className="mb-6 text-center text-sm leading-tight">
+        DOG GROOMING<br />NATALIA TX
+      </p>
+      <Suspense fallback={null}>
+        <LoginForm />
+      </Suspense>
+      <div className="mt-8 flex gap-8 text-5xl text-yellow-400">
+        <span>✂️</span>
+        <span>🪮</span>
+        <span>🧼</span>
+      </div>
+    </div>
   );
 }

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -29,46 +29,82 @@ export default function LoginForm() {
   };
 
   return (
-    <form onSubmit={onSubmit} className="w-full max-w-sm rounded-lg border p-6 bg-white">
-      <h1 className="text-xl font-semibold mb-4">Log in</h1>
-
+    <form onSubmit={onSubmit} className="w-full max-w-xs text-center">
       {err && (
         <div className="mb-3 rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700">
           {err}
         </div>
       )}
 
-      <label className="block text-sm font-medium">Email</label>
-      <input
-        className="mt-1 mb-3 w-full rounded border px-3 py-2"
-        type="email"
-        required
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        placeholder="you@example.com"
-      />
+      <div className="relative mb-4">
+        <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-yellow-500">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className="h-5 w-5"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.02 1.89l-7.5 4.875a2.25 2.25 0 01-2.46 0L3.27 8.883a2.25 2.25 0 01-1.02-1.89V6.75"
+            />
+          </svg>
+        </div>
+        <input
+          className="w-full rounded-full border py-2 pl-10 pr-3 placeholder-gray-500"
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="User@email.com"
+        />
+      </div>
 
-      <label className="block text-sm font-medium">Password</label>
-      <input
-        className="mt-1 mb-4 w-full rounded border px-3 py-2"
-        type="password"
-        required
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        placeholder="••••••••"
-      />
+      <div className="relative mb-6">
+        <div className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3 text-yellow-500">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={1.5}
+            stroke="currentColor"
+            className="h-5 w-5"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-1.5 0h12a2.25 2.25 0 012.25 2.25v6.75a2.25 2.25 0 01-2.25 2.25h-12A2.25 2.25 0 012 19.5v-6.75a2.25 2.25 0 012.25-2.25z"
+            />
+          </svg>
+        </div>
+        <input
+          className="w-full rounded-full border py-2 pl-10 pr-3"
+          type="password"
+          required
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+        />
+      </div>
 
       <button
         type="submit"
         disabled={loading}
-        className="w-full rounded bg-black px-4 py-2 text-white disabled:opacity-60"
+        className="w-full rounded-full bg-blue-800 py-2 text-white disabled:opacity-60"
       >
-        {loading ? 'Signing in…' : 'Sign in'}
+        {loading ? 'Signing in…' : 'Log In'}
       </button>
 
-      <div className="mt-4 flex justify-between text-sm">
-        <a className="text-blue-600 underline" href="/signup">Create account</a>
-        <a className="text-blue-600 underline" href="/reset-password">Forgot password?</a>
+      <div className="mt-4 space-y-2 text-sm">
+        <a className="block text-white underline" href="/reset-password">
+          Forgot Password?
+        </a>
+        <a className="block text-white underline" href="/signup">
+          Sign up for an account
+        </a>
       </div>
     </form>
   );

--- a/components/LogoutButton.tsx
+++ b/components/LogoutButton.tsx
@@ -1,30 +1,36 @@
-'use client'
+'use client';
 
-import { useEffect, useState } from 'react'
-import { supabase } from '@/lib/supabase/client'
+import { useEffect, useState } from 'react';
+import { supabase } from '@/lib/supabase/client';
 
 export default function LogoutButton() {
-  const [hasUser, setHasUser] = useState(false)
+  const [email, setEmail] = useState<string | null>(null);
 
   useEffect(() => {
-    let mounted = true
+    let mounted = true;
     supabase.auth.getUser().then(({ data: { user } }) => {
-      if (mounted) setHasUser(!!user)
-    })
-    const { data: sub } = supabase.auth.onAuthStateChange((_e, s) => {
-      setHasUser(!!s?.user)
-    })
-    return () => sub.subscription.unsubscribe()
-  }, [])
+      if (mounted) setEmail(user?.email ?? null);
+    });
+    const { data: subscription } = supabase.auth.onAuthStateChange((_e, session) => {
+      setEmail(session?.user?.email ?? null);
+    });
+    return () => subscription.subscription.unsubscribe();
+  }, []);
 
-  if (!hasUser) return null
+  if (!email) return null;
 
   return (
-    <button
-      className="w-full rounded bg-gray-800 px-3 py-2 text-white"
-      onClick={async () => { await supabase.auth.signOut(); window.location.href = '/login' }}
-    >
-      Log out
-    </button>
-  )
+    <div className="space-y-2">
+      <div className="break-all text-sm text-gray-600">{email}</div>
+      <button
+        className="w-full rounded bg-gray-800 px-3 py-2 text-white"
+        onClick={async () => {
+          await supabase.auth.signOut();
+          window.location.href = '/login';
+        }}
+      >
+        Log out
+      </button>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- Add gradient login page matching provided design
- Style login form with icons, links, and rounded inputs
- Show signed-in user email above logout button

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c11acfdd1083249c8b6a562924d334