### PR TITLE
feat(employee): calendar page, editable notes, payroll widget

### DIFF
--- a/app/employees/[id]/components/AppointmentsList.tsx
+++ b/app/employees/[id]/components/AppointmentsList.tsx
@@ -2,23 +2,41 @@
 import { useEffect, useState } from "react";
 import Card from "@/components/Card";
 import { supabase } from "../../../../supabase/client";
-type Row = { id: number; start_time: string; end_time: string | null; status: string; service?: string | null; client_id?: number | null; pet_id?: number | null };
-export default function AppointmentsList({ employeeId, kind }: { employeeId: number; kind: "upcoming"|"past" }) {
+
+type Row = {
+  id: number;
+  start_time: string;
+  end_time: string | null;
+  status: string;
+  service: string | null;
+};
+
+export default function AppointmentsList({ employeeId, kind }: { employeeId: number; kind: "upcoming" | "past" }) {
   const [rows, setRows] = useState<Row[]>([]);
-  useEffect(()=>{ let on=true;(async()=>{
-    const now = new Date().toISOString();
-    let q = supabase.from("appointments").select("id,start_time,end_time,status,service,client_id,pet_id").eq("employee_id", employeeId);
-    q = kind==="upcoming" ? q.gte("start_time", now).order("start_time", { ascending: true }).limit(20)
-                          : q.lt("start_time", now).order("start_time", { ascending: false }).limit(20);
-    const { data } = await q;
-    if(on) setRows((data||[]) as Row[]);
-  })(); return ()=>{on=false}; },[employeeId,kind]);
+  useEffect(() => {
+    let on = true;
+    (async () => {
+      const now = new Date().toISOString();
+      let q = supabase
+        .from("appointments")
+        .select("id,start_time,end_time,status,service")
+        .eq("employee_id", employeeId);
+      q =
+        kind === "upcoming"
+          ? q.gte("start_time", now).order("start_time", { ascending: true }).limit(20)
+          : q.lt("start_time", now).order("start_time", { ascending: false }).limit(20);
+      const { data } = await q;
+      if (on) setRows((data ?? []) as Row[]);
+    })();
+    return () => { on = false; };
+  }, [employeeId, kind]);
+
   return (
     <Card>
-      <h3 className="text-lg font-semibold">{kind==="upcoming"?"Upcoming Appointments":"Past Appointments"}</h3>
+      <h3 className="text-lg font-semibold">{kind === "upcoming" ? "Upcoming Appointments" : "Past Appointments"}</h3>
       <ul className="mt-3 space-y-2 text-sm">
-        {rows.length===0 && <li className="text-gray-500">None</li>}
-        {rows.map(r => (
+        {rows.length === 0 && <li className="text-gray-500">None</li>}
+        {rows.map((r) => (
           <li key={r.id} className="flex justify-between">
             <span>{new Date(r.start_time).toLocaleString()}</span>
             <span className="truncate max-w-[50%] text-right">{r.service ?? "Service"}</span>

--- a/app/employees/[id]/components/NotesCard.tsx
+++ b/app/employees/[id]/components/NotesCard.tsx
@@ -2,17 +2,52 @@
 import { useEffect, useState } from "react";
 import Card from "@/components/Card";
 import { supabase } from "../../../../supabase/client";
-type Pref = { notes: string | null };
+
 export default function NotesCard({ employeeId }: { employeeId: number }) {
-  const [notes, setNotes] = useState<string>("");
-  useEffect(()=>{ let on=true;(async()=>{
-    const { data } = await supabase.from("employee_prefs").select("notes").eq("employee_id", employeeId).maybeSingle();
-    if(on) setNotes((data as Pref)?.notes ?? "");
-  })(); return ()=>{on=false}; },[employeeId]);
+  const [notes, setNotes] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let on = true;
+    (async () => {
+      const { data } = await supabase
+        .from("employee_prefs")
+        .select("notes")
+        .eq("employee_id", employeeId)
+        .maybeSingle();
+      if (on) { setNotes((data?.notes as string) ?? ""); setLoaded(true); }
+    })();
+    return () => { on = false; };
+  }, [employeeId]);
+
+  async function save() {
+    setSaving(true);
+    await supabase
+      .from("employee_prefs")
+      .upsert({ employee_id: employeeId, notes }, { onConflict: "employee_id" });
+    setSaving(false);
+  }
+
   return (
     <Card>
-      <h3 className="text-lg font-semibold">Notes</h3>
-      <p className="mt-3 text-sm whitespace-pre-wrap">{notes || "No notes"}</p>
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">Notes</h3>
+        <button
+          onClick={save}
+          disabled={!loaded || saving}
+          className="text-sm rounded border px-3 py-1 disabled:opacity-50"
+        >
+          {saving ? "Saving…" : "Save"}
+        </button>
+      </div>
+      <textarea
+        className="mt-3 w-full rounded border p-2 text-sm"
+        rows={5}
+        value={notes}
+        onChange={(e) => setNotes(e.target.value)}
+        placeholder="Add notes for this employee"
+      />
     </Card>
   );
 }

--- a/app/employees/[id]/components/PayrollWidget.tsx
+++ b/app/employees/[id]/components/PayrollWidget.tsx
@@ -1,10 +1,41 @@
 "use client";
+import { useEffect, useState } from "react";
 import Card from "@/components/Card";
+import { supabase } from "../../../../supabase/client";
+
+function weekStart(d = new Date()) {
+  const s = new Date(d); s.setHours(0,0,0,0);
+  s.setDate(s.getDate() - s.getDay());
+  return s;
+}
+
 export default function PayrollWidget({ employeeId }: { employeeId: number }) {
+  const [grossCents, setGrossCents] = useState(0);
+
+  useEffect(() => {
+    let on = true;
+    (async () => {
+      const start = weekStart();
+      const end = new Date(start); end.setDate(start.getDate() + 7);
+      const { data } = await supabase
+        .from("appointments")
+        .select("price_cents,start_time,status")
+        .eq("employee_id", employeeId)
+        .eq("status", "completed")
+        .gte("start_time", start.toISOString())
+        .lt("start_time", end.toISOString());
+      const total = (data ?? []).reduce((s, r: any) => s + (r.price_cents ?? 0), 0);
+      if (on) setGrossCents(total);
+    })();
+    return () => { on = false; };
+  }, [employeeId]);
+
+  const dollars = (grossCents / 100).toFixed(2);
   return (
     <Card>
-      <h3 className="text-lg font-semibold">Payroll</h3>
-      <p className="mt-3 text-sm text-gray-600">Payroll summary coming soon.</p>
+      <h3 className="text-lg font-semibold">Payroll (Week-to-Date)</h3>
+      <div className="mt-3 text-2xl font-bold">${dollars}</div>
+      <div className="text-sm text-gray-600">Completed appointment revenue</div>
     </Card>
   );
 }

--- a/app/employees/[id]/schedule/page.tsx
+++ b/app/employees/[id]/schedule/page.tsx
@@ -1,10 +1,42 @@
+export const runtime = "nodejs";
 import PageContainer from "@/components/PageContainer";
+import { createClient } from "@/supabase/server";
 
-export default function EmployeeSchedulePage() {
+type Params = { params: { id: string } };
+
+function iso(d: Date) { return d.toISOString(); }
+
+export default async function EmployeeSchedulePage({ params }: Params) {
+  const supabase = createClient();
+  const empId = Number(params.id);
+
+  const start = new Date(); start.setHours(0,0,0,0);
+  const end = new Date(start); end.setDate(start.getDate()+14);
+
+  const { data: appts } = await supabase
+    .from("appointments")
+    .select("id,start_time,end_time,status,service")
+    .eq("employee_id", empId)
+    .gte("start_time", iso(start))
+    .lt("start_time", iso(end))
+    .order("start_time", { ascending: true });
+
+  // simple agenda list
   return (
     <PageContainer>
-      <h1 className="text-2xl font-bold">Employee Schedule</h1>
-      {/* TODO: Month/Week/Day calendar editor + recurring template + time off */}
+      <h1 className="text-2xl font-bold mb-4">Schedule (Next 14 Days)</h1>
+      <div className="space-y-2">
+        {(appts ?? []).length === 0 && <p className="text-gray-600">No appointments.</p>}
+        {(appts ?? []).map(a => (
+          <div key={a.id} className="rounded border p-3 flex items-center justify-between">
+            <div>
+              <div className="font-semibold">{new Date(a.start_time).toLocaleString()}</div>
+              <div className="text-sm text-gray-600">{a.service ?? "Service"}</div>
+            </div>
+            <div className="text-sm text-gray-700">{a.status}</div>
+          </div>
+        ))}
+      </div>
     </PageContainer>
   );
 }


### PR DESCRIPTION
## Summary
- add employee schedule page for next 14 days
- make employee notes editable and persist via upsert
- show week-to-date payroll from completed appointments
- include service and status in appointment lists

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`
- `npm run build` *(warnings about Node.js APIs in supabase libraries)*


------
https://chatgpt.com/codex/tasks/task_e_68c6c4ca34888324aa6f42e19616b970