### PR TITLE
feat: expand employee profile card

### DIFF
--- a/app/employees/[id]/components/ProfileCard.tsx
+++ b/app/employees/[id]/components/ProfileCard.tsx
@@ -1,23 +1,71 @@
 "use client";
+/* eslint-disable @next/next/no-img-element */
 import Card from "@/components/Card";
-type Emp = { id: number; name: string; active: boolean | null };
+
+type Emp = {
+  id: number;
+  name: string;
+  active: boolean | null;
+  role?: string | null;
+  phone?: string | null;
+  email?: string | null;
+  address?: string | null;
+  photo_url?: string | null;
+  photo?: string | null;
+};
+
 export default function ProfileCard({ employee }: { employee: Emp }) {
+  const photo = employee.photo_url || employee.photo;
   return (
     <Card>
-      <div className="flex items-center justify-between">
-        <h3 className="text-lg font-semibold">Profile</h3>
-        <span className={`text-xs px-2 py-0.5 rounded ${employee.active ? "bg-green-100 text-green-700" : "bg-gray-200 text-gray-700"}`}>
+      <div className="flex items-center gap-4">
+        <img
+          src={photo || "https://via.placeholder.com/80"}
+          alt={employee.name}
+          className="h-16 w-16 rounded-full object-cover"
+        />
+        <div className="flex-1">
+          <h3 className="text-lg font-semibold">{employee.name}</h3>
+          {employee.role && <p className="text-sm text-gray-600">{employee.role}</p>}
+        </div>
+        <span
+          className={`text-xs px-2 py-0.5 rounded ${
+            employee.active ? "bg-green-100 text-green-700" : "bg-gray-200 text-gray-700"
+          }`}
+        >
           {employee.active ? "Active" : "Inactive"}
         </span>
       </div>
-      <div className="mt-3 text-sm text-gray-700">
-        <div>ID: {employee.id}</div>
-        <div>Name: {employee.name}</div>
+      <div className="mt-4 space-y-1 text-sm text-gray-700">
+        {employee.phone && <div>{employee.phone}</div>}
+        {employee.email && <div>{employee.email}</div>}
+        {employee.address && <div>{employee.address}</div>}
       </div>
       <div className="mt-4 flex gap-2">
-        <button className="rounded border px-3 py-1 text-sm">Call</button>
-        <button className="rounded border px-3 py-1 text-sm">Text</button>
-        <button className="rounded border px-3 py-1 text-sm">Email</button>
+        {employee.phone && (
+          <a
+            href={`tel:${employee.phone}`}
+            className="rounded border px-3 py-1 text-sm"
+          >
+            Call
+          </a>
+        )}
+        {employee.phone && (
+          <a
+            href={`sms:${employee.phone}`}
+            className="rounded border px-3 py-1 text-sm"
+          >
+            Text
+          </a>
+        )}
+        {employee.email && (
+          <a
+            href={`mailto:${employee.email}`}
+            className="rounded border px-3 py-1 text-sm"
+          >
+            Email
+          </a>
+        )}
       </div>
     </Card>
   );

--- a/app/employees/[id]/page.tsx
+++ b/app/employees/[id]/page.tsx
@@ -18,7 +18,7 @@ export default async function EmployeePage({ params }: Params) {
   const empId = Number(params.id);
   const { data: employee, error } = await supabase
     .from("employees")
-    .select("id,name,active")
+    .select("*")
     .eq("id", empId)
     .single();
   if (error || !employee) notFound();


### PR DESCRIPTION
## Summary
- show employee avatar, role, and contact info with quick actions
- query full employee record to avoid missing-field 404s

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c6d55ec9f883248dbacbf49ed89038