### PR TITLE
Show user email and improve login flow

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,11 +1,15 @@
-'use client';
-import { Suspense } from 'react';
-import LoginForm from '@/components/LoginForm';
+import { Suspense } from 'react'
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import LoginForm from '@/components/LoginForm'
 
-export default function LoginPage() {
+export default async function LoginPage() {
+  const supabase = createClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (user) redirect('/dashboard')
   return (
     <Suspense fallback={null}>
       <LoginForm />
     </Suspense>
-  );
+  )
 }

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -20,7 +20,7 @@ export default function LoginForm() {
       const { error } = await supabase.auth.signInWithPassword({ email, password });
       if (error) throw error;
       // Use a full page reload so server components can pick up the new session.
-      window.location.href = '/dashboard';
+      window.location.href = '/';
     } catch (e: any) {
       setErr(e?.message || 'Sign in failed');
     } finally {

--- a/components/LogoutButton.tsx
+++ b/components/LogoutButton.tsx
@@ -4,27 +4,36 @@ import { useEffect, useState } from 'react'
 import { supabase } from '@/lib/supabase/client'
 
 export default function LogoutButton() {
-  const [hasUser, setHasUser] = useState(false)
+  const [email, setEmail] = useState<string | null>(null)
 
   useEffect(() => {
     let mounted = true
     supabase.auth.getUser().then(({ data: { user } }) => {
-      if (mounted) setHasUser(!!user)
+      if (mounted) setEmail(user?.email ?? null)
     })
     const { data: sub } = supabase.auth.onAuthStateChange((_e, s) => {
-      setHasUser(!!s?.user)
+      setEmail(s?.user?.email ?? null)
     })
-    return () => sub.subscription.unsubscribe()
+    return () => {
+      mounted = false
+      sub.subscription.unsubscribe()
+    }
   }, [])
 
-  if (!hasUser) return null
+  if (!email) return null
 
   return (
-    <button
-      className="w-full rounded bg-gray-800 px-3 py-2 text-white"
-      onClick={async () => { await supabase.auth.signOut(); window.location.href = '/login' }}
-    >
-      Log out
-    </button>
+    <div className="space-y-2 text-sm">
+      <div className="truncate">{email}</div>
+      <button
+        className="w-full rounded bg-gray-800 px-3 py-2 text-white"
+        onClick={async () => {
+          await supabase.auth.signOut()
+          window.location.href = '/login'
+        }}
+      >
+        Log out
+      </button>
+    </div>
   )
 }


### PR DESCRIPTION
## Summary
- Display logged-in user's email above the logout button
- Redirect login form to the main page after sign in
- Skip login page when already authenticated

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c17fede2a48324a576c0e90c457fc6