### PR TITLE
fix: add supabase browser client and use relative import in PerformanceCard

### DIFF
--- a/app/employees/[id]/components/PerformanceCard.tsx
+++ b/app/employees/[id]/components/PerformanceCard.tsx
@@ -1,4 +1,5 @@
 import Card from "@/components/Card";
+import { supabase } from "../../../../supabase/client";
 
 type Props = { employeeId: string };
 


### PR DESCRIPTION
## Summary
- ensure Supabase browser client uses createClient with `NEXT_PUBLIC` env vars
- import Supabase client via relative path in PerformanceCard to avoid alias issues

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6a4eb30c48324b29d8c13de8ecc9f