### PR TITLE
style: redesign login page

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from 'react'
+import Image from 'next/image'
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import LoginForm from '@/components/LoginForm'
@@ -8,9 +9,19 @@ export default async function LoginPage() {
   const { data: { user } } = await supabase.auth.getUser()
   if (user) redirect('/dashboard')
   return (
-    <div className="relative flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-blue-400 to-blue-800">
+    <div
+      className="relative flex min-h-screen flex-col items-center justify-center bg-cover bg-center"
+      style={{ backgroundImage: "url('/login-bg.svg')" }}
+    >
       <div className="mb-8 text-center text-white">
-        <h1 className="text-5xl font-extrabold drop-shadow">Scruffy Butts</h1>
+        <Image
+          src="/logo.svg"
+          alt="Scruffy Butts logo"
+          width={300}
+          height={100}
+          className="mx-auto mb-4 h-auto w-64"
+          priority
+        />
         <p className="mt-2 text-sm font-semibold uppercase tracking-wide">
           Dog Grooming
           <br />

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -8,12 +8,18 @@ export default async function LoginPage() {
   const supabase = createClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (user) redirect('/dashboard')
+
   return (
-    <div
-      className="relative flex min-h-screen flex-col items-center justify-center bg-cover bg-center"
-      style={{ backgroundImage: "url('/login-bg.svg')" }}
-    >
-      <div className="mb-8 text-center text-white">
+    <div className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden">
+      <Image
+        src="/login-bg.svg"
+        alt=""
+        fill
+        priority
+        sizes="100vw"
+        className="object-cover"
+      />
+      <div className="relative z-10 mb-8 text-center text-white">
         <Image
           src="/logo.svg"
           alt="Scruffy Butts logo"
@@ -31,7 +37,6 @@ export default async function LoginPage() {
       <Suspense fallback={null}>
         <LoginForm />
       </Suspense>
-      <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-40 rounded-t-[50%] bg-pink-400 -z-10" />
     </div>
   )
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -8,8 +8,19 @@ export default async function LoginPage() {
   const { data: { user } } = await supabase.auth.getUser()
   if (user) redirect('/dashboard')
   return (
-    <Suspense fallback={null}>
-      <LoginForm />
-    </Suspense>
+    <div className="relative flex min-h-screen flex-col items-center justify-center bg-gradient-to-b from-blue-400 to-blue-800">
+      <div className="mb-8 text-center text-white">
+        <h1 className="text-5xl font-extrabold drop-shadow">Scruffy Butts</h1>
+        <p className="mt-2 text-sm font-semibold uppercase tracking-wide">
+          Dog Grooming
+          <br />
+          Natalia TX
+        </p>
+      </div>
+      <Suspense fallback={null}>
+        <LoginForm />
+      </Suspense>
+      <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-40 rounded-t-[50%] bg-pink-400 -z-10" />
+    </div>
   )
 }

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -29,46 +29,56 @@ export default function LoginForm() {
   };
 
   return (
-    <form onSubmit={onSubmit} className="w-full max-w-sm rounded-lg border p-6 bg-white">
-      <h1 className="text-xl font-semibold mb-4">Log in</h1>
-
+    <form onSubmit={onSubmit} className="w-80 space-y-3">
       {err && (
-        <div className="mb-3 rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700">
+        <div className="mb-2 rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700">
           {err}
         </div>
       )}
 
-      <label className="block text-sm font-medium">Email</label>
-      <input
-        className="mt-1 mb-3 w-full rounded border px-3 py-2"
-        type="email"
-        required
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        placeholder="you@example.com"
-      />
+      <div className="relative">
+        <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-yellow-500">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-5 w-5">
+            <path d="M1.5 6.75A3.75 3.75 0 0 1 5.25 3h13.5A3.75 3.75 0 0 1 22.5 6.75v10.5A3.75 3.75 0 0 1 18.75 21H5.25A3.75 3.75 0 0 1 1.5 17.25V6.75Zm3.75-.75a.75.75 0 0 0-.75.75v.334l7.5 4.688 7.5-4.688V6.75a.75.75 0 0 0-.75-.75H5.25Zm14.25 3.091-6.956 4.348a.75.75 0 0 1-.788 0L4.8 9.091v8.159c0 .414.336.75.75.75h13.5a.75.75 0 0 0 .75-.75V9.091Z" />
+          </svg>
+        </span>
+        <input
+          className="w-full rounded-full py-3 pl-12 pr-4 text-sm placeholder-gray-500 focus:outline-none"
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="User@email.com"
+        />
+      </div>
 
-      <label className="block text-sm font-medium">Password</label>
-      <input
-        className="mt-1 mb-4 w-full rounded border px-3 py-2"
-        type="password"
-        required
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        placeholder="••••••••"
-      />
+      <div className="relative">
+        <span className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2 text-yellow-500">
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="h-5 w-5">
+            <path fillRule="evenodd" d="M12 1.5a5.25 5.25 0 0 0-5.25 5.25v3a3 3 0 0 0-3 3v6.75A3.75 3.75 0 0 0 7.5 22.5h9a3.75 3.75 0 0 0 3.75-3.75v-6.75a3 3 0 0 0-3-3v-3A5.25 5.25 0 0 0 12 1.5Zm3.75 8.25v-3a3.75 3.75 0 1 0-7.5 0v3h7.5Z" clipRule="evenodd" />
+          </svg>
+        </span>
+        <input
+          className="w-full rounded-full py-3 pl-12 pr-4 text-sm placeholder-gray-500 focus:outline-none"
+          type="password"
+          required
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+        />
+      </div>
 
       <button
         type="submit"
         disabled={loading}
-        className="w-full rounded bg-black px-4 py-2 text-white disabled:opacity-60"
+        className="w-full rounded-full bg-blue-800 py-3 text-white disabled:opacity-60"
       >
-        {loading ? 'Signing in…' : 'Sign in'}
+        {loading ? 'Signing in…' : 'Log In'}
       </button>
 
-      <div className="mt-4 flex justify-between text-sm">
-        <a className="text-blue-600 underline" href="/signup">Create account</a>
-        <a className="text-blue-600 underline" href="/reset-password">Forgot password?</a>
+      <div className="pt-2 text-center text-sm">
+        <a className="text-white underline" href="/forgot-password">Forgot Password?</a>
+        <a className="mt-2 block text-white underline" href="/signup">Sign up for an account</a>
       </div>
     </form>
   );

--- a/public/login-bg.svg
+++ b/public/login-bg.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="900" viewBox="0 0 1600 900">
+  <defs>
+    <linearGradient id="g" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#60a5fa"/>
+      <stop offset="100%" stop-color="#1e3a8a"/>
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#g)"/>
+</svg>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="100" viewBox="0 0 300 100">
+  <rect width="300" height="100" fill="white"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle"
+        font-family="Arial, sans-serif" font-size="32" font-weight="700" fill="black">
+    Scruffy Butts
+  </text>
+</svg>


### PR DESCRIPTION
## Summary
- redesign login page with branded gradient and heading
- implement styled login form with icons, email/password fields and action links

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1cfd9c4c88324853cdd2fd7e97657