### PR TITLE
Enable portrait layout for mobile

### DIFF
--- a/app/book/page.tsx
+++ b/app/book/page.tsx
@@ -87,7 +87,7 @@ export default function BookPage() {
   };
 
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen flex-col md:flex-row">
       <Sidebar />
       <main className="flex-1 p-4 md:p-8">
         <h1 className="text-2xl font-bold mb-4">Book Appointment</h1>

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -39,7 +39,7 @@ export default function CalendarPage() {
   }, []);
 
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen flex-col md:flex-row">
       <Sidebar />
       <main className="flex-1 p-4 md:p-8">
         <h1 className="text-2xl font-bold mb-4">Calendar</h1>

--- a/app/clients/[id]/page.tsx
+++ b/app/clients/[id]/page.tsx
@@ -37,7 +37,7 @@ export default function ClientDetail({ params }: { params: { id: string } }) {
   }, [params.id]);
 
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen flex-col md:flex-row">
       <Sidebar />
       <main className="flex-1 p-4 md:p-8">
         {loading && <p>Loading…</p>}

--- a/app/clients/new/page.tsx
+++ b/app/clients/new/page.tsx
@@ -115,7 +115,7 @@ export default function NewClientPage() {
   };
 
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen flex-col md:flex-row">
       <Sidebar />
       <main className="flex-1 p-4 md:p-8 max-w-2xl">
         <h1 className="text-2xl font-bold mb-4">Add New Client</h1>

--- a/app/clients/page.tsx
+++ b/app/clients/page.tsx
@@ -37,7 +37,7 @@ export default function ClientsPage() {
   }, [q]);
 
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen flex-col md:flex-row">
       <Sidebar />
       <main className="flex-1 p-4 md:p-8">
         <h1 className="text-2xl font-bold mb-4">Clients</h1>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -15,7 +15,7 @@ export default async function DashboardPage() {
   } = await supabase.auth.getUser()
   if (!user) redirect('/login')
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen flex-col md:flex-row">
       <Sidebar />
       <main className="flex-1 p-4 md:p-8">
         <h1 className="mb-4 text-2xl font-bold">Dashboard</h1>

--- a/app/employees/new/page.tsx
+++ b/app/employees/new/page.tsx
@@ -38,7 +38,7 @@ export default function NewEmployeePage() {
   };
 
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen flex-col md:flex-row">
       <Sidebar />
       <main className="flex-1 p-4 md:p-8 max-w-xl">
         <h1 className="text-2xl font-bold mb-4">Add New Employee</h1>

--- a/app/employees/page.tsx
+++ b/app/employees/page.tsx
@@ -33,7 +33,7 @@ export default function EmployeesPage() {
   }, []);
 
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen flex-col md:flex-row">
       <Sidebar />
       <main className="flex-1 p-4 md:p-8">
         <h1 className="text-2xl font-bold mb-4">Employees</h1>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,11 @@ export const metadata = {
   description: 'Grooming dashboard',
 };
 
+export const viewport = {
+  width: 'device-width',
+  initialScale: 1,
+};
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">

--- a/app/messages/page.tsx
+++ b/app/messages/page.tsx
@@ -30,7 +30,7 @@ export default function MessagesPage() {
   }, []);
 
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen flex-col md:flex-row">
       <Sidebar />
       <main className="flex-1 p-4 md:p-8">
         <h1 className="text-2xl font-bold mb-4">Messages</h1>

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -165,7 +165,7 @@ export default function ReportsPage() {
   }, [range]);
 
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen flex-col md:flex-row">
       <Sidebar />
       <main className="flex-1 p-4 md:p-8">
         <h1 className="text-2xl font-bold mb-4">Reports</h1>

