### PR TITLE
Revamp dashboard and seed demo appointments

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -3,8 +3,8 @@ import PageContainer from "@/components/PageContainer";
 import Card from "@/components/Card";
 import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
 import { useState, useEffect, useMemo } from "react";
-import { supabase } from "@/lib/supabase/client";
 import clsx from "clsx";
+import { getDemoAppointments, demoGroomers } from "@/lib/demoData";
 
 type Appt = {
   id: string;
@@ -44,30 +44,17 @@ export default function CalendarPage() {
   const [selected, setSelected] = useState<string>(todayKey);
 
   useEffect(() => {
-    const fetchData = async () => {
-      const [apptsRes, groomersRes] = await Promise.all([
-        supabase
-          .from("appointments")
-          .select(
-            "id,start_time,service,status,groomer_name,pets(name),clients(full_name)"
-          )
-          .order("start_time"),
-        supabase
-          .from("employees")
-          .select("name")
-          .eq("active", true)
-          .order("name"),
-      ]);
-
-      if (!apptsRes.error && apptsRes.data) {
-        setAppts(apptsRes.data as unknown as Appt[]);
-      }
-
-      if (!groomersRes.error && groomersRes.data) {
-        setGroomers(groomersRes.data.map((g: { name: string }) => g.name));
-      }
-    };
-    fetchData();
+    const demos = getDemoAppointments().map((a) => ({
+      id: a.id,
+      start_time: a.start.toISOString(),
+      service: a.service,
+      status: a.status,
+      groomer_name: a.groomerName,
+      pets: [{ name: a.petName }],
+      clients: [{ full_name: a.clientName }],
+    }));
+    setAppts(demos);
+    setGroomers(demoGroomers);
   }, []);
 
   const filtered = useMemo(() => {

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,5 +1,3 @@
-import { redirect } from 'next/navigation'
-import { createClient } from '@/lib/supabase/server'
 import PageContainer from '@/components/PageContainer'
 import Widget from '@/components/Widget'
 import TodaysAppointments from '@/components/dashboard/TodaysAppointments'
@@ -7,15 +5,10 @@ import EmployeeWorkload from '@/components/dashboard/EmployeeWorkload'
 import Messages from '@/components/dashboard/Messages'
 import Revenue from '@/components/dashboard/Revenue'
 
-export default async function DashboardPage() {
-  const supabase = createClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-  if (!user) redirect('/login')
+export default function DashboardPage() {
   return (
     <PageContainer>
-      <h1 className="text-3xl font-bold text-primary-dark">Dashboard</h1>
+      <h1 className="text-3xl font-bold">Dashboard</h1>
       <div className="grid gap-6 md:grid-cols-3">
         <Widget title="Today's Appointments" color="pink" className="md:col-span-2 md:row-span-4">
           <TodaysAppointments />

--- a/components/PageContainer.tsx
+++ b/components/PageContainer.tsx
@@ -4,9 +4,11 @@ import clsx from 'clsx'
 
 export default function PageContainer({ children, className = '' }: { children: ReactNode; className?: string }) {
   return (
-    <div className="min-h-screen bg-gray-100">
+    <div className="min-h-screen bg-blue-400">
       <TopNav />
-      <main className={clsx('mx-auto max-w-7xl p-6 space-y-6', className)}>{children}</main>
+      <main className={clsx('mx-auto max-w-7xl p-6 space-y-6 text-white', className)}>
+        {children}
+      </main>
     </div>
   )
 }

--- a/components/Widget.tsx
+++ b/components/Widget.tsx
@@ -21,7 +21,7 @@ export default function Widget({ title, color = 'pink', children, className }: W
       <div className={clsx('px-5 py-3 text-sm font-semibold text-primary-dark', headerColor)}>
         {title}
       </div>
-      <div className="p-5">
+      <div className="p-5 text-primary-dark">
         {children}
       </div>
     </div>

--- a/components/dashboard/TodaysAppointments.tsx
+++ b/components/dashboard/TodaysAppointments.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useState } from 'react'
-import { supabase } from '@/lib/supabase/client'
+import { getDemoAppointments } from '@/lib/demoData'
 
 interface Appointment {
   id: string
@@ -12,70 +12,56 @@ interface Appointment {
 
 export default function TodaysAppointments() {
   const [appointments, setAppointments] = useState<Appointment[]>([])
-  const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    // Query the appointments scheduled for today. The Supabase table is expected
-    // to have fields: id, scheduled_time, pet_name, client_name, status.
-    const fetchAppointments = async () => {
-      const start = new Date()
-      start.setHours(0, 0, 0, 0)
-      const end = new Date()
-      end.setHours(23, 59, 59, 999)
-
-      const { data, error } = await supabase
-        .from('appointments')
-        .select('id, scheduled_time, pet_name, client_name, status')
-        .gte('scheduled_time', start.toISOString())
-        .lte('scheduled_time', end.toISOString())
-        .order('scheduled_time', { ascending: true })
-
-      if (!error && data) {
-        setAppointments(
-          data.map((row) => ({
-            id: row.id as string,
-            time: new Date(row.scheduled_time).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
-            pet_name: row.pet_name,
-            client_name: row.client_name,
-            status: row.status,
-          }))
-        )
-      }
-      setLoading(false)
-    }
-    fetchAppointments()
+    const today = new Date().toDateString()
+    const demos = getDemoAppointments()
+      .filter((a) => a.start.toDateString() === today)
+      .map((a) => ({
+        id: a.id,
+        time: a.start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }),
+        pet_name: a.petName,
+        client_name: a.clientName,
+        status: a.status,
+      }))
+    setAppointments(demos)
   }, [])
-
-  if (loading) {
-    return <div>Loading...</div>
-  }
 
   if (appointments.length === 0) {
     return <div>No appointments today.</div>
   }
 
+  const statusStyles: Record<string, string> = {
+    Completed: 'bg-green-100 text-green-700',
+    Upcoming: 'bg-sky-100 text-sky-700',
+    'In Progress': 'bg-blue-100 text-blue-700',
+    Cancelled: 'bg-gray-200 text-gray-600',
+  }
+
   return (
     <ul className="space-y-2">
       {appointments.map((appt) => (
-        <li key={appt.id} className="flex justify-between items-center">
-          <div className="flex flex-col">
-            <span className="font-medium">{appt.time}</span>
-            <span>{appt.pet_name}</span>
-            <span className="text-sm text-gray-500">{appt.client_name}</span>
+        <li
+          key={appt.id}
+          className="flex items-center justify-between rounded-lg bg-white/80 p-2"
+        >
+          <div className="flex items-center space-x-2">
+            <span className="text-xl">🐶</span>
+            <div>
+              <p className="font-semibold">{appt.pet_name}</p>
+              <p className="text-xs text-gray-600">{appt.client_name}</p>
+            </div>
           </div>
-          <span className={
-            appt.status === 'Completed'
-              ? 'text-green-600'
-              : appt.status === 'Cancelled'
-              ? 'text-orange-600'
-              : appt.status === 'In Progress'
-              ? 'text-green-500'
-              : appt.status === 'Checked In'
-              ? 'text-blue-600'
-              : 'text-gray-600'
-          }>
-            {appt.status}
-          </span>
+          <div className="flex items-center space-x-2">
+            <span className="text-sm font-medium">{appt.time}</span>
+            <span
+              className={`rounded-full px-2 py-1 text-xs font-semibold ${
+                statusStyles[appt.status] || 'bg-gray-200 text-gray-600'
+              }`}
+            >
+              {appt.status}
+            </span>
+          </div>
         </li>
       ))}
     </ul>

--- a/lib/demoData.ts
+++ b/lib/demoData.ts
@@ -1,0 +1,78 @@
+export interface DemoAppointment {
+  id: string;
+  start: Date;
+  petName: string;
+  clientName: string;
+  groomerName: string;
+  service: string;
+  status: string;
+}
+
+function makeDate(offset: number, hour: number) {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  d.setDate(d.getDate() + offset);
+  d.setHours(hour, 0, 0, 0);
+  return d;
+}
+
+export function getDemoAppointments(): DemoAppointment[] {
+  return [
+    {
+      id: '1',
+      start: makeDate(0, 9),
+      petName: 'Bella',
+      clientName: 'Karen G.',
+      groomerName: 'Richelle',
+      service: 'Full Groom',
+      status: 'Completed',
+    },
+    {
+      id: '2',
+      start: makeDate(0, 11),
+      petName: 'Max',
+      clientName: 'John S.',
+      groomerName: 'Alex',
+      service: 'Bath & Brush',
+      status: 'Upcoming',
+    },
+    {
+      id: '3',
+      start: makeDate(0, 13),
+      petName: 'Milo',
+      clientName: 'Nancy D.',
+      groomerName: 'Jamie',
+      service: 'Nail Trim',
+      status: 'Upcoming',
+    },
+    {
+      id: '4',
+      start: makeDate(1, 10),
+      petName: 'Lucy',
+      clientName: 'Amy R.',
+      groomerName: 'Richelle',
+      service: 'Full Groom',
+      status: 'Upcoming',
+    },
+    {
+      id: '5',
+      start: makeDate(2, 9),
+      petName: 'Rocky',
+      clientName: 'Dylan P.',
+      groomerName: 'Jamie',
+      service: 'Bath & Brush',
+      status: 'Upcoming',
+    },
+    {
+      id: '6',
+      start: makeDate(3, 15),
+      petName: 'Bailey',
+      clientName: 'Oscar W.',
+      groomerName: 'Alex',
+      service: 'Nail Trim',
+      status: 'Upcoming',
+    }
+  ];
+}
+
+export const demoGroomers = ['Richelle', 'Alex', 'Jamie'];


### PR DESCRIPTION
## Summary
- Refresh dashboard layout with blue background and dark-text widgets
- Add demo appointments and show them on dashboard and calendar
- Simplify dashboard page by removing auth requirement for demo

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c64b3c2db88324ad0d1b958b13ff9f