### PR TITLE
feat: add dog-themed login page

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react'
 import { redirect } from 'next/navigation'
+import Image from 'next/image'
 import { createClient } from '@/lib/supabase/server'
 import LoginForm from '@/components/LoginForm'
 
@@ -8,8 +9,27 @@ export default async function LoginPage() {
   const { data: { user } } = await supabase.auth.getUser()
   if (user) redirect('/dashboard')
   return (
-    <Suspense fallback={null}>
-      <LoginForm />
-    </Suspense>
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-orange-200 via-pink-200 to-pink-400 p-4">
+      <div className="flex items-center gap-6 mb-8">
+        <div className="flex flex-col items-center justify-center rounded-full bg-blue-500 px-6 py-8 text-white shadow-lg">
+          <h1 className="text-4xl font-extrabold leading-tight text-center">
+            Scruffy
+            <br />
+            Butts
+          </h1>
+          <p className="mt-2 text-sm uppercase tracking-wide">Dog Grooming</p>
+        </div>
+        <Image
+          src="https://images.dog.ceo/breeds/poodle-miniature/n02113712_1403.jpg"
+          alt="Happy dog"
+          width={160}
+          height={160}
+          className="w-40 h-40 object-cover"
+        />
+      </div>
+      <Suspense fallback={null}>
+        <LoginForm />
+      </Suspense>
+    </div>
   )
 }

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -29,47 +29,44 @@ export default function LoginForm() {
   };
 
   return (
-    <form onSubmit={onSubmit} className="w-full max-w-sm rounded-lg border p-6 bg-white">
-      <h1 className="text-xl font-semibold mb-4">Log in</h1>
-
+    <form onSubmit={onSubmit} className="w-full max-w-xs flex flex-col gap-4">
       {err && (
-        <div className="mb-3 rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700">
+        <div className="rounded border border-red-300 bg-red-50 px-4 py-2 text-sm text-red-700">
           {err}
         </div>
       )}
 
-      <label className="block text-sm font-medium">Email</label>
       <input
-        className="mt-1 mb-3 w-full rounded border px-3 py-2"
+        className="rounded-md border px-4 py-3 shadow-sm placeholder-gray-400"
         type="email"
         required
         value={email}
         onChange={(e) => setEmail(e.target.value)}
-        placeholder="you@example.com"
+        placeholder="Email"
       />
 
-      <label className="block text-sm font-medium">Password</label>
       <input
-        className="mt-1 mb-4 w-full rounded border px-3 py-2"
+        className="rounded-md border px-4 py-3 shadow-sm placeholder-gray-400"
         type="password"
         required
         value={password}
         onChange={(e) => setPassword(e.target.value)}
-        placeholder="••••••••"
+        placeholder="Password"
       />
+
+      <div className="flex justify-end text-sm">
+        <a className="text-blue-600 hover:underline" href="/reset-password">
+          Forgot password?
+        </a>
+      </div>
 
       <button
         type="submit"
         disabled={loading}
-        className="w-full rounded bg-black px-4 py-2 text-white disabled:opacity-60"
+        className="rounded-md bg-blue-600 py-3 font-bold uppercase text-white shadow hover:bg-blue-700 disabled:opacity-60"
       >
-        {loading ? 'Signing in…' : 'Sign in'}
+        {loading ? 'Signing in…' : 'Log in'}
       </button>
-
-      <div className="mt-4 flex justify-between text-sm">
-        <a className="text-blue-600 underline" href="/signup">Create account</a>
-        <a className="text-blue-600 underline" href="/reset-password">Forgot password?</a>
-      </div>
     </form>
   );
 }

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,8 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  images: {
+    domains: ['images.dog.ceo']
+  }
+};
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- replace login page with Scruffy Butts dog-themed design
- style login form with placeholders and bold log in button
- allow remote dog image via updated Next.js config

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2056533148324b2ae5e0302391f69