### PR TITLE
Employee: data wiring phase 2

### DIFF
--- a/app/employees/[id]/components/AppointmentsList.tsx
+++ b/app/employees/[id]/components/AppointmentsList.tsx
@@ -1,14 +1,98 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import Widget from "@/components/Widget";
+import { supabase } from "@/supabase/client";
+
+type Appointment = {
+  id: string;
+  start_time: string;
+  end_time: string;
+  service: string | null;
+  status: string | null;
+  pet_id: string | null;
+  client_id: string | null;
+};
 
 type Props = { employeeId: string };
 
 export default function AppointmentsList({ employeeId }: Props) {
+  const [upcoming, setUpcoming] = useState<Appointment[]>([]);
+  const [past, setPast] = useState<Appointment[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadAppointments = async () => {
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+
+      const { data: upcomingData } = await supabase
+        .from("appointments")
+        .select(
+          "id,start_time,end_time,service,status,pet_id,client_id"
+        )
+        .eq("employee_id", employeeId)
+        .gte("start_time", today.toISOString())
+        .order("start_time", { ascending: true })
+        .limit(20);
+
+      const { data: pastData } = await supabase
+        .from("appointments")
+        .select(
+          "id,start_time,end_time,service,status,pet_id,client_id"
+        )
+        .eq("employee_id", employeeId)
+        .lt("start_time", today.toISOString())
+        .order("start_time", { ascending: false })
+        .limit(20);
+
+      setUpcoming(upcomingData ?? []);
+      setPast(pastData ?? []);
+      setLoading(false);
+    };
+    loadAppointments();
+  }, [employeeId]);
+
+  if (loading) {
+    return <Widget title="Appointments">Loading...</Widget>;
+  }
+
   return (
     <Widget title="Appointments">
-      <ul className="list-disc pl-5 text-sm text-gray-600">
-        <li>Consultation - 9:00 AM</li>
-        <li>Follow-up - 1:00 PM</li>
-      </ul>
+      {upcoming.length === 0 && past.length === 0 ? (
+        <p className="text-sm text-gray-600">No appointments found.</p>
+      ) : (
+        <div className="space-y-4">
+          {upcoming.length > 0 && (
+            <div>
+              <h3 className="mb-1 font-semibold">Upcoming</h3>
+              <ul className="list-disc pl-5 text-sm text-gray-600">
+                {upcoming.map((appt) => (
+                  <li key={appt.id}>
+                    {new Date(appt.start_time).toLocaleString()} -
+                    {" "}
+                    {appt.service ?? "Appointment"}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {past.length > 0 && (
+            <div>
+              <h3 className="mb-1 font-semibold">Past</h3>
+              <ul className="list-disc pl-5 text-sm text-gray-600">
+                {past.map((appt) => (
+                  <li key={appt.id}>
+                    {new Date(appt.start_time).toLocaleString()} -
+                    {" "}
+                    {appt.service ?? "Appointment"}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
     </Widget>
   );
 }

--- a/app/employees/[id]/components/LifetimeTotalsCard.tsx
+++ b/app/employees/[id]/components/LifetimeTotalsCard.tsx
@@ -1,12 +1,40 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import Card from "@/components/Card";
+import { supabase } from "@/supabase/client";
 
 type Props = { employeeId: string };
 
 export default function LifetimeTotalsCard({ employeeId }: Props) {
+  const [total, setTotal] = useState<number | null>(null);
+
+  useEffect(() => {
+    const loadTotals = async () => {
+      const { count } = await supabase
+        .from("appointments")
+        .select("id", { count: "exact", head: true })
+        .eq("employee_id", employeeId);
+      if (typeof count === "number") {
+        setTotal(count);
+      }
+    };
+    loadTotals();
+  }, [employeeId]);
+
+  if (total === null) {
+    return (
+      <Card>
+        <h2 className="mb-2 text-lg font-semibold">Lifetime Totals</h2>
+        Loading...
+      </Card>
+    );
+  }
+
   return (
     <Card>
       <h2 className="mb-2 text-lg font-semibold">Lifetime Totals</h2>
-      <p>Placeholder totals for {employeeId}</p>
+      <p>Total Grooms: {total}</p>
     </Card>
   );
 }

--- a/app/employees/[id]/components/PayrollWidget.tsx
+++ b/app/employees/[id]/components/PayrollWidget.tsx
@@ -5,7 +5,7 @@ type Props = { employeeId: string };
 export default function PayrollWidget({ employeeId }: Props) {
   return (
     <Widget title="Payroll" color="pink">
-      <p>Payroll information for {employeeId}</p>
+      <p>Payroll summary coming soon</p>
     </Widget>
   );
 }

--- a/app/employees/[id]/components/PerformanceCard.tsx
+++ b/app/employees/[id]/components/PerformanceCard.tsx
@@ -1,13 +1,73 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import Card from "@/components/Card";
-import { supabase } from "../../../../supabase/client";
+import { supabase } from "@/supabase/client";
 
 type Props = { employeeId: string };
 
 export default function PerformanceCard({ employeeId }: Props) {
+  const [dogs, setDogs] = useState<number | null>(null);
+  const [preferredBreed, setPreferredBreed] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadPerformance = async () => {
+      const now = new Date();
+      const startOfWeek = new Date(now);
+      const endOfWeek = new Date(now);
+      const day = now.getDay();
+      startOfWeek.setDate(now.getDate() - day);
+      startOfWeek.setHours(0, 0, 0, 0);
+      endOfWeek.setDate(startOfWeek.getDate() + 6);
+      endOfWeek.setHours(23, 59, 59, 999);
+
+      const { data } = await supabase
+        .from("appointments")
+        .select("start_time,status,pet:pets(breed)")
+        .eq("employee_id", employeeId)
+        .gte("start_time", startOfWeek.toISOString())
+        .lte("start_time", endOfWeek.toISOString());
+
+      if (data) {
+        const completed = data.filter((r) => r.status === "completed");
+        setDogs(completed.length);
+
+        const breedCount: Record<string, number> = {};
+        completed.forEach((row: any) => {
+          const pet = Array.isArray(row.pet) ? row.pet[0] : row.pet;
+          const breed = pet?.breed as string | undefined;
+          if (breed) {
+            breedCount[breed] = (breedCount[breed] || 0) + 1;
+          }
+        });
+        let topBreed: string | null = null;
+        let max = 0;
+        Object.entries(breedCount).forEach(([breed, count]) => {
+          if (count > max) {
+            max = count;
+            topBreed = breed;
+          }
+        });
+        setPreferredBreed(topBreed);
+      }
+    };
+    loadPerformance();
+  }, [employeeId]);
+
+  if (dogs === null) {
+    return (
+      <Card>
+        <h2 className="mb-2 text-lg font-semibold">Performance</h2>
+        Loading...
+      </Card>
+    );
+  }
+
   return (
     <Card>
       <h2 className="mb-2 text-lg font-semibold">Performance</h2>
-      <p>Mock performance metrics for {employeeId}</p>
+      <p>Dogs Groomed This Week: {dogs}</p>
+      <p>Preferred Breed: {preferredBreed ?? "N/A"}</p>
     </Card>
   );
 }

--- a/app/employees/[id]/components/TodayWorkload.tsx
+++ b/app/employees/[id]/components/TodayWorkload.tsx
@@ -1,11 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import Widget from "@/components/Widget";
+import { supabase } from "@/supabase/client";
 
 type Props = { employeeId: string };
 
 export default function TodayWorkload({ employeeId }: Props) {
+  const [dogsToday, setDogsToday] = useState<number | null>(null);
+  const [hours, setHours] = useState<number | null>(null);
+  const [completed, setCompleted] = useState<number | null>(null);
+
+  useEffect(() => {
+    const loadWorkload = async () => {
+      const start = new Date();
+      start.setHours(0, 0, 0, 0);
+      const end = new Date();
+      end.setHours(23, 59, 59, 999);
+
+      const { data } = await supabase
+        .from("appointments")
+        .select("start_time,end_time,status")
+        .eq("employee_id", employeeId)
+        .gte("start_time", start.toISOString())
+        .lte("start_time", end.toISOString());
+
+      if (data) {
+        setDogsToday(data.length);
+        const totalHours = data.reduce((sum, row) => {
+          const startTime = new Date(row.start_time);
+          const endTime = new Date(row.end_time);
+          return sum + (endTime.getTime() - startTime.getTime()) / 3600000;
+        }, 0);
+        setHours(totalHours);
+        setCompleted(data.filter((r) => r.status === "completed").length);
+      }
+    };
+    loadWorkload();
+  }, [employeeId]);
+
+  if (dogsToday === null || hours === null || completed === null) {
+    return <Widget title="Today's Workload">Loading...</Widget>;
+  }
+
   return (
     <Widget title="Today's Workload">
-      <p>Static workload for {employeeId}</p>
+      <p>Dogs Today: {dogsToday}</p>
+      <p>Hours: {hours.toFixed(2)}</p>
+      <p>Completed: {completed}</p>
     </Widget>
   );
 }

--- a/app/employees/[id]/components/WeekScheduleWidget.tsx
+++ b/app/employees/[id]/components/WeekScheduleWidget.tsx
@@ -1,11 +1,72 @@
+"use client";
+
+import { useEffect, useState } from "react";
 import Widget from "@/components/Widget";
+import { supabase } from "@/supabase/client";
+
+type Schedule = {
+  day_of_week: number;
+  start_time: string | null;
+  end_time: string | null;
+};
 
 type Props = { employeeId: string };
 
+const DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+
 export default function WeekScheduleWidget({ employeeId }: Props) {
+  const [schedule, setSchedule] = useState<Record<number, Schedule>>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const loadSchedule = async () => {
+      const { data } = await supabase
+        .from("employee_schedule_templates")
+        .select("day_of_week,start_time,end_time")
+        .eq("employee_id", employeeId);
+      if (data) {
+        const map: Record<number, Schedule> = {};
+        data.forEach((row) => {
+          map[row.day_of_week as number] = row as Schedule;
+        });
+        setSchedule(map);
+      }
+      setLoading(false);
+    };
+    loadSchedule();
+  }, [employeeId]);
+
+  if (loading) {
+    return <Widget title="Week Schedule" color="green">Loading...</Widget>;
+  }
+
   return (
     <Widget title="Week Schedule" color="green">
-      <p>Static schedule for {employeeId}</p>
+      <ul className="text-sm text-gray-600">
+        {DAYS.map((day, idx) => {
+          const entry = schedule[idx];
+          return (
+            <li key={day} className="flex justify-between">
+              <span>{day}</span>
+              {entry && entry.start_time && entry.end_time ? (
+                <span>
+                  {new Date(entry.start_time).toLocaleTimeString([], {
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
+                  {" - "}
+                  {new Date(entry.end_time).toLocaleTimeString([], {
+                    hour: "2-digit",
+                    minute: "2-digit",
+                  })}
+                </span>
+              ) : (
+                <span>Off</span>
+              )}
+            </li>
+          );
+        })}
+      </ul>
     </Widget>
   );
 }


### PR DESCRIPTION
## Summary
- Wire employee appointments list to Supabase and show upcoming/past groupings
- Add workload metrics, weekly schedule, performance stats and lifetime totals backed by Supabase
- Placeholder payroll widget

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6aaa450048324afef4d55cf79cbf7