### PR TITLE
fix: correct employee links; remove gradient flash

### DIFF
--- a/app/employees/page.tsx
+++ b/app/employees/page.tsx
@@ -61,7 +61,7 @@ export default function EmployeesPage() {
                   <span className="text-sm text-gray-600">{e.active ? "Active" : "Inactive"}</span>
                   {selected?.id === e.id && (
                     <Link
-                      href={`/employees/${e.id}`}
+                      href={`/employees/${Number(e.id)}`}
                       className="absolute inset-0 flex items-center justify-center bg-primary/80 text-lg font-semibold text-white"
                     >
                       Employee Page

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,5 +4,5 @@
 
 /* Custom global styles */
 body {
-  @apply bg-gradient-to-br from-secondary-pink via-secondary-purple to-secondary-green text-gray-900;
+  @apply bg-gray-50 text-gray-900;
 }


### PR DESCRIPTION
## Summary
- correct employee link generation for integer IDs
- remove gradient background to prevent flash

## Testing
- `npm run build` *(fails: missing? Wait compile with warnings but succeeded)*


------
https://chatgpt.com/codex/tasks/task_e_68c6b847c9d4832480e23f4fc60358a8