### PR TITLE
fix: persist logout button

### DIFF
--- a/components/LogoutButton.tsx
+++ b/components/LogoutButton.tsx
@@ -1,39 +1,37 @@
-'use client'
+'use client';
 
-import { useEffect, useState } from 'react'
-import { supabase } from '@/lib/supabase/client'
+import { useEffect, useState } from 'react';
+import { supabase } from '@/lib/supabase/client';
 
 export default function LogoutButton() {
-  const [email, setEmail] = useState<string | null>(null)
+  const [email, setEmail] = useState<string | null>(null);
 
   useEffect(() => {
-    let mounted = true
-    supabase.auth.getUser().then(({ data: { user } }) => {
-      if (mounted) setEmail(user?.email ?? null)
-    })
+    let mounted = true;
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (mounted) setEmail(session?.user?.email ?? null);
+    });
     const { data: sub } = supabase.auth.onAuthStateChange((_e, s) => {
-      setEmail(s?.user?.email ?? null)
-    })
+      setEmail(s?.user?.email ?? null);
+    });
     return () => {
-      mounted = false
-      sub.subscription.unsubscribe()
-    }
-  }, [])
-
-  if (!email) return null
+      mounted = false;
+      sub.subscription.unsubscribe();
+    };
+  }, []);
 
   return (
     <div className="space-y-2 text-sm">
-      <div className="truncate">{email}</div>
+      {email && <div className="truncate">{email}</div>}
       <button
         className="w-full rounded bg-gray-800 px-3 py-2 text-white"
         onClick={async () => {
-          await supabase.auth.signOut()
-          window.location.href = '/login'
+          await supabase.auth.signOut();
+          window.location.href = '/login';
         }}
       >
         Log out
       </button>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- ensure logout button stays visible across page navigation
- fetch user email from auth session instead of user request

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1afa5349c8324b5910cbba2e572c5