### PR TITLE
fix: force node runtime on auth pages to stop /login 500

### DIFF
--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+export const runtime = "nodejs";
 
 import { useState } from 'react';
 import { supabase } from '@/lib/supabase/client';

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,17 +1,25 @@
-import { Suspense } from 'react'
-import { redirect } from 'next/navigation'
-import { createClient } from '@/lib/supabase/server'
-import LoginForm from '@/components/LoginForm'
+'use client';
+export const runtime = "nodejs";
 
-export default async function LoginPage() {
-  const supabase = createClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (user) redirect('/dashboard')
+import { useEffect, Suspense } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/lib/supabase/client';
+import LoginForm from '@/components/LoginForm';
+
+export default function LoginPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      if (user) router.replace('/dashboard');
+    });
+  }, [router]);
+
   return (
     <Suspense fallback={null}>
       <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-primary-light via-primary to-primary-dark p-4">
         <LoginForm />
       </div>
     </Suspense>
-  )
+  );
 }

--- a/app/logout/page.tsx
+++ b/app/logout/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+export const runtime = "nodejs";
 
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+export const runtime = "nodejs";
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+export const runtime = "nodejs";
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';


### PR DESCRIPTION
## Summary
- run auth flows on the Node.js runtime and mark login as a client page
- redirect logged-in users from /login using Supabase client

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c6b3272b30832494cd4a831ef8d93a