### PR TITLE
feat(employee): add missing widgets and wire to Supabase

### DIFF
--- a/app/employees/[id]/components/LifetimeTotalsCard.tsx
+++ b/app/employees/[id]/components/LifetimeTotalsCard.tsx
@@ -1,40 +1,15 @@
 "use client";
-
 import { useEffect, useState } from "react";
 import Card from "@/components/Card";
 import { supabase } from "@/supabase/client";
-
-type Props = { employeeId: string };
-
-export default function LifetimeTotalsCard({ employeeId }: Props) {
-  const [total, setTotal] = useState<number | null>(null);
-
-  useEffect(() => {
-    const loadTotals = async () => {
-      const { count } = await supabase
-        .from("appointments")
-        .select("id", { count: "exact", head: true })
-        .eq("employee_id", employeeId);
-      if (typeof count === "number") {
-        setTotal(count);
-      }
-    };
-    loadTotals();
-  }, [employeeId]);
-
-  if (total === null) {
-    return (
-      <Card>
-        <h2 className="mb-2 text-lg font-semibold">Lifetime Totals</h2>
-        Loading...
-      </Card>
-    );
-  }
-
-  return (
-    <Card>
-      <h2 className="mb-2 text-lg font-semibold">Lifetime Totals</h2>
-      <p>Total Grooms: {total}</p>
-    </Card>
-  );
+export default function LifetimeTotalsCard({ employeeId }:{employeeId:number}) {
+  const [count,setCount]=useState(0);
+  useEffect(()=>{let on=true;(async()=>{
+    const { count:c }=await supabase.from("appointments").select("*",{count:"exact",head:true})
+      .eq("employee_id",employeeId).eq("status","completed");
+    if(on) setCount(c||0);
+  })();return()=>{on=false};},[employeeId]);
+  return (<Card><h3 className="text-lg font-semibold">Lifetime Totals</h3>
+    <div className="mt-3"><div className="text-2xl font-bold">{count}</div>
+    <div className="text-sm text-gray-600">Completed grooms</div></div></Card>);
 }

--- a/app/employees/[id]/components/NotesCard.tsx
+++ b/app/employees/[id]/components/NotesCard.tsx
@@ -1,12 +1,14 @@
+"use client";
+import { useEffect, useState } from "react";
 import Card from "@/components/Card";
-
-type Props = { employeeId: string };
-
-export default function NotesCard({ employeeId }: Props) {
-  return (
-    <Card>
-      <h2 className="mb-2 text-lg font-semibold">Notes</h2>
-      <p>Sample note for {employeeId}</p>
-    </Card>
-  );
+import { supabase } from "@/supabase/client";
+type Pref={notes:string|null};
+export default function NotesCard({ employeeId }:{employeeId:number}) {
+  const [notes,setNotes]=useState("");
+  useEffect(()=>{let on=true;(async()=>{
+    const { data }=await supabase.from("employee_prefs").select("notes").eq("employee_id",employeeId).maybeSingle();
+    if(on) setNotes((data as Pref)?.notes ?? "");
+  })();return()=>{on=false};},[employeeId]);
+  return (<Card><h3 className="text-lg font-semibold">Notes</h3>
+    <p className="mt-3 text-sm whitespace-pre-wrap">{notes || "No notes"}</p></Card>);
 }

--- a/app/employees/[id]/components/PayrollWidget.tsx
+++ b/app/employees/[id]/components/PayrollWidget.tsx
@@ -1,11 +1,6 @@
-import Widget from "@/components/Widget";
-
-type Props = { employeeId: string };
-
-export default function PayrollWidget({ employeeId }: Props) {
-  return (
-    <Widget title="Payroll" color="pink">
-      <p>Payroll summary coming soon</p>
-    </Widget>
-  );
+"use client";
+import Card from "@/components/Card";
+export default function PayrollWidget({ employeeId }:{employeeId:number}) {
+  return (<Card><h3 className="text-lg font-semibold">Payroll</h3>
+    <p className="mt-3 text-sm text-gray-600">Payroll summary coming soon.</p></Card>);
 }

--- a/app/employees/[id]/components/PerformanceCard.tsx
+++ b/app/employees/[id]/components/PerformanceCard.tsx
@@ -1,73 +1,15 @@
 "use client";
-
 import { useEffect, useState } from "react";
 import Card from "@/components/Card";
 import { supabase } from "@/supabase/client";
-
-type Props = { employeeId: string };
-
-export default function PerformanceCard({ employeeId }: Props) {
-  const [dogs, setDogs] = useState<number | null>(null);
-  const [preferredBreed, setPreferredBreed] = useState<string | null>(null);
-
-  useEffect(() => {
-    const loadPerformance = async () => {
-      const now = new Date();
-      const startOfWeek = new Date(now);
-      const endOfWeek = new Date(now);
-      const day = now.getDay();
-      startOfWeek.setDate(now.getDate() - day);
-      startOfWeek.setHours(0, 0, 0, 0);
-      endOfWeek.setDate(startOfWeek.getDate() + 6);
-      endOfWeek.setHours(23, 59, 59, 999);
-
-      const { data } = await supabase
-        .from("appointments")
-        .select("start_time,status,pet:pets(breed)")
-        .eq("employee_id", employeeId)
-        .gte("start_time", startOfWeek.toISOString())
-        .lte("start_time", endOfWeek.toISOString());
-
-      if (data) {
-        const completed = data.filter((r) => r.status === "completed");
-        setDogs(completed.length);
-
-        const breedCount: Record<string, number> = {};
-        completed.forEach((row: any) => {
-          const pet = Array.isArray(row.pet) ? row.pet[0] : row.pet;
-          const breed = pet?.breed as string | undefined;
-          if (breed) {
-            breedCount[breed] = (breedCount[breed] || 0) + 1;
-          }
-        });
-        let topBreed: string | null = null;
-        let max = 0;
-        Object.entries(breedCount).forEach(([breed, count]) => {
-          if (count > max) {
-            max = count;
-            topBreed = breed;
-          }
-        });
-        setPreferredBreed(topBreed);
-      }
-    };
-    loadPerformance();
-  }, [employeeId]);
-
-  if (dogs === null) {
-    return (
-      <Card>
-        <h2 className="mb-2 text-lg font-semibold">Performance</h2>
-        Loading...
-      </Card>
-    );
-  }
-
-  return (
-    <Card>
-      <h2 className="mb-2 text-lg font-semibold">Performance</h2>
-      <p>Dogs Groomed This Week: {dogs}</p>
-      <p>Preferred Breed: {preferredBreed ?? "N/A"}</p>
-    </Card>
-  );
+type V={dogs_wtd:number};
+export default function PerformanceCard({ employeeId }:{employeeId:number}) {
+  const [v,setV]=useState<V|null>(null);
+  useEffect(()=>{let on=true;(async()=>{
+    const { data }=await supabase.from("v_employee_wtd").select("*").eq("employee_id",employeeId).maybeSingle();
+    if(on) setV(data as V);
+  })();return()=>{on=false};},[employeeId]);
+  return (<Card><h3 className="text-lg font-semibold">Performance</h3>
+    <div className="mt-3"><div className="text-2xl font-bold">{v?.dogs_wtd??0}</div>
+    <div className="text-sm text-gray-600">Dogs this week</div></div></Card>);
 }

--- a/app/employees/[id]/components/WeekScheduleWidget.tsx
+++ b/app/employees/[id]/components/WeekScheduleWidget.tsx
@@ -1,72 +1,29 @@
 "use client";
-
 import { useEffect, useState } from "react";
-import Widget from "@/components/Widget";
+import Card from "@/components/Card";
 import { supabase } from "@/supabase/client";
-
-type Schedule = {
-  day_of_week: number;
-  start_time: string | null;
-  end_time: string | null;
-};
-
-type Props = { employeeId: string };
-
-const DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-
-export default function WeekScheduleWidget({ employeeId }: Props) {
-  const [schedule, setSchedule] = useState<Record<number, Schedule>>({});
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const loadSchedule = async () => {
-      const { data } = await supabase
-        .from("employee_schedule_templates")
-        .select("day_of_week,start_time,end_time")
-        .eq("employee_id", employeeId);
-      if (data) {
-        const map: Record<number, Schedule> = {};
-        data.forEach((row) => {
-          map[row.day_of_week as number] = row as Schedule;
-        });
-        setSchedule(map);
-      }
-      setLoading(false);
-    };
-    loadSchedule();
-  }, [employeeId]);
-
-  if (loading) {
-    return <Widget title="Week Schedule" color="green">Loading...</Widget>;
-  }
-
+const DAYS = ["Sun","Mon","Tue","Wed","Thu","Fri","Sat"];
+type Row = { dow:number; start_time:string|null; end_time:string|null; break_minutes:number|null };
+export default function WeekScheduleWidget({ employeeId }:{employeeId:number}) {
+  const [rows, setRows] = useState<Row[]>([]);
+  useEffect(()=>{ let on=true;(async()=>{
+    const { data } = await supabase.from("employee_schedule_templates")
+      .select("dow,start_time,end_time,break_minutes").eq("employee_id", employeeId);
+    if(!on) return;
+    const map=new Map<number,Row>(); (data||[]).forEach(r=>map.set(r.dow, r as Row));
+    setRows(Array.from({length:7},(_,i)=>map.get(i)??{dow:i,start_time:null,end_time:null,break_minutes:0}));
+  })(); return()=>{on=false}; },[employeeId]);
   return (
-    <Widget title="Week Schedule" color="green">
-      <ul className="text-sm text-gray-600">
-        {DAYS.map((day, idx) => {
-          const entry = schedule[idx];
-          return (
-            <li key={day} className="flex justify-between">
-              <span>{day}</span>
-              {entry && entry.start_time && entry.end_time ? (
-                <span>
-                  {new Date(entry.start_time).toLocaleTimeString([], {
-                    hour: "2-digit",
-                    minute: "2-digit",
-                  })}
-                  {" - "}
-                  {new Date(entry.end_time).toLocaleTimeString([], {
-                    hour: "2-digit",
-                    minute: "2-digit",
-                  })}
-                </span>
-              ) : (
-                <span>Off</span>
-              )}
-            </li>
-          );
-        })}
+    <Card>
+      <h3 className="text-lg font-semibold">Week Schedule</h3>
+      <ul className="mt-3 space-y-1 text-sm">
+        {rows.map(r=>(
+          <li key={r.dow} className="flex justify-between">
+            <span>{DAYS[r.dow]}</span>
+            <span>{r.start_time&&r.end_time?`${r.start_time} – ${r.end_time}`:"Off"}</span>
+          </li>
+        ))}
       </ul>
-    </Widget>
+    </Card>
   );
 }

--- a/app/employees/[id]/page.tsx
+++ b/app/employees/[id]/page.tsx
@@ -1,8 +1,15 @@
 export const runtime = "nodejs";
 import { notFound } from "next/navigation";
 import PageContainer from "@/components/PageContainer";
-import Card from "@/components/Card";
 import { createClient } from "@/supabase/server";
+import Card from "@/components/Card";
+import WeekScheduleWidget from "./components/WeekScheduleWidget";
+import TodayWorkload from "./components/TodayWorkload";
+import AppointmentsList from "./components/AppointmentsList";
+import PerformanceCard from "./components/PerformanceCard";
+import LifetimeTotalsCard from "./components/LifetimeTotalsCard";
+import PayrollWidget from "./components/PayrollWidget";
+import NotesCard from "./components/NotesCard";
 
 type Params = { params: { id: string } };
 
@@ -10,44 +17,38 @@ export default async function EmployeePage({ params }: Params) {
   const supabase = createClient();
   const empId = Number(params.id);
 
-  const { data: employee, error: eErr } = await supabase
+  const { data: employee, error } = await supabase
     .from("employees")
     .select("id,name,active")
     .eq("id", empId)
     .single();
-  if (eErr || !employee) notFound();
-
-  const { data: workload } = await supabase
-    .from("v_employee_today_workload")
-    .select("*")
-    .eq("employee_id", empId)
-    .maybeSingle();
-
-  const { data: wtd } = await supabase
-    .from("v_employee_wtd")
-    .select("*")
-    .eq("employee_id", empId)
-    .maybeSingle();
+  if (error || !employee) notFound();
 
   return (
     <PageContainer>
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <Card>
-          <h2 className="text-xl font-bold">Profile</h2>
-          <p>ID: {employee.id}</p>
-          <p>Name: {employee.name}</p>
-          <p>Status: {employee.active ? "Active" : "Inactive"}</p>
-        </Card>
-        <Card>
-          <h2 className="text-xl font-bold">Today’s Workload</h2>
-          <p>Dogs Today: {workload?.dogs_today ?? 0}</p>
-          <p>Hours: {Number(workload?.hours_today ?? 0).toFixed(2)}</p>
-          <p>Completed: {workload?.completed_today ?? 0}</p>
-        </Card>
-        <Card>
-          <h2 className="text-xl font-bold">Performance</h2>
-          <p>Dogs This Week: {wtd?.dogs_wtd ?? 0}</p>
-        </Card>
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        <div className="space-y-4">
+          <Card>
+            <h3 className="text-lg font-semibold">Profile</h3>
+            <p>ID: {employee.id}</p>
+            <p>Name: {employee.name}</p>
+            <p>Status: {employee.active ? "Active" : "Inactive"}</p>
+          </Card>
+          <WeekScheduleWidget employeeId={empId} />
+          <NotesCard employeeId={empId} />
+        </div>
+
+        <div className="space-y-4">
+          <TodayWorkload employeeId={empId} />
+          <AppointmentsList employeeId={empId} kind="upcoming" />
+          <AppointmentsList employeeId={empId} kind="past" />
+        </div>
+
+        <div className="space-y-4">
+          <PerformanceCard employeeId={empId} />
+          <LifetimeTotalsCard employeeId={empId} />
+          <PayrollWidget employeeId={empId} />
+        </div>
       </div>
     </PageContainer>
   );


### PR DESCRIPTION
## Summary
- render all employee widgets, including schedule, notes, workload, appointments, performance, totals, and payroll placeholder
- implement client-side components backed by Supabase queries

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build` *(warnings: Node.js APIs not supported in Edge Runtime)*


------
https://chatgpt.com/codex/tasks/task_e_68c6bbe2f9c08324a236af29f92565a6