### PR TITLE
Add detailed employee profile card

### DIFF
--- a/app/employees/[id]/components/ProfileCard.tsx
+++ b/app/employees/[id]/components/ProfileCard.tsx
@@ -1,23 +1,70 @@
 "use client";
 import Card from "@/components/Card";
-type Emp = { id: number; name: string; active: boolean | null };
+import Image from "next/image";
+
+type Emp = {
+  id: number;
+  name: string;
+  active: boolean | null;
+  role: string | null;
+  phone: string | null;
+  email: string | null;
+  address: string | null;
+  photo: string | null;
+};
+
 export default function ProfileCard({ employee }: { employee: Emp }) {
   return (
     <Card>
       <div className="flex items-center justify-between">
         <h3 className="text-lg font-semibold">Profile</h3>
-        <span className={`text-xs px-2 py-0.5 rounded ${employee.active ? "bg-green-100 text-green-700" : "bg-gray-200 text-gray-700"}`}>
+        <span
+          className={`text-xs px-2 py-0.5 rounded ${employee.active ? "bg-green-100 text-green-700" : "bg-gray-200 text-gray-700"}`}
+        >
           {employee.active ? "Active" : "Inactive"}
         </span>
       </div>
-      <div className="mt-3 text-sm text-gray-700">
-        <div>ID: {employee.id}</div>
-        <div>Name: {employee.name}</div>
+      <div className="mt-4 flex items-center gap-4">
+        {employee.photo ? (
+          <Image
+            src={employee.photo}
+            alt={employee.name}
+            width={64}
+            height={64}
+            className="h-16 w-16 rounded-full object-cover"
+          />
+        ) : (
+          <div className="h-16 w-16 rounded-full bg-gray-200" />
+        )}
+        <div>
+          <div className="font-medium">{employee.name}</div>
+          <div className="text-sm text-gray-600">{employee.role || "—"}</div>
+        </div>
+      </div>
+      <div className="mt-4 space-y-1 text-sm text-gray-700">
+        <div>Phone: {employee.phone || "—"}</div>
+        <div>Email: {employee.email || "—"}</div>
+        <div>Address: {employee.address || "—"}</div>
       </div>
       <div className="mt-4 flex gap-2">
-        <button className="rounded border px-3 py-1 text-sm">Call</button>
-        <button className="rounded border px-3 py-1 text-sm">Text</button>
-        <button className="rounded border px-3 py-1 text-sm">Email</button>
+        <a
+          href={employee.phone ? `tel:${employee.phone}` : undefined}
+          className="rounded border px-3 py-1 text-sm"
+        >
+          Call
+        </a>
+        <a
+          href={employee.phone ? `sms:${employee.phone}` : undefined}
+          className="rounded border px-3 py-1 text-sm"
+        >
+          Text
+        </a>
+        <a
+          href={employee.email ? `mailto:${employee.email}` : undefined}
+          className="rounded border px-3 py-1 text-sm"
+        >
+          Email
+        </a>
       </div>
     </Card>
   );

--- a/app/employees/[id]/page.tsx
+++ b/app/employees/[id]/page.tsx
@@ -18,7 +18,7 @@ export default async function EmployeePage({ params }: Params) {
   const empId = Number(params.id);
   const { data: employee, error } = await supabase
     .from("employees")
-    .select("id,name,active")
+    .select("id,name,active,role,phone,email,address,photo")
     .eq("id", empId)
     .single();
   if (error || !employee) notFound();


### PR DESCRIPTION
## Summary
- display employee photo, role, contact info and quick actions in profile card
- load additional employee fields from Supabase

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c6c70a9abc8324a2cc20bb9ce0959e