### PR TITLE
Add stub Settings sub-pages and clean hub links

### DIFF
--- a/app/settings/agreement/page.tsx
+++ b/app/settings/agreement/page.tsx
@@ -1,0 +1,13 @@
+import PageContainer from "@/components/PageContainer";
+import Card from "@/components/Card";
+
+export default function SettingsSectionPage() {
+  return (
+    <PageContainer>
+      <Card>
+        <h1 className="mb-4 text-2xl font-bold">Settings</h1>
+        <p className="text-gray-600">This section is a placeholder. Content coming soon.</p>
+      </Card>
+    </PageContainer>
+  );
+}

--- a/app/settings/branding/page.tsx
+++ b/app/settings/branding/page.tsx
@@ -1,0 +1,13 @@
+import PageContainer from "@/components/PageContainer";
+import Card from "@/components/Card";
+
+export default function SettingsSectionPage() {
+  return (
+    <PageContainer>
+      <Card>
+        <h1 className="mb-4 text-2xl font-bold">Settings</h1>
+        <p className="text-gray-600">This section is a placeholder. Content coming soon.</p>
+      </Card>
+    </PageContainer>
+  );
+}

--- a/app/settings/business/page.tsx
+++ b/app/settings/business/page.tsx
@@ -1,0 +1,13 @@
+import PageContainer from "@/components/PageContainer";
+import Card from "@/components/Card";
+
+export default function SettingsSectionPage() {
+  return (
+    <PageContainer>
+      <Card>
+        <h1 className="mb-4 text-2xl font-bold">Settings</h1>
+        <p className="text-gray-600">This section is a placeholder. Content coming soon.</p>
+      </Card>
+    </PageContainer>
+  );
+}

--- a/app/settings/dashboard/page.tsx
+++ b/app/settings/dashboard/page.tsx
@@ -1,0 +1,13 @@
+import PageContainer from "@/components/PageContainer";
+import Card from "@/components/Card";
+
+export default function SettingsSectionPage() {
+  return (
+    <PageContainer>
+      <Card>
+        <h1 className="mb-4 text-2xl font-bold">Settings</h1>
+        <p className="text-gray-600">This section is a placeholder. Content coming soon.</p>
+      </Card>
+    </PageContainer>
+  );
+}

--- a/app/settings/employees/page.tsx
+++ b/app/settings/employees/page.tsx
@@ -1,0 +1,13 @@
+import PageContainer from "@/components/PageContainer";
+import Card from "@/components/Card";
+
+export default function SettingsSectionPage() {
+  return (
+    <PageContainer>
+      <Card>
+        <h1 className="mb-4 text-2xl font-bold">Settings</h1>
+        <p className="text-gray-600">This section is a placeholder. Content coming soon.</p>
+      </Card>
+    </PageContainer>
+  );
+}

--- a/app/settings/notifications/page.tsx
+++ b/app/settings/notifications/page.tsx
@@ -1,0 +1,13 @@
+import PageContainer from "@/components/PageContainer";
+import Card from "@/components/Card";
+
+export default function SettingsSectionPage() {
+  return (
+    <PageContainer>
+      <Card>
+        <h1 className="mb-4 text-2xl font-bold">Settings</h1>
+        <p className="text-gray-600">This section is a placeholder. Content coming soon.</p>
+      </Card>
+    </PageContainer>
+  );
+}

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 export default function Settings() {
   const items = [
     { href: "/settings/business", label: "Business details" },
+    { href: "/settings/employees", label: "Employees" },
     { href: "/settings/notifications", label: "Notifications" },
     { href: "/settings/dashboard", label: "Dashboard customization" },
     { href: "/settings/branding", label: "Branding" },


### PR DESCRIPTION
## Summary
- add placeholder TopNav-based settings section pages for Dashboard, Employees, Branding, Business, Notifications, and Agreement
- update Settings hub to link only to TopNav stubs

## Testing
- `npm run build`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c69b755394832496e70dc6ed819798