### PR TITLE
Arrange dashboard widgets into three columns

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -16,25 +16,31 @@ export default async function DashboardPage() {
   return (
     <PageContainer>
       <div className="grid gap-6 md:grid-cols-3">
-        <Widget title="Today's Appointments" color="pink" className="md:col-span-2 md:row-span-4">
-          <TodaysAppointments />
-        </Widget>
-        <Widget title="Employee Workload" color="green" className="md:col-start-3">
-          <EmployeeWorkload />
-        </Widget>
-        <Widget title="Revenue" color="purple" className="md:col-start-3">
-          <Revenue />
-        </Widget>
-        <Widget title="Messages" color="purple" className="md:col-start-3">
-          <Messages />
-        </Widget>
-        <Widget title="Quick Actions" color="pink" className="md:col-start-3">
-          <div className="flex flex-col space-y-2">
-            <button className="rounded-full bg-primary px-4 py-2 text-white">Book Appointment</button>
-            <button className="rounded-full bg-primary px-4 py-2 text-white">Add Client</button>
-            <button className="rounded-full bg-primary px-4 py-2 text-white">Generate Report</button>
-          </div>
-        </Widget>
+        <div className="flex flex-col space-y-6">
+          <Widget title="Today's Appointments" color="pink">
+            <TodaysAppointments />
+          </Widget>
+          <Widget title="Messages" color="purple">
+            <Messages />
+          </Widget>
+        </div>
+        <div className="flex flex-col space-y-6">
+          <Widget title="Employee Workload" color="green">
+            <EmployeeWorkload />
+          </Widget>
+          <Widget title="Quick Actions" color="pink">
+            <div className="flex flex-col space-y-2">
+              <button className="rounded-full bg-primary px-4 py-2 text-white">Book Appointment</button>
+              <button className="rounded-full bg-primary px-4 py-2 text-white">Add Client</button>
+              <button className="rounded-full bg-primary px-4 py-2 text-white">Generate Report</button>
+            </div>
+          </Widget>
+        </div>
+        <div className="flex flex-col space-y-6">
+          <Widget title="Revenue" color="purple">
+            <Revenue />
+          </Widget>
+        </div>
       </div>
     </PageContainer>
   )


### PR DESCRIPTION
## Summary
- Display dashboard widgets in three evenly spaced columns
- Balance widgets vertically within each column for a cleaner layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c6510de04c832481564daa0fc423ce