### PR TITLE
Add missing pages to sidebar navigation

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -13,6 +13,12 @@ const nav = [
   { href: '/book', label: 'Book Appointment' },
   { href: '/reports', label: 'Reports' },
   { href: '/settings', label: 'Settings' },
+  { href: '/messages', label: 'Messages' },
+  { href: '/login', label: 'Login' },
+  { href: '/signup', label: 'Sign Up' },
+  { href: '/forgot-password', label: 'Forgot Password' },
+  { href: '/reset-password', label: 'Reset Password' },
+  { href: '/logout', label: 'Logout' },
 ];
 
 export default function Sidebar() {


### PR DESCRIPTION
## Summary
- List all site pages in the sidebar navigation so they are discoverable

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c17b22d5a483249184ba6221875a17