### PR TITLE
feat: add PDF417 ID scanner

### DIFF
--- a/app/clients/scan/page.tsx
+++ b/app/clients/scan/page.tsx
@@ -1,0 +1,62 @@
+"use client";
+
+import Sidebar from "@/components/Sidebar";
+import { useEffect, useRef, useState } from "react";
+import { BrowserMultiFormatReader, IScannerControls } from "@zxing/browser";
+import { BarcodeFormat, DecodeHintType, NotFoundException } from "@zxing/library";
+
+export default function ClientIdScanPage() {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<string | null>(null);
+
+  useEffect(() => {
+    const hints = new Map();
+    hints.set(DecodeHintType.POSSIBLE_FORMATS, [BarcodeFormat.PDF_417]);
+    const reader = new BrowserMultiFormatReader(hints);
+    let controls: IScannerControls | undefined;
+
+    const start = async () => {
+      try {
+        controls = await reader.decodeFromVideoDevice(
+          undefined,
+          videoRef.current!,
+          (res, err) => {
+            if (res) {
+              setResult(res.getText());
+              setError(null);
+              controls?.stop();
+            } else if (err && !(err instanceof NotFoundException)) {
+              setError("Unable to read ID");
+            }
+          }
+        );
+      } catch (e: any) {
+        setError(e?.message || "Unable to access camera");
+      }
+    };
+
+    start();
+    return () => {
+      controls?.stop();
+    };
+  }, []);
+
+  return (
+    <div className="flex min-h-screen">
+      <Sidebar />
+      <main className="flex-1 p-4 pb-20 md:p-8">
+        <h1 className="text-2xl font-bold mb-4">Scan Driver License</h1>
+        <video ref={videoRef} className="w-full max-w-md border" />
+        {error && <p className="mt-2 text-red-600">{error}</p>}
+        {result && (
+          <div className="mt-4">
+            <p className="font-semibold">Raw data</p>
+            <pre className="whitespace-pre-wrap break-words bg-gray-100 p-2 rounded">{result}</pre>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
         "@supabase/auth-helpers-nextjs": "^0.9.0",
         "@supabase/ssr": "^0.3.0",
         "@supabase/supabase-js": "^2.0.0",
+        "@zxing/browser": "^0.1.5",
+        "@zxing/library": "^0.21.3",
         "clsx": "^2.0.0",
         "next": "^14.0.0",
         "react": "^18.2.0",
@@ -1300,6 +1302,40 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@zxing/browser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@zxing/browser/-/browser-0.1.5.tgz",
+      "integrity": "sha512-4Lmrn/il4+UNb87Gk8h1iWnhj39TASEHpd91CwwSJtY5u+wa0iH9qS0wNLAWbNVYXR66WmT5uiMhZ7oVTrKfxw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@zxing/text-encoding": "^0.9.0"
+      },
+      "peerDependencies": {
+        "@zxing/library": "^0.21.0"
+      }
+    },
+    "node_modules/@zxing/library": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.21.3.tgz",
+      "integrity": "sha512-hZHqFe2JyH/ZxviJZosZjV+2s6EDSY0O24R+FQmlWZBZXP9IqMo7S3nb3+2LBWxodJQkSurdQGnqE7KXqrYgow==",
+      "license": "MIT",
+      "dependencies": {
+        "ts-custom-error": "^3.2.1"
+      },
+      "engines": {
+        "node": ">= 10.4.0"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "~0.9.0"
+      }
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "license": "(Unlicense OR Apache-2.0)",
+      "optional": true
     },
     "node_modules/acorn": {
       "version": "8.15.0",
@@ -5959,6 +5995,15 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-custom-error": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
+      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-interface-checker": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "@supabase/auth-helpers-nextjs": "^0.9.0",
     "@supabase/ssr": "^0.3.0",
     "@supabase/supabase-js": "^2.0.0",
+    "@zxing/browser": "^0.1.5",
+    "@zxing/library": "^0.21.3",
     "clsx": "^2.0.0",
     "next": "^14.0.0",
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- add client ID scan page that reads PDF417 driver license barcodes
- include ZXing dependencies for barcode decoding

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2830a5584832497fa385fd741cdc7