### PR TITLE
fix: ensure login redirects to dashboard

### DIFF
--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useState } from 'react';
-import { useSearchParams } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { supabase } from '@/lib/supabase/client';
 
 export default function LoginForm() {
+  const router = useRouter();
   const params = useSearchParams();
 
   const [email, setEmail] = useState(params.get('email') || '');
@@ -19,8 +20,8 @@ export default function LoginForm() {
     try {
       const { error } = await supabase.auth.signInWithPassword({ email, password });
       if (error) throw error;
-      // Use a full page reload so server components can pick up the new session.
-      window.location.href = '/dashboard';
+      router.replace('/dashboard');
+      router.refresh();
     } catch (e: any) {
       setErr(e?.message || 'Sign in failed');
     } finally {


### PR DESCRIPTION
## Summary
- use Next.js router to navigate to dashboard after successful login

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c168317c88832485855347f38df4a4