### PR TITLE
Add background image to login page

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -9,7 +9,10 @@ export default async function LoginPage() {
   if (user) redirect('/dashboard')
   return (
     <Suspense fallback={null}>
-      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-primary-light via-primary to-primary-dark p-4">
+      <div
+        className="flex min-h-screen items-center justify-center bg-cover bg-center p-4"
+        style={{ backgroundImage: "url('/login-background.svg')" }}
+      >
         <LoginForm />
       </div>
     </Suspense>

--- a/public/login-background.svg
+++ b/public/login-background.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1920 1080">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6c63ff" />
+      <stop offset="100%" stop-color="#b993d6" />
+    </linearGradient>
+  </defs>
+  <rect width="1920" height="1080" fill="url(#bg)" />
+</svg>


### PR DESCRIPTION
## Summary
- show login form over a full-screen background image
- use SVG placeholder instead of binary PNG asset

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c328dcee208324ac951c9829beaba0