### PR TITLE
Allow booking without login and remove signature

### DIFF
--- a/app/book/page.tsx
+++ b/app/book/page.tsx
@@ -2,18 +2,18 @@
 
 import PageContainer from '@/components/PageContainer';
 import Card from '@/components/Card';
-import LoginForm from '@/components/LoginForm';
 import LogoutButton from '@/components/LogoutButton';
 import BookingForm from '@/components/BookingForm';
-import { Suspense, useEffect, useState } from 'react';
+import LoginBanner from '@/components/LoginBanner';
+import { useEffect, useState } from 'react';
 import type { Session } from '@supabase/supabase-js';
 import { supabase } from '@/lib/supabase/client';
 
 /**
- * Public booking page.  Shows a login form at the top so clients can quickly
- * sign in.  Once authenticated the full booking form is displayed allowing
- * owners to provide their information, dog details, upload vaccination
- * documents, sign the waiver and submit a grooming appointment request.
+ * Public booking page.  Displays an optional login banner so clients can
+ * sign in, but the booking form is available without authentication. Owners
+ * can enter their information, dog details, upload vaccination documents and
+ * submit a grooming appointment request.
  */
 export default function BookPage() {
   const [session, setSession] = useState<Session | null>(null);
@@ -32,20 +32,16 @@ export default function BookPage() {
       <Card>
         <h1 className="mb-6 text-3xl font-bold text-primary-dark">Book Appointment</h1>
 
-        {!session ? (
-          // Login form shown when not authenticated
-          <Suspense fallback={<div>Loading...</div>}>
-            <LoginForm />
-          </Suspense>
-        ) : (
-          <div className="space-y-8">
-            <div className="flex items-center justify-between rounded border p-3 text-sm">
-              <span>Logged in as {session.user.email}</span>
-              <LogoutButton />
-            </div>
-            <BookingForm />
+        {session ? (
+          <div className="mb-6 flex items-center justify-between rounded border p-3 text-sm">
+            <span>Logged in as {session.user.email}</span>
+            <LogoutButton />
           </div>
+        ) : (
+          <LoginBanner />
         )}
+
+        <BookingForm />
       </Card>
     </PageContainer>
   );

--- a/components/BookingForm.tsx
+++ b/components/BookingForm.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import SignaturePad from './SignaturePad';
 
 interface OwnerInfo {
   firstName: string;
@@ -268,15 +267,6 @@ export default function BookingForm() {
       >
         Add another dog
       </button>
-
-      {/* Signature */}
-      <section className="space-y-2">
-        <h2 className="text-xl font-semibold">Agreement & Signature</h2>
-        <p className="text-sm text-gray-600">
-          By signing below you agree to our grooming waiver and policies.
-        </p>
-        <SignaturePad />
-      </section>
 
       <div className="flex justify-between border-t pt-4 text-lg font-bold">
         <span>Total:</span>

--- a/components/LoginBanner.tsx
+++ b/components/LoginBanner.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useState } from 'react';
+import { supabase } from '@/lib/supabase/client';
+
+export default function LoginBanner() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setErr(null);
+    setLoading(true);
+    try {
+      const { error } = await supabase.auth.signInWithPassword({ email, password });
+      if (error) throw error;
+      window.location.reload();
+    } catch (e: any) {
+      setErr(e?.message || 'Sign in failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="mb-6 flex flex-wrap items-center gap-2 rounded border p-3 text-sm">
+      <input
+        type="email"
+        required
+        placeholder="Email"
+        className="rounded border p-1"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <input
+        type="password"
+        required
+        placeholder="Password"
+        className="rounded border p-1"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button
+        type="submit"
+        disabled={loading}
+        className="rounded bg-primary px-3 py-1 text-white disabled:opacity-60"
+      >
+        {loading ? 'Logging in...' : 'Login'}
+      </button>
+      {err && <span className="ml-2 text-red-600">{err}</span>}
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
- Make booking page accessible without authentication
- Add optional top-of-page login banner
- Remove waiver signature from booking form

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4f0cb956883249b1ce99fade428a9