### PR TITLE
feat: add Scruffy Butts theme system

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -6,35 +6,36 @@ import TodaysAppointments from '@/components/dashboard/TodaysAppointments'
 import EmployeeWorkload from '@/components/dashboard/EmployeeWorkload'
 import Messages from '@/components/dashboard/Messages'
 import Revenue from '@/components/dashboard/Revenue'
+import Button from '@/components/ui/Button'
 
-export const runtime = "nodejs"
+export const runtime = 'nodejs'
 
 export default async function DashboardPage() {
   const supabase = createClient()
   const {
-    data: { user },
+    data: { user }
   } = await supabase.auth.getUser()
   if (!user) redirect('/login')
   return (
     <PageContainer>
       <div className="grid gap-6 md:grid-cols-3">
-        <Widget title="Today's Appointments" color="pink" className="md:col-span-2 md:row-span-4">
+        <Widget title="Today's Appointments" color="accent" className="md:col-span-2 md:row-span-4">
           <TodaysAppointments />
         </Widget>
-        <Widget title="Employee Workload" color="green" className="md:col-start-3">
+        <Widget title="Employee Workload" color="success" className="md:col-start-3">
           <EmployeeWorkload />
         </Widget>
-        <Widget title="Revenue" color="purple" className="md:col-start-3">
+        <Widget title="Revenue" color="progress" className="md:col-start-3">
           <Revenue />
         </Widget>
-        <Widget title="Messages" color="purple" className="md:col-start-3">
+        <Widget title="Messages" color="progress" className="md:col-start-3">
           <Messages />
         </Widget>
-        <Widget title="Quick Actions" color="pink" className="md:col-start-3">
+        <Widget title="Quick Actions" color="accent" className="md:col-start-3">
           <div className="flex flex-col space-y-2">
-            <button className="rounded-full bg-primary px-4 py-2 text-white">Book Appointment</button>
-            <button className="rounded-full bg-primary px-4 py-2 text-white">Add Client</button>
-            <button className="rounded-full bg-primary px-4 py-2 text-white">Generate Report</button>
+            <Button fullWidth>Book Appointment</Button>
+            <Button fullWidth>Add Client</Button>
+            <Button fullWidth>Generate Report</Button>
           </div>
         </Widget>
       </div>

--- a/app/employees/[id]/components/PreferencesEditor.tsx
+++ b/app/employees/[id]/components/PreferencesEditor.tsx
@@ -1,11 +1,11 @@
-import Widget from "@/components/Widget";
+import Widget from '@/components/Widget'
 
-type Props = { employeeId: string };
+type Props = { employeeId: string }
 
 export default function PreferencesEditor({ employeeId }: Props) {
   return (
-    <Widget title="Preferences" color="purple">
+    <Widget title="Preferences" color="progress">
       <p>Preferences editor placeholder for {employeeId}</p>
     </Widget>
-  );
+  )
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,7 +2,73 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Custom global styles */
+:root {
+  --sb-bg: linear-gradient(to bottom, #0b5fff, #19a2ff);
+  --sb-primary: 11 95 255;
+  --sb-primary-700: 8 75 204;
+  --sb-accent: 255 58 166;
+  --sb-accent-700: 204 46 132;
+  --sb-surface: 255 255 255;
+  --sb-muted: 242 246 255;
+  --sb-text: 15 23 42;
+  --info: 59 130 246;
+  --success: 16 185 129;
+  --warn: 245 158 11;
+  --danger: 239 68 68;
+  --progress: 168 85 247;
+  --radius-sm: 8px;
+  --radius-md: 14px;
+  --radius-lg: 22px;
+  --radius-pill: 9999px;
+  --shadow-card: 0 8px 24px rgba(2, 6, 23, 0.08);
+}
+
+.sb-gradient {
+  background-image: var(--sb-bg);
+}
+
 body {
-  @apply bg-gray-50 text-gray-900;
+  @apply bg-muted text-text;
+  font-family: 'Inter', system-ui, sans-serif;
+}
+
+.rounded-pill {
+  border-radius: var(--radius-pill);
+}
+
+.card {
+  @apply rounded-sb bg-surface shadow-card;
+}
+.card-header {
+  @apply mb-4 font-semibold;
+}
+.card-body {
+  @apply p-4;
+}
+.card-footer {
+  @apply mt-4;
+}
+
+
+.btn {
+  @apply inline-flex items-center justify-center rounded-sb font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-accent;
+}
+.btn-primary {
+  @apply bg-primary text-white hover:bg-primary-700;
+}
+.btn-secondary {
+  @apply bg-muted text-text hover:bg-primary/10;
+}
+.btn-accent {
+  @apply bg-accent text-white hover:bg-accent-700;
+}
+.btn-ghost {
+  @apply bg-transparent text-text hover:bg-muted;
+}
+.btn-destructive {
+  @apply bg-danger text-white hover:bg-danger/90;
+}
+
+.chip {
+  @apply inline-flex items-center rounded-pill px-2 py-0.5 text-xs font-medium;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,22 +1,22 @@
-import TopNav from "@/components/TopNav";
-import "./globals.css";
-import AuthProvider from "@/components/AuthProvider";
+import SiteHeader from '@/components/layout/SiteHeader'
+import './globals.css'
+import AuthProvider from '@/components/AuthProvider'
 
 export const metadata = {
-  title: "Scruffy Butts",
-  description: "Grooming dashboard",
-};
-export const runtime = "nodejs";
+  title: 'Scruffy Butts',
+  description: 'Grooming dashboard'
+}
+export const runtime = 'nodejs'
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <body>
-        <TopNav />
+        <SiteHeader />
         <main>
           <AuthProvider>{children}</AuthProvider>
         </main>
       </body>
     </html>
-  );
+  )
 }

