### PR TITLE
Display current user above logout button

### DIFF
--- a/components/LogoutButton.tsx
+++ b/components/LogoutButton.tsx
@@ -1,30 +1,42 @@
 'use client'
 
 import { useEffect, useState } from 'react'
+import type { User } from '@supabase/supabase-js'
 import { supabase } from '@/lib/supabase/client'
 
 export default function LogoutButton() {
-  const [hasUser, setHasUser] = useState(false)
+  const [user, setUser] = useState<User | null>(null)
 
   useEffect(() => {
     let mounted = true
     supabase.auth.getUser().then(({ data: { user } }) => {
-      if (mounted) setHasUser(!!user)
+      if (mounted) setUser(user)
     })
     const { data: sub } = supabase.auth.onAuthStateChange((_e, s) => {
-      setHasUser(!!s?.user)
+      setUser(s?.user ?? null)
     })
     return () => sub.subscription.unsubscribe()
   }, [])
 
-  if (!hasUser) return null
+  if (!user) return null
+
+  const name =
+    (user.user_metadata?.name as string | undefined) ||
+    (user.user_metadata?.full_name as string | undefined) ||
+    user.email
 
   return (
-    <button
-      className="w-full rounded bg-gray-800 px-3 py-2 text-white"
-      onClick={async () => { await supabase.auth.signOut(); window.location.href = '/login' }}
-    >
-      Log out
-    </button>
+    <div>
+      <p className="mb-2 text-sm text-gray-600">Logged in as {name}</p>
+      <button
+        className="w-full rounded bg-gray-800 px-3 py-2 text-white"
+        onClick={async () => {
+          await supabase.auth.signOut()
+          window.location.href = '/login'
+        }}
+      >
+        Log out
+      </button>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- show "Logged in as" with the user's name or email above the logout button

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c16ba8cec4832497361490ccdc08db