### PR TITLE
Redesign primary pages with top navigation

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -205,8 +205,9 @@ export default function CalendarPage() {
 
   return (
     <PageContainer>
-      <Card>
-        <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+      <div className="grid gap-6 md:grid-cols-3">
+        <Card className="md:col-span-2">
+          <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
           <div className="flex gap-2">
             {(["day", "week", "month", "list"] as const).map((v) => (
               <button
@@ -487,7 +488,12 @@ export default function CalendarPage() {
             )}
           </div>
         )}
-      </Card>
+        </Card>
+        <Card className="md:col-start-3">
+          <h2 className="mb-4 text-lg font-semibold text-primary-dark">Upcoming Appointments</h2>
+          <p className="text-sm text-gray-600">Select a date to view appointments.</p>
+        </Card>
+      </div>
     </PageContainer>
   );
 }

--- a/app/clients/page.tsx
+++ b/app/clients/page.tsx
@@ -22,6 +22,7 @@ export default function ClientsPage() {
   const [q, setQ] = useState("");
   const [rows, setRows] = useState<Client[]>([]);
   const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState<Client | null>(null);
 
   useEffect(() => {
     const run = async () => {
@@ -39,42 +40,72 @@ export default function ClientsPage() {
 
   return (
     <PageContainer>
-      <Card className="space-y-4">
-        <h1 className="text-3xl font-bold text-primary-dark">Clients</h1>
-        <div>
-          <Link
-            href="/clients/new"
-            className="inline-block rounded-full bg-primary px-4 py-2 text-white shadow hover:bg-primary-dark"
-          >
-            Add Client
-          </Link>
-        </div>
-        <input
-          value={q}
-          onChange={(e) => setQ(e.target.value)}
-          placeholder="Search clients…"
-          className="mb-4 w-full max-w-md rounded-full border border-gray-300 px-4 py-2 focus:border-primary focus:ring-2 focus:ring-primary-light"
-        />
-        {loading ? (
-          <p>Loading…</p>
-        ) : (
-          <ul className="divide-y">
-            {rows.map((c) => (
-              <li key={c.id} className="flex items-center justify-between py-3">
-                <div>
-                  <div className="font-medium">{c.full_name}</div>
-                  <div className="text-sm text-gray-500">
-                    {c.phone || "—"} · {c.email || "—"}
+      <div className="grid gap-6 md:grid-cols-3">
+        <Card className="space-y-4 md:col-span-2">
+          <h1 className="text-3xl font-bold text-primary-dark">Clients</h1>
+          <div>
+            <Link
+              href="/clients/new"
+              className="inline-block rounded-full bg-primary px-4 py-2 text-white shadow hover:bg-primary-dark"
+            >
+              Add Client
+            </Link>
+          </div>
+          <input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search clients…"
+            className="mb-4 w-full max-w-md rounded-full border border-gray-300 px-4 py-2 focus:border-primary focus:ring-2 focus:ring-primary-light"
+          />
+          {loading ? (
+            <p>Loading…</p>
+          ) : (
+            <ul className="divide-y">
+              {rows.map((c) => (
+                <li
+                  key={c.id}
+                  onClick={() => setSelected(c)}
+                  className="relative flex cursor-pointer items-center justify-between py-3"
+                >
+                  <div>
+                    <div className="font-medium">{c.full_name}</div>
+                    <div className="text-sm text-gray-500">
+                      {c.phone || "—"} · {c.email || "—"}
+                    </div>
                   </div>
-                </div>
-                <Link className="text-primary underline" href={`/clients/${c.id}`}>
-                  Open
-                </Link>
-              </li>
-            ))}
-          </ul>
-        )}
-      </Card>
+                  {selected?.id === c.id && (
+                    <Link
+                      href={`/clients/${c.id}`}
+                      className="absolute inset-0 flex items-center justify-center bg-primary/80 text-lg font-semibold text-white"
+                    >
+                      Client Page
+                    </Link>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </Card>
+        <Card className="md:col-start-3">
+          {selected ? (
+            <div className="space-y-2">
+              <h2 className="text-lg font-semibold text-primary-dark">Quick View</h2>
+              <p className="font-medium">{selected.full_name}</p>
+              <p className="text-sm text-gray-600">
+                Phone: {selected.phone || "—"}
+              </p>
+              <p className="text-sm text-gray-600">
+                Email: {selected.email || "—"}
+              </p>
+            </div>
+          ) : (
+            <>
+              <h2 className="mb-4 text-lg font-semibold text-primary-dark">Client Details</h2>
+              <p className="text-sm text-gray-600">Select a client to view details.</p>
+            </>
+          )}
+        </Card>
+      </div>
     </PageContainer>
   );
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -6,7 +6,6 @@ import TodaysAppointments from '@/components/dashboard/TodaysAppointments'
 import EmployeeWorkload from '@/components/dashboard/EmployeeWorkload'
 import Messages from '@/components/dashboard/Messages'
 import Revenue from '@/components/dashboard/Revenue'
-import Alerts from '@/components/dashboard/Alerts'
 
 export default async function DashboardPage() {
   const supabase = createClient()
@@ -17,21 +16,25 @@ export default async function DashboardPage() {
   return (
     <PageContainer>
       <h1 className="text-3xl font-bold text-primary-dark">Dashboard</h1>
-      <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
-        <Widget title="Today's Appointments" color="pink">
+      <div className="grid gap-6 md:grid-cols-3">
+        <Widget title="Today's Appointments" color="pink" className="md:col-span-2 md:row-span-4">
           <TodaysAppointments />
         </Widget>
-        <Widget title="Revenue" color="purple">
-          <Revenue />
-        </Widget>
-        <Widget title="Employee Workload" color="green">
+        <Widget title="Employee Workload" color="green" className="md:col-start-3">
           <EmployeeWorkload />
         </Widget>
-        <Widget title="Messages" color="purple">
+        <Widget title="Revenue" color="purple" className="md:col-start-3">
+          <Revenue />
+        </Widget>
+        <Widget title="Messages" color="purple" className="md:col-start-3">
           <Messages />
         </Widget>
-        <Widget title="Alerts" color="pink">
-          <Alerts />
+        <Widget title="Quick Actions" color="pink" className="md:col-start-3">
+          <div className="flex flex-col space-y-2">
+            <button className="rounded-full bg-primary px-4 py-2 text-white">Book Appointment</button>
+            <button className="rounded-full bg-primary px-4 py-2 text-white">Add Client</button>
+            <button className="rounded-full bg-primary px-4 py-2 text-white">Generate Report</button>
+          </div>
         </Widget>
       </div>
     </PageContainer>

--- a/app/employees/page.tsx
+++ b/app/employees/page.tsx
@@ -2,7 +2,7 @@
 import PageContainer from "@/components/PageContainer";
 import Card from "@/components/Card";
 import { useEffect, useState } from "react";
-import { supabase } from "@/lib/supabase/client"; 
+import { supabase } from "@/lib/supabase/client";
 import Link from "next/link";
 
 // Type definition for an employee record
@@ -20,6 +20,7 @@ interface Employee {
 export default function EmployeesPage() {
   const [rows, setRows] = useState<Employee[]>([]);
   const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState<Employee | null>(null);
 
   useEffect(() => {
     const run = async () => {
@@ -35,29 +36,59 @@ export default function EmployeesPage() {
 
   return (
     <PageContainer>
-      <Card className="space-y-4">
-        <h1 className="text-3xl font-bold text-primary-dark">Employees</h1>
-        <div>
-          <Link
-            href="/employees/new"
-            className="inline-block rounded-full bg-primary px-4 py-2 text-white shadow hover:bg-primary-dark"
-          >
-            Add Employee
-          </Link>
-        </div>
-        {loading ? (
-          <p>Loading…</p>
-        ) : (
-          <ul className="divide-y">
-            {rows.map((e) => (
-              <li key={e.id} className="flex justify-between py-3">
-                <span className="font-medium">{e.name}</span>
-                <span className="text-sm text-gray-600">{e.active ? "Active" : "Inactive"}</span>
-              </li>
-            ))}
-          </ul>
-        )}
-      </Card>
+      <div className="grid gap-6 md:grid-cols-3">
+        <Card className="space-y-4 md:col-span-2">
+          <h1 className="text-3xl font-bold text-primary-dark">Employees</h1>
+          <div>
+            <Link
+              href="/employees/new"
+              className="inline-block rounded-full bg-primary px-4 py-2 text-white shadow hover:bg-primary-dark"
+            >
+              Add Employee
+            </Link>
+          </div>
+          {loading ? (
+            <p>Loading…</p>
+          ) : (
+            <ul className="divide-y">
+              {rows.map((e) => (
+                <li
+                  key={e.id}
+                  onClick={() => setSelected(e)}
+                  className="relative flex cursor-pointer justify-between py-3"
+                >
+                  <span className="font-medium">{e.name}</span>
+                  <span className="text-sm text-gray-600">{e.active ? "Active" : "Inactive"}</span>
+                  {selected?.id === e.id && (
+                    <Link
+                      href={`/employees/${e.id}`}
+                      className="absolute inset-0 flex items-center justify-center bg-primary/80 text-lg font-semibold text-white"
+                    >
+                      Employee Page
+                    </Link>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </Card>
+        <Card className="md:col-start-3">
+          {selected ? (
+            <div className="space-y-2">
+              <h2 className="text-lg font-semibold text-primary-dark">Quick View</h2>
+              <p className="font-medium">{selected.name}</p>
+              <p className="text-sm text-gray-600">
+                Status: {selected.active ? "Active" : "Inactive"}
+              </p>
+            </div>
+          ) : (
+            <>
+              <h2 className="mb-4 text-lg font-semibold text-primary-dark">Employee Details</h2>
+              <p className="text-sm text-gray-600">Select an employee to view details.</p>
+            </>
+          )}
+        </Card>
+      </div>
     </PageContainer>
   );
 }

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -2,5 +2,5 @@ import { ReactNode } from 'react'
 import clsx from 'clsx'
 
 export default function Card({ children, className = '' }: { children: ReactNode; className?: string }) {
-  return <div className={clsx('rounded-3xl bg-white/80 p-6 shadow', className)}>{children}</div>
+  return <div className={clsx('rounded-3xl bg-white p-6 shadow', className)}>{children}</div>
 }

--- a/components/PageContainer.tsx
+++ b/components/PageContainer.tsx
@@ -1,12 +1,12 @@
 import { ReactNode } from 'react'
-import Sidebar from './Sidebar'
+import TopNav from './TopNav'
 import clsx from 'clsx'
 
 export default function PageContainer({ children, className = '' }: { children: ReactNode; className?: string }) {
   return (
-    <div className="flex min-h-screen bg-gradient-to-br from-secondary-pink via-secondary-purple to-secondary-green">
-      <Sidebar />
-      <main className={clsx('flex-1 p-6 md:p-10 space-y-6', className)}>{children}</main>
+    <div className="min-h-screen bg-gray-100">
+      <TopNav />
+      <main className={clsx('mx-auto max-w-7xl p-6 space-y-6', className)}>{children}</main>
     </div>
   )
 }

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -1,0 +1,41 @@
+'use client'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import clsx from 'clsx'
+
+const links = [
+  { href: '/dashboard', label: 'Dashboard' },
+  { href: '/calendar', label: 'Calendar' },
+  { href: '/clients', label: 'Clients' },
+  { href: '/employees', label: 'Employees' },
+  { href: '/reports', label: 'Reports' },
+  { href: '/messages', label: 'Messages' },
+  { href: '/settings', label: 'Settings' },
+]
+
+export default function TopNav() {
+  const pathname = usePathname()
+  return (
+    <header className="bg-primary text-white shadow">
+      <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3 sm:px-6">
+        <div className="text-2xl font-extrabold">
+          Scruffy<span className="text-secondary-pink">Butts</span>
+        </div>
+        <nav className="hidden space-x-2 md:flex">
+          {links.map((l) => (
+            <Link
+              key={l.href}
+              href={l.href}
+              className={clsx(
+                'rounded-full px-3 py-2 transition-colors hover:bg-primary-dark',
+                pathname?.startsWith(l.href) && 'bg-white text-primary-dark'
+              )}
+            >
+              {l.label}
+            </Link>
+          ))}
+        </nav>
+      </div>
+    </header>
+  )
+}

--- a/components/Widget.tsx
+++ b/components/Widget.tsx
@@ -5,18 +5,19 @@ interface WidgetProps {
   title: string
   color?: 'pink' | 'purple' | 'green'
   children: ReactNode
+  className?: string
 }
 
 // A simple card with a thin colored header matching the supplied color. See the
 // dashboard mockups for examples of how these widgets should look.
-export default function Widget({ title, color = 'pink', children }: WidgetProps) {
+export default function Widget({ title, color = 'pink', children, className }: WidgetProps) {
   const headerColor = {
     pink: 'bg-secondary-pink',
     purple: 'bg-secondary-purple',
     green: 'bg-secondary-green',
   }[color]
   return (
-    <div className="overflow-hidden rounded-3xl bg-white shadow">
+    <div className={clsx('overflow-hidden rounded-3xl bg-white shadow', className)}>
       <div className={clsx('px-5 py-3 text-sm font-semibold text-primary-dark', headerColor)}>
         {title}
       </div>


### PR DESCRIPTION
## Summary
- add reusable top navigation bar
- update dashboard layout with quick actions widget
- align calendar, clients and employees pages with new theme
- enable quick-view overlays for client and employee lists

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6444965b8832480a9741df4a52779