### PR TITLE
feat: add basic employee profile page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,9 @@ The following environment variables must be set before running or deploying the 
 - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
 
 Create an `.env.local` file based on `.env.local.example` and populate these values with your Supabase project credentials.
+
+## Routes
+
+- `/employees` - list of employees
+- `/employees/[id]` - employee profile page
+- `/employees/[id]/schedule` - employee schedule editor (coming soon)

--- a/app/(employees)/components/ProfileCard.tsx
+++ b/app/(employees)/components/ProfileCard.tsx
@@ -1,0 +1,32 @@
+'use client';
+import Image from 'next/image';
+
+interface Profile {
+  name: string;
+  role: string | null;
+  phone: string | null;
+  email: string | null;
+  photo_url?: string | null;
+}
+
+export default function ProfileCard({ profile }: { profile: Profile }) {
+  return (
+    <div className="p-4 bg-white rounded shadow">
+      <div className="flex items-center gap-4">
+        <div className="relative w-24 h-24 rounded-full overflow-hidden bg-gray-100">
+          {profile.photo_url ? (
+            <Image src={profile.photo_url} alt={profile.name} fill className="object-cover" />
+          ) : null}
+        </div>
+        <div>
+          <h2 className="text-xl font-semibold">{profile.name}</h2>
+          <p className="text-gray-600">{profile.role || '—'}</p>
+          <div className="mt-2 space-y-1 text-sm text-gray-600">
+            <p>{profile.phone || 'No phone'}</p>
+            <p>{profile.email || 'No email'}</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/employees/[id]/page.tsx
+++ b/app/employees/[id]/page.tsx
@@ -1,0 +1,16 @@
+'use client';
+import ProfileCard from '@/app/(employees)/components/ProfileCard';
+import { useEmployeeProfile } from '@/lib/hooks/useEmployeeProfile';
+
+export default function EmployeeDetailPage({ params }: { params: { id: string } }) {
+  const { data, loading, error } = useEmployeeProfile(params.id);
+
+  if (loading) return <p>Loading…</p>;
+  if (error || !data) return <p>Error loading employee.</p>;
+
+  return (
+    <div className="p-4">
+      <ProfileCard profile={data} />
+    </div>
+  );
+}

--- a/app/employees/[id]/schedule/page.tsx
+++ b/app/employees/[id]/schedule/page.tsx
@@ -1,0 +1,8 @@
+export default function EmployeeSchedulePage({ params }: { params: { id: string } }) {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">Schedule for employee {params.id}</h1>
+      <p>Calendar editor coming soon.</p>
+    </div>
+  );
+}

--- a/lib/hooks/useEmployeeProfile.ts
+++ b/lib/hooks/useEmployeeProfile.ts
@@ -1,0 +1,46 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { supabase } from '@/lib/supabase/client';
+
+export interface EmployeeProfile {
+  id: string;
+  name: string;
+  role: string | null;
+  phone: string | null;
+  email: string | null;
+  photo_url?: string | null;
+}
+
+export function useEmployeeProfile(id: string) {
+  const [data, setData] = useState<EmployeeProfile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    const run = async () => {
+      setLoading(true);
+      const { data, error } = await supabase
+        .from('employees')
+        .select('id, name, role, phone, email, photo_url')
+        .eq('id', id)
+        .single();
+      if (error) {
+        setError(error as any);
+      } else if (data) {
+        setData({
+          id: data.id,
+          name: data.name,
+          role: data.role,
+          phone: data.phone,
+          email: data.email,
+          photo_url: data.photo_url,
+        });
+      }
+      setLoading(false);
+    };
+    run();
+  }, [id]);
+
+  return { data, loading, error };
+}


### PR DESCRIPTION
## Summary
- add employee profile page with basic details
- include ProfileCard component and hook
- document employee routes
- fix employee profile hook to use `name` field

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

Preview: N/A

------
https://chatgpt.com/codex/tasks/task_e_68c661799d3c83249bd371f2b6f25f9f