--- a/app/settings/agreement/page.tsx
+++ b/app/settings/agreement/page.tsx
@@ -7,7 +7,7 @@ import Sidebar from "@/components/Sidebar";
  */
 export default function AgreementSettings() {
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen flex-col md:flex-row">
       <Sidebar />
       <main className="flex-1 p-4 md:p-8">
         <h1 className="text-2xl font-bold mb-4">Agreement</h1>

--- a/app/settings/branding/page.tsx
+++ b/app/settings/branding/page.tsx
@@ -3,7 +3,7 @@ import Sidebar from "@/components/Sidebar";
 
 export default function BrandingSettings() {
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen flex-col md:flex-row">
       <Sidebar />
       <main className="flex-1 p-4 md:p-8">
         <h1 className="text-2xl font-bold mb-4">Branding Settings</h1>

--- a/app/settings/business/page.tsx
+++ b/app/settings/business/page.tsx
@@ -3,7 +3,7 @@ import Sidebar from "@/components/Sidebar";
 
 export default function BusinessSettings() {
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen flex-col md:flex-row">
       <Sidebar />
       <main className="flex-1 p-4 md:p-8">
         <h1 className="text-2xl font-bold mb-4">Business Details</h1>

--- a/app/settings/dashboard/page.tsx
+++ b/app/settings/dashboard/page.tsx
@@ -3,7 +3,7 @@ import Sidebar from "@/components/Sidebar";
 
 export default function DashboardSettings() {
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen flex-col md:flex-row">
       <Sidebar />
       <main className="flex-1 p-4 md:p-8">
         <h1 className="text-2xl font-bold mb-4">Dashboard Settings</h1>

--- a/app/settings/employees/page.tsx
+++ b/app/settings/employees/page.tsx
@@ -3,7 +3,7 @@ import Sidebar from "@/components/Sidebar";
 
 export default function SettingsEmployees() {
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen flex-col md:flex-row">
       <Sidebar />
       <main className="flex-1 p-4 md:p-8">
         <h1 className="text-2xl font-bold mb-4">Employee Settings</h1>

--- a/app/settings/notifications/page.tsx
+++ b/app/settings/notifications/page.tsx
@@ -3,7 +3,7 @@ import Sidebar from "@/components/Sidebar";
 
 export default function NotificationsSettings() {
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen flex-col md:flex-row">
       <Sidebar />
       <main className="flex-1 p-4 md:p-8">
         <h1 className="text-2xl font-bold mb-4">Notification Settings</h1>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -16,7 +16,7 @@ export default function Settings() {
     { href: "/settings/agreement", label: "Agreement" },
   ];
   return (
-    <div className="flex min-h-screen">
+    <div className="flex min-h-screen flex-col md:flex-row">
       <Sidebar />
       <main className="flex-1 p-4 md:p-8">
         <h1 className="text-2xl font-bold mb-6">Settings</h1>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -19,14 +19,14 @@ export default function Sidebar() {
   const pathname = usePathname();
 
   return (
-    <aside className="w-64 border-r p-4">
-      <nav className="space-y-1">
+    <aside className="w-full md:w-64 border-b md:border-r p-4">
+      <nav className="flex space-x-2 overflow-x-auto md:block md:space-x-0 md:space-y-1">
         {nav.map((item) => (
           <Link
             key={item.href}
             href={item.href}
             className={clsx(
-              'block rounded px-3 py-2 hover:bg-gray-100',
+              'block whitespace-nowrap rounded px-3 py-2 hover:bg-gray-100',
               pathname?.startsWith(item.href) && 'bg-gray-100 font-medium'
             )}
           >
@@ -35,7 +35,7 @@ export default function Sidebar() {
         ))}
       </nav>
 
-      <div className="mt-6 border-t pt-4">
+      <div className="mt-4 border-t pt-4 md:mt-6">
         <LogoutButton />
       </div>
     </aside>


### PR DESCRIPTION
## Summary
- make sidebar responsive and stack on small screens
- add viewport metadata for better mobile scaling
- update pages to support column layout on phones

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c27b158de48324b34fd533fc39c137