### PR TITLE
fix: narrow time-off request status type

### DIFF
--- a/app/employees/[id]/components/ScheduleEditor.tsx
+++ b/app/employees/[id]/components/ScheduleEditor.tsx
@@ -133,18 +133,18 @@ export default function ScheduleEditor({ employeeId, initialSchedule }: Schedule
   // Approve a time off request. Update the local state and persist to Supabase.
   const approveRequest = async (requestId: string) => {
     if (!schedule) return;
-    const updatedRequests: TimeOffRequest[] = schedule.requests.map((req) =>
-      req.id === requestId ? { ...req, status: "approved" as const } : req
-    );
+    const updatedRequests = schedule.requests.map((req) =>
+      req.id === requestId ? { ...req, status: "approved" } : req
+    ) satisfies TimeOffRequest[];
     await persistSchedule({ ...(schedule as Schedule), requests: updatedRequests });
   };
 
   // Deny a time off request. Update the local state and persist to Supabase.
   const denyRequest = async (requestId: string) => {
     if (!schedule) return;
-    const updatedRequests: TimeOffRequest[] = schedule.requests.map((req) =>
-      req.id === requestId ? { ...req, status: "denied" as const } : req
-    );
+    const updatedRequests = schedule.requests.map((req) =>
+      req.id === requestId ? { ...req, status: "denied" } : req
+    ) satisfies TimeOffRequest[];
     await persistSchedule({ ...(schedule as Schedule), requests: updatedRequests });
   };
 


### PR DESCRIPTION
## Summary
- ensure time-off requests carry literal status types when approving or denying

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `npm test` *(fails: test failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c75a71b2088324bebce597b516e882