--- a/components/Widget.tsx
+++ b/components/Widget.tsx
@@ -3,27 +3,21 @@ import clsx from 'clsx'
 
 interface WidgetProps {
   title: string
-  color?: 'pink' | 'purple' | 'green'
+  color?: 'accent' | 'progress' | 'success'
   children: ReactNode
   className?: string
 }
 
-// A simple card with a thin colored header matching the supplied color. See the
-// dashboard mockups for examples of how these widgets should look.
-export default function Widget({ title, color = 'pink', children, className }: WidgetProps) {
+export default function Widget({ title, color = 'accent', children, className }: WidgetProps) {
   const headerColor = {
-    pink: 'bg-secondary-pink',
-    purple: 'bg-secondary-purple',
-    green: 'bg-secondary-green',
+    accent: 'bg-accent',
+    progress: 'bg-progress',
+    success: 'bg-success'
   }[color]
   return (
-    <div className={clsx('overflow-hidden rounded-3xl bg-white shadow', className)}>
-      <div className={clsx('px-5 py-3 text-sm font-semibold text-primary-dark', headerColor)}>
-        {title}
-      </div>
-      <div className="p-5">
-        {children}
-      </div>
+    <div className={clsx('card', className)}>
+      <div className={clsx('card-header text-white', headerColor)}>{title}</div>
+      <div className="card-body">{children}</div>
     </div>
   )
 }

--- a/components/layout/SiteHeader.tsx
+++ b/components/layout/SiteHeader.tsx
@@ -1,0 +1,43 @@
+"use client"
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import clsx from 'clsx'
+import Avatar from '@/components/ui/Avatar'
+
+const navItems = [
+  { href: '/dashboard', label: 'Dashboard' },
+  { href: '/calendar', label: 'Calendar' },
+  { href: '/clients', label: 'Clients' },
+  { href: '/employees', label: 'Employees' },
+  { href: '/reports', label: 'Reports' },
+  { href: '/messages', label: 'Messages' },
+  { href: '/settings', label: 'Settings' }
+]
+
+export default function SiteHeader() {
+  const pathname = usePathname()
+  return (
+    <header className="sb-gradient text-white">
+      <div className="mx-auto flex max-w-7xl items-center justify-between p-4">
+        <Link href="/" className="font-semibold">ScruffyButts</Link>
+        <nav className="hidden gap-6 md:flex">
+          {navItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={clsx(
+                'pb-1',
+                pathname.startsWith(item.href) && 'border-b-2 border-accent'
+              )}
+            >
+              {item.label}
+            </Link>
+          ))}
+        </nav>
+        <div className="flex items-center">
+          <Avatar name="User" />
+        </div>
+      </div>
+    </header>
+  )
+}

