### PR TITLE
feat: refresh app theme with vibrant new style

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,5 +4,11 @@
 
 /* Custom global styles */
 body {
-  @apply bg-gradient-to-br from-secondary-pink via-secondary-purple to-secondary-green text-gray-900;
+  @apply bg-gradient-to-br from-secondary-pink via-secondary-purple to-secondary-green text-gray-100;
+}
+
+input,
+textarea,
+select {
+  @apply text-gray-900;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,11 @@
 import './globals.css';
 import AuthProvider from '@/components/AuthProvider';
+import { Poppins } from 'next/font/google';
+
+const poppins = Poppins({
+  subsets: ['latin'],
+  weight: ['400', '600', '700'],
+});
 
 export const metadata = {
   title: 'Scruffy Butts',
@@ -9,7 +15,7 @@ export const metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="min-h-screen text-gray-900 antialiased">
+      <body className={`${poppins.className} min-h-screen text-gray-100 antialiased`}>
         <AuthProvider>{children}</AuthProvider>
       </body>
     </html>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,14 +9,14 @@ const config: Config = {
     extend: {
       colors: {
         primary: {
-          light: '#76b2fe',
-          DEFAULT: '#4b79a1',
-          dark: '#283e51'
+          light: '#c084fc',
+          DEFAULT: '#a855f7',
+          dark: '#7e22ce'
         },
         secondary: {
-          pink: '#f8b4c0',
-          purple: '#dcbcef',
-          green: '#b5e5cf'
+          pink: '#ec4899',
+          purple: '#8b5cf6',
+          green: '#14b8a6'
         }
       }
     }


### PR DESCRIPTION
## Summary
- adopt modern purple-focused palette with bright accent gradient
- use Poppins font and light-on-dark text for a sleek look
- ensure form fields keep readable text

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c606c61ec0832489233d57e7096118