### PR TITLE
Persist auth context to prevent logout button flicker

### DIFF
--- a/components/AuthProvider.tsx
+++ b/components/AuthProvider.tsx
@@ -1,16 +1,51 @@
 // components/AuthProvider.tsx
 'use client'
-import { useEffect } from 'react'
+
+import { createContext, useContext, useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabase/client'
 
+type AuthContextValue = {
+  email: string | null
+}
+
+const AuthContext = createContext<AuthContextValue>({ email: null })
+
+export function useAuth() {
+  return useContext(AuthContext)
+}
+
 export default function AuthProvider({ children }: { children: React.ReactNode }) {
   const router = useRouter()
+  const [email, setEmail] = useState<string | null>(() => {
+    if (typeof window !== 'undefined') {
+      return window.localStorage.getItem('sb-email')
+    }
+    return null
+  })
+
   useEffect(() => {
-    const { data: sub } = supabase.auth.onAuthStateChange(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      const newEmail = session?.user?.email ?? null
+      setEmail(newEmail)
+      if (newEmail) {
+        window.localStorage.setItem('sb-email', newEmail)
+      } else {
+        window.localStorage.removeItem('sb-email')
+      }
+    })
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
+      const newEmail = session?.user?.email ?? null
+      setEmail(newEmail)
+      if (newEmail) {
+        window.localStorage.setItem('sb-email', newEmail)
+      } else {
+        window.localStorage.removeItem('sb-email')
+      }
       router.refresh()
     })
-    return () => sub?.subscription?.unsubscribe()
+    return () => sub.subscription.unsubscribe()
   }, [router])
-  return <>{children}</>
+
+  return <AuthContext.Provider value={{ email }}>{children}</AuthContext.Provider>
 }

--- a/components/LogoutButton.tsx
+++ b/components/LogoutButton.tsx
@@ -1,37 +1,23 @@
-'use client';
+'use client'
 
-import { useEffect, useState } from 'react';
-import { supabase } from '@/lib/supabase/client';
+import { supabase } from '@/lib/supabase/client'
+import { useAuth } from '@/components/AuthProvider'
 
 export default function LogoutButton() {
-  const [email, setEmail] = useState<string | null>(null);
-
-  useEffect(() => {
-    let mounted = true;
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      if (mounted) setEmail(session?.user?.email ?? null);
-    });
-    const { data: sub } = supabase.auth.onAuthStateChange((_e, s) => {
-      setEmail(s?.user?.email ?? null);
-    });
-    return () => {
-      mounted = false;
-      sub.subscription.unsubscribe();
-    };
-  }, []);
+  const { email } = useAuth()
 
   return (
-    <div className="space-y-2 text-sm">
-      {email && <div className="truncate">{email}</div>}
+    <div className="text-sm">
+      <div className="mb-2 h-5 truncate">{email}</div>
       <button
         className="w-full rounded bg-gray-800 px-3 py-2 text-white"
         onClick={async () => {
-          await supabase.auth.signOut();
-          window.location.href = '/login';
+          await supabase.auth.signOut()
+          window.location.href = '/login'
         }}
       >
         Log out
       </button>
     </div>
-  );
+  )
 }


### PR DESCRIPTION
## Summary
- initialize auth email from localStorage so it persists across navigation
- keep logout button height consistent to eliminate jumping when switching tabs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1c6a223588324934a500e6bf8bb1e