--- a/components/ui/Avatar.tsx
+++ b/components/ui/Avatar.tsx
@@ -1,0 +1,28 @@
+import clsx from 'clsx'
+
+interface AvatarProps {
+  src?: string
+  alt?: string
+  name: string
+  className?: string
+}
+
+export default function Avatar({ src, alt, name, className }: AvatarProps) {
+  const initials = name
+    .split(' ')
+    .map((n) => n[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase()
+
+  return (
+    <div className={clsx('inline-flex h-8 w-8 items-center justify-center rounded-full bg-muted text-text text-sm', className)}>
+      {src ? (
+        // eslint-disable-next-line @next/next/no-img-element
+        <img src={src} alt={alt ?? name} className="h-full w-full rounded-full object-cover" />
+      ) : (
+        initials
+      )}
+    </div>
+  )
+}

--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -1,0 +1,23 @@
+import clsx from 'clsx'
+import { ReactNode } from 'react'
+
+export type BadgeVariant = 'info' | 'success' | 'warn' | 'danger' | 'progress' | 'accent'
+
+interface BadgeProps {
+  children: ReactNode
+  variant?: BadgeVariant
+  className?: string
+}
+
+export default function Badge({ children, variant = 'info', className }: BadgeProps) {
+  const variantClass: Record<BadgeVariant, string> = {
+    info: 'bg-info text-white',
+    success: 'bg-success text-white',
+    warn: 'bg-warn text-white',
+    danger: 'bg-danger text-white',
+    progress: 'bg-progress text-white',
+    accent: 'bg-accent text-white'
+  }
+
+  return <span className={clsx('chip', variantClass[variant], className)}>{children}</span>
+}

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -1,0 +1,41 @@
+import clsx from 'clsx'
+import { ButtonHTMLAttributes } from 'react'
+
+export type ButtonVariant = 'primary' | 'secondary' | 'accent' | 'ghost' | 'destructive'
+export type ButtonSize = 'sm' | 'md' | 'lg'
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: ButtonVariant
+  size?: ButtonSize
+  fullWidth?: boolean
+  className?: string
+}
+
+export default function Button({
+  variant = 'primary',
+  size = 'md',
+  fullWidth = false,
+  className,
+  ...props
+}: ButtonProps) {
+  const variantClass: Record<ButtonVariant, string> = {
+    primary: 'btn-primary',
+    secondary: 'btn-secondary',
+    accent: 'btn-accent',
+    ghost: 'btn-ghost',
+    destructive: 'btn-destructive'
+  }
+
+  const sizeClass: Record<ButtonSize, string> = {
+    sm: 'px-3 py-1.5 text-sm',
+    md: 'px-4 py-2 text-sm',
+    lg: 'px-6 py-3 text-base'
+  }
+
+  return (
+    <button
+      className={clsx('btn', variantClass[variant], sizeClass[size], fullWidth && 'w-full', className)}
+      {...props}
+    />
+  )
+}

--- a/components/ui/Card.tsx
+++ b/components/ui/Card.tsx
@@ -1,0 +1,19 @@
+import clsx from 'clsx'
+import { ReactNode } from 'react'
+
+interface CardProps {
+  header?: ReactNode
+  footer?: ReactNode
+  children: ReactNode
+  className?: string
+}
+
+export default function Card({ header, footer, children, className }: CardProps) {
+  return (
+    <div className={clsx('card', className)}>
+      {header && <div className="card-header">{header}</div>}
+      <div className="card-body">{children}</div>
+      {footer && <div className="card-footer">{footer}</div>}
+    </div>
+  )
+}

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -1,0 +1,52 @@
+export const cssVariables: Record<string, string> = {
+  '--sb-bg': 'linear-gradient(to bottom, #0b5fff, #19a2ff)',
+  '--sb-primary': '11 95 255',
+  '--sb-primary-700': '8 75 204',
+  '--sb-accent': '255 58 166',
+  '--sb-accent-700': '204 46 132',
+  '--sb-surface': '255 255 255',
+  '--sb-muted': '242 246 255',
+  '--sb-text': '15 23 42',
+  '--info': '59 130 246',
+  '--success': '16 185 129',
+  '--warn': '245 158 11',
+  '--danger': '239 68 68',
+  '--progress': '168 85 247',
+  '--radius-sm': '8px',
+  '--radius-md': '14px',
+  '--radius-lg': '22px',
+  '--radius-pill': '9999px',
+  '--shadow-card': '0 8px 24px rgba(2, 6, 23, 0.08)'
+}
+
+export const theme = {
+  colors: {
+    primary: 'rgb(var(--sb-primary))',
+    primary700: 'rgb(var(--sb-primary-700))',
+    accent: 'rgb(var(--sb-accent))',
+    accent700: 'rgb(var(--sb-accent-700))',
+    surface: 'rgb(var(--sb-surface))',
+    muted: 'rgb(var(--sb-muted))',
+    text: 'rgb(var(--sb-text))',
+    status: {
+      info: 'rgb(var(--info))',
+      success: 'rgb(var(--success))',
+      warn: 'rgb(var(--warn))',
+      danger: 'rgb(var(--danger))',
+      progress: 'rgb(var(--progress))'
+    }
+  },
+  radii: {
+    sm: 'var(--radius-sm)',
+    md: 'var(--radius-md)',
+    lg: 'var(--radius-lg)',
+    pill: 'var(--radius-pill)'
+  },
+  shadows: {
+    card: 'var(--shadow-card)'
+  }
+}
+
+export const useThemeTokens = () => theme
+
+export default theme

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,23 +1,45 @@
 import type { Config } from 'tailwindcss'
 
+const withOpacity = (variable: string) => {
+  return ({ opacityValue }: { opacityValue?: string }) => {
+    if (opacityValue === undefined) {
+      return `rgb(var(${variable}))`
+    }
+    return `rgb(var(${variable}) / ${opacityValue})`
+  }
+}
+
 const config: Config = {
   content: [
     './app/**/*.{js,ts,jsx,tsx}',
-    './components/**/*.{js,ts,jsx,tsx}'
+    './components/**/*.{js,ts,jsx,tsx}',
+    './styles/**/*.{js,ts,jsx,tsx}'
   ],
   theme: {
     extend: {
       colors: {
         primary: {
-          light: '#76b2fe',
-          DEFAULT: '#4b79a1',
-          dark: '#283e51'
+          DEFAULT: withOpacity('--sb-primary') as any,
+          700: withOpacity('--sb-primary-700') as any
         },
-        secondary: {
-          pink: '#f8b4c0',
-          purple: '#dcbcef',
-          green: '#b5e5cf'
-        }
+        accent: {
+          DEFAULT: withOpacity('--sb-accent') as any,
+          700: withOpacity('--sb-accent-700') as any
+        },
+        surface: withOpacity('--sb-surface') as any,
+        muted: withOpacity('--sb-muted') as any,
+        text: withOpacity('--sb-text') as any,
+        info: withOpacity('--info') as any,
+        success: withOpacity('--success') as any,
+        warn: withOpacity('--warn') as any,
+        danger: withOpacity('--danger') as any,
+        progress: withOpacity('--progress') as any
+      },
+      borderRadius: {
+        sb: 'var(--radius-md)'
+      },
+      boxShadow: {
+        card: 'var(--shadow-card)'
       }
     }
   },


### PR DESCRIPTION
## Summary
- define global design tokens and CSS variables
- add typed UI components and gradient header
- apply new theme to dashboard widgets
- expose color variants in tailwind config for hover states
- convert theme color variables to RGB and add opacity helper so classes like `hover:bg-primary/10` compile

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c76b3d54bc8324ac5aef5214ef83b9