### PR TITLE
Restyle app with Scruffy Butts dashboard theme

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -18,23 +18,40 @@ export default async function DashboardPage() {
   return (
     <PageContainer>
       <div className="grid gap-6 md:grid-cols-3">
-        <Widget title="Today's Appointments" color="pink" className="md:col-span-2 md:row-span-4">
+        <Widget
+          title="Today's Appointments"
+          color="blue"
+          className="md:col-span-2 md:row-span-4"
+          hideHeader
+        >
           <TodaysAppointments />
         </Widget>
-        <Widget title="Employee Workload" color="green" className="md:col-start-3">
+        <Widget title="Employee Workload" color="purple" className="md:col-start-3">
           <EmployeeWorkload />
         </Widget>
-        <Widget title="Revenue" color="purple" className="md:col-start-3">
+        <Widget title="Revenue" color="green" className="md:col-start-3">
           <Revenue />
         </Widget>
         <Widget title="Messages" color="purple" className="md:col-start-3">
           <Messages />
         </Widget>
         <Widget title="Quick Actions" color="pink" className="md:col-start-3">
-          <div className="flex flex-col space-y-2">
-            <button className="rounded-full bg-primary px-4 py-2 text-white">Book Appointment</button>
-            <button className="rounded-full bg-primary px-4 py-2 text-white">Add Client</button>
-            <button className="rounded-full bg-primary px-4 py-2 text-white">Generate Report</button>
+          <div className="flex flex-col space-y-3">
+            {[
+              'Book Appointment',
+              'Add Client',
+              'Generate Report',
+            ].map((label) => (
+              <button
+                key={label}
+                className="group flex items-center justify-between rounded-2xl bg-white/95 px-5 py-3 text-left font-semibold text-brand-navy shadow-lg transition duration-200 hover:-translate-y-0.5 hover:bg-white"
+              >
+                <span>{label}</span>
+                <span className="flex h-9 w-9 items-center justify-center rounded-full bg-brand-bubble text-lg text-white shadow-inner transition-transform duration-200 group-hover:scale-105">
+                  →
+                </span>
+              </button>
+            ))}
           </div>
         </Widget>
       </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,6 +3,37 @@
 @tailwind utilities;
 
 /* Custom global styles */
-body {
-  @apply bg-gray-50 text-gray-900;
+@layer base {
+  body {
+    @apply relative min-h-screen;
+    background-attachment: fixed;
+  }
+
+  main {
+    @apply w-full;
+  }
+
+  input:not([type="checkbox"]):not([type="radio"]),
+  select,
+  textarea {
+    @apply rounded-2xl border border-white/40 bg-white/90 px-4 py-3 text-brand-navy placeholder:text-brand-navy/50 shadow-sm transition focus:border-brand-bubble focus:outline-none focus:ring-2 focus:ring-brand-bubble/40;
+  }
+
+  label {
+    @apply text-brand-navy;
+  }
+
+  ::selection {
+    @apply bg-brand-bubble/70 text-white;
+  }
+}
+
+@layer components {
+  .glass-panel {
+    @apply rounded-[2.25rem] border border-white/20 bg-white/10 shadow-soft backdrop-blur-2xl;
+  }
+
+  .nav-link {
+    @apply rounded-full px-4 py-2 text-sm font-semibold text-white/90 transition hover:bg-white/15;
+  }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import TopNav from "@/components/TopNav";
 import "./globals.css";
 import AuthProvider from "@/components/AuthProvider";
+import { Nunito } from "next/font/google";
 
 export const metadata = {
   title: "Scruffy Butts",
@@ -8,14 +9,28 @@ export const metadata = {
 };
 export const runtime = "nodejs";
 
+const nunito = Nunito({
+  subsets: ["latin"],
+  variable: "--font-sans",
+});
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
-      <body>
-        <TopNav />
-        <main>
-          <AuthProvider>{children}</AuthProvider>
-        </main>
+    <html lang="en" className="scroll-smooth">
+      <body
+        className={`${nunito.variable} font-sans text-white/90 antialiased bg-gradient-to-br from-brand-blue via-primary to-brand-sky min-h-screen overflow-x-hidden`}
+      >
+        <div className="relative flex min-h-screen flex-col overflow-hidden">
+          <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+            <div className="absolute -left-32 -top-40 h-96 w-96 rounded-full bg-brand-bubble/30 blur-[120px]" />
+            <div className="absolute -right-24 top-24 h-[28rem] w-[28rem] rounded-full bg-brand-lavender/25 blur-[140px]" />
+            <div className="absolute bottom-[-18rem] left-1/2 h-[32rem] w-[32rem] -translate-x-1/2 rounded-full bg-brand-mint/20 blur-[160px]" />
+          </div>
+          <TopNav />
+          <main className="relative z-10 flex-1">
+            <AuthProvider>{children}</AuthProvider>
+          </main>
+        </div>
       </body>
     </html>
   );

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -17,7 +17,11 @@ export default function LoginPage() {
 
   return (
     <Suspense fallback={null}>
-      <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-primary-light via-primary to-primary-dark p-4">
+      <div className="relative flex min-h-[calc(100vh-6rem)] w-full items-center justify-center px-4 pb-16 pt-12">
+        <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+          <div className="absolute -left-24 top-10 h-80 w-80 rounded-full bg-white/15 blur-[140px]" />
+          <div className="absolute bottom-0 right-0 h-[28rem] w-[28rem] rounded-full bg-brand-bubble/20 blur-[200px]" />
+        </div>
         <LoginForm />
       </div>
     </Suspense>

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -2,5 +2,14 @@ import { ReactNode } from 'react'
 import clsx from 'clsx'
 
 export default function Card({ children, className = '' }: { children: ReactNode; className?: string }) {
-  return <div className={clsx('rounded-3xl bg-white p-6 shadow', className)}>{children}</div>
+  return (
+    <div
+      className={clsx(
+        'rounded-[2rem] border border-white/30 bg-white/85 p-6 text-brand-navy shadow-soft backdrop-blur-xl',
+        className
+      )}
+    >
+      {children}
+    </div>
+  )
 }

--- a/components/LoginBanner.tsx
+++ b/components/LoginBanner.tsx
@@ -25,12 +25,14 @@ export default function LoginBanner() {
   };
 
   return (
-    <form onSubmit={onSubmit} className="mb-6 flex flex-wrap items-center gap-2 rounded border p-3 text-sm">
+    <form
+      onSubmit={onSubmit}
+      className="glass-panel mb-6 flex flex-wrap items-center gap-3 bg-white/95 p-4 text-sm text-brand-navy"
+    >
       <input
         type="email"
         required
         placeholder="Email"
-        className="rounded border p-1"
         value={email}
         onChange={(e) => setEmail(e.target.value)}
       />
@@ -38,18 +40,17 @@ export default function LoginBanner() {
         type="password"
         required
         placeholder="Password"
-        className="rounded border p-1"
         value={password}
         onChange={(e) => setPassword(e.target.value)}
       />
       <button
         type="submit"
         disabled={loading}
-        className="rounded bg-primary px-3 py-1 text-white disabled:opacity-60"
+        className="rounded-full bg-brand-bubble px-4 py-2 font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:bg-brand-bubbleDark disabled:cursor-not-allowed disabled:opacity-60"
       >
         {loading ? 'Logging in...' : 'Login'}
       </button>
-      {err && <span className="ml-2 text-red-600">{err}</span>}
+      {err && <span className="ml-2 font-medium text-red-600">{err}</span>}
     </form>
   );
 }

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -31,52 +31,63 @@ export default function LoginForm() {
   return (
     <form
       onSubmit={onSubmit}
-      className="w-full max-w-md rounded-xl border border-primary-light/30 bg-white/90 p-8 shadow-lg backdrop-blur"
+      className="glass-panel w-full max-w-md space-y-5 bg-white/95 p-10 text-brand-navy"
     >
-      <h1 className="mb-2 text-2xl font-bold text-primary-dark">
-        Welcome back! <span className="ml-1">🐶</span>
-      </h1>
-      <p className="mb-6 text-sm text-gray-600">Sign in to continue.</p>
+      <div className="space-y-1">
+        <p className="text-xs font-semibold uppercase tracking-[0.35em] text-brand-navy/60">
+          Welcome back
+        </p>
+        <h1 className="text-3xl font-black tracking-tight text-brand-navy">
+          Scruffy squad <span className="ml-1">🐶</span>
+        </h1>
+        <p className="text-sm text-brand-navy/70">Sign in to keep the tails wagging.</p>
+      </div>
 
       {err && (
-        <div className="mb-3 rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700">
+        <div className="rounded-2xl border border-red-300/60 bg-red-100/60 px-3 py-2 text-sm text-red-700">
           {err}
         </div>
       )}
 
-      <label className="block text-sm font-medium text-gray-700">Email</label>
-      <input
-        className="mt-1 mb-3 w-full rounded-md border border-gray-300 px-3 py-2 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary-light"
-        type="email"
-        required
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        placeholder="you@example.com"
-      />
+      <div className="space-y-4">
+        <div className="space-y-1">
+          <label className="block text-sm font-semibold text-brand-navy">Email</label>
+          <input
+            className="w-full"
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="you@example.com"
+          />
+        </div>
 
-      <label className="block text-sm font-medium text-gray-700">Password</label>
-      <input
-        className="mt-1 mb-4 w-full rounded-md border border-gray-300 px-3 py-2 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary-light"
-        type="password"
-        required
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        placeholder="••••••••"
-      />
+        <div className="space-y-1">
+          <label className="block text-sm font-semibold text-brand-navy">Password</label>
+          <input
+            className="w-full"
+            type="password"
+            required
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="••••••••"
+          />
+        </div>
+      </div>
 
       <button
         type="submit"
         disabled={loading}
-        className="w-full rounded-md bg-primary px-4 py-2 font-medium text-white transition-colors hover:bg-primary-dark disabled:opacity-60"
+        className="w-full rounded-full bg-brand-bubble px-5 py-3 text-base font-semibold text-white shadow-lg transition-all duration-200 hover:-translate-y-0.5 hover:bg-brand-bubbleDark disabled:cursor-not-allowed disabled:opacity-60"
       >
         {loading ? 'Signing in…' : 'Sign in'}
       </button>
 
-      <div className="mt-6 flex justify-between text-sm">
-        <a className="text-primary-light underline transition-colors hover:text-primary-dark" href="/signup">
+      <div className="flex justify-between text-sm text-brand-navy/70">
+        <a className="font-semibold text-brand-bubble transition-colors hover:text-brand-bubbleDark" href="/signup">
           Create account
         </a>
-        <a className="text-primary-light underline transition-colors hover:text-primary-dark" href="/reset-password">
+        <a className="font-semibold text-brand-bubble transition-colors hover:text-brand-bubbleDark" href="/reset-password">
           Forgot password?
         </a>
       </div>

--- a/components/PageContainer.tsx
+++ b/components/PageContainer.tsx
@@ -3,8 +3,12 @@ import clsx from 'clsx'
 
 export default function PageContainer({ children, className = '' }: { children: ReactNode; className?: string }) {
   return (
-    <div className="min-h-screen bg-gray-100">
-      <main className={clsx('mx-auto max-w-7xl p-6 space-y-6', className)}>{children}</main>
+    <div className="relative z-10 flex w-full justify-center px-4 pb-24 pt-10 md:px-8">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute left-0 top-10 h-72 w-72 rounded-full bg-white/10 blur-3xl" />
+        <div className="absolute bottom-0 right-0 h-[28rem] w-[28rem] rounded-full bg-brand-bubble/10 blur-[160px]" />
+      </div>
+      <div className={clsx('w-full max-w-6xl space-y-6', className)}>{children}</div>
     </div>
   )
 }

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -1,21 +1,54 @@
 "use client";
+
 import Link from "next/link";
+import { usePathname } from "next/navigation";
+import clsx from "clsx";
+
+const navLinks = [
+  { href: "/dashboard", label: "Dashboard" },
+  { href: "/calendar", label: "Calendar" },
+  { href: "/clients", label: "Clients" },
+  { href: "/employees", label: "Employees" },
+  { href: "/reports", label: "Reports" },
+  { href: "/messages", label: "Messages" },
+  { href: "/settings", label: "Settings" },
+];
 
 export default function TopNav() {
+  const pathname = usePathname();
+
   return (
-    <header className="w-full border-b bg-white">
-      <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-3">
-        <Link href="/" className="flex items-center gap-2">
-          <span className="text-xl font-bold text-primary-dark">ScruffyButts</span>
+    <header className="sticky top-0 z-40 flex justify-center px-4 pt-6">
+      <div className="glass-panel flex w-full max-w-6xl items-center justify-between px-6 py-4">
+        <Link href="/" className="group flex items-center gap-4 text-white">
+          <span className="grid h-12 w-12 place-items-center rounded-full bg-white/90 text-2xl shadow-inner ring-4 ring-white/40 transition-transform duration-300 group-hover:-rotate-12">
+            🐾
+          </span>
+          <div className="flex flex-col leading-tight">
+            <span className="text-xs font-semibold uppercase tracking-[0.4em] text-white/70">Scruffy</span>
+            <span className="text-2xl font-black text-white transition-colors duration-300 group-hover:text-brand-cream">
+              Butts
+            </span>
+          </div>
         </Link>
-        <nav className="flex items-center gap-4 text-sm">
-          <Link href="/dashboard">Dashboard</Link>
-          <Link href="/calendar">Calendar</Link>
-          <Link href="/clients">Clients</Link>
-          <Link href="/employees">Employees</Link>
-          <Link href="/reports">Reports</Link>
-          <Link href="/messages">Messages</Link>
-          <Link href="/settings">Settings</Link>
+        <nav className="flex flex-wrap items-center justify-end gap-2 text-sm">
+          {navLinks.map((link) => {
+            const isActive = pathname?.startsWith(link.href);
+            return (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={clsx(
+                  "nav-link",
+                  isActive
+                    ? "bg-white/25 text-white shadow-sm"
+                    : "text-white/80 hover:text-white"
+                )}
+              >
+                {link.label}
+              </Link>
+            );
+          })}
         </nav>
       </div>
     </header>

--- a/components/Widget.tsx
+++ b/components/Widget.tsx
@@ -3,25 +3,47 @@ import clsx from 'clsx'
 
 interface WidgetProps {
   title: string
-  color?: 'pink' | 'purple' | 'green'
+  color?: 'blue' | 'pink' | 'purple' | 'green'
   children: ReactNode
   className?: string
+  hideHeader?: boolean
+  headerContent?: ReactNode
 }
 
-// A simple card with a thin colored header matching the supplied color. See the
-// dashboard mockups for examples of how these widgets should look.
-export default function Widget({ title, color = 'pink', children, className }: WidgetProps) {
-  const headerColor = {
-    pink: 'bg-secondary-pink',
-    purple: 'bg-secondary-purple',
-    green: 'bg-secondary-green',
-  }[color]
+const backgroundMap: Record<Required<WidgetProps>['color'], string> = {
+  blue: 'bg-gradient-to-br from-[#1D4DFF] via-[#2E8CFF] to-[#55C3FF]',
+  pink: 'bg-gradient-to-br from-brand-bubble to-brand-bubbleDark',
+  purple: 'bg-gradient-to-br from-brand-lavender via-[#5B7DFF] to-primary',
+  green: 'bg-gradient-to-br from-brand-mint via-[#3CE0B7] to-[#43F0C5]'
+}
+
+export default function Widget({
+  title,
+  color = 'blue',
+  children,
+  className,
+  hideHeader = false,
+  headerContent
+}: WidgetProps) {
+  const gradient = backgroundMap[color]
+
   return (
-    <div className={clsx('overflow-hidden rounded-3xl bg-white shadow', className)}>
-      <div className={clsx('px-5 py-3 text-sm font-semibold text-primary-dark', headerColor)}>
-        {title}
-      </div>
-      <div className="p-5">
+    <div
+      className={clsx(
+        'relative overflow-hidden rounded-[2rem] border border-white/25 text-white shadow-soft backdrop-blur-xl',
+        gradient,
+        className
+      )}
+    >
+      <div className="pointer-events-none absolute -right-16 -top-24 h-64 w-64 rounded-full bg-white/25 blur-[120px]" />
+      <div className="pointer-events-none absolute bottom-[-30%] left-[-20%] h-80 w-80 rounded-full bg-white/10 blur-[160px]" />
+      {!hideHeader && (
+        <div className="relative flex items-center justify-between px-6 pt-6">
+          <h2 className="text-lg font-semibold tracking-tight drop-shadow-md">{title}</h2>
+          {headerContent}
+        </div>
+      )}
+      <div className={clsx('relative px-6 pb-6', hideHeader ? 'pt-6' : 'pt-4')}>
         {children}
       </div>
     </div>

--- a/components/dashboard/EmployeeWorkload.tsx
+++ b/components/dashboard/EmployeeWorkload.tsx
@@ -32,16 +32,41 @@ export default function EmployeeWorkload() {
     fetchWorkloads()
   }, [])
 
-  if (loading) return <div>Loading...</div>
-  if (workloads.length === 0) return <div>No active jobs.</div>
+  if (loading) return <div className="text-white/80">Loading...</div>
+  if (workloads.length === 0)
+    return (
+      <div className="rounded-3xl border border-white/25 bg-white/10 p-6 text-white/85 backdrop-blur-lg">
+        No active jobs.
+      </div>
+    )
+
+  const max = workloads.length ? Math.max(...workloads.map((w) => w.count), 1) : 1
+
   return (
-    <ul className="space-y-1">
-      {workloads.map((wl) => (
-        <li key={wl.employee_name} className="flex justify-between">
-          <span>{wl.employee_name}</span>
-          <span className="font-semibold">{wl.count}</span>
-        </li>
-      ))}
+    <ul className="space-y-3 text-white/90">
+      {workloads.map((wl) => {
+        const width = Math.max((wl.count / max) * 100, 12)
+        return (
+          <li
+            key={wl.employee_name}
+            className="rounded-3xl border border-white/15 bg-white/10 p-4 shadow-inner backdrop-blur"
+          >
+            <div className="flex items-center justify-between text-sm font-semibold tracking-tight">
+              <span>{wl.employee_name}</span>
+              <span className="flex items-center gap-1 text-xs uppercase">
+                <span className="inline-flex h-2 w-2 rounded-full bg-white/80" />
+                {wl.count} {wl.count === 1 ? 'dog' : 'dogs'}
+              </span>
+            </div>
+            <div className="mt-3 h-2 rounded-full bg-white/15">
+              <div
+                className="h-full rounded-full bg-white/80"
+                style={{ width: `${width}%` }}
+              />
+            </div>
+          </li>
+        )
+      })}
     </ul>
   )
 }

--- a/components/dashboard/Messages.tsx
+++ b/components/dashboard/Messages.tsx
@@ -27,14 +27,35 @@ export default function Messages() {
     fetchMessages()
   }, [])
 
-  if (loading) return <div>Loading...</div>
-  if (!messages.length) return <div>No messages.</div>
+  const formatTime = (date: string) =>
+    new Date(date).toLocaleTimeString(undefined, {
+      hour: '2-digit',
+      minute: '2-digit'
+    })
+
+  if (loading) return <div className="text-white/80">Loading...</div>
+  if (!messages.length)
+    return (
+      <div className="rounded-3xl border border-white/25 bg-white/10 p-6 text-white/80 backdrop-blur-lg">
+        No messages yet.
+      </div>
+    )
   return (
-    <ul className="space-y-2">
+    <ul className="space-y-3">
       {messages.map((msg) => (
-        <li key={msg.id} className="border rounded-lg p-2 bg-gray-50">
-          <p className="text-sm font-medium">{msg.sender} → {msg.recipient}</p>
-          <p className="text-sm text-gray-700 truncate" title={msg.body}>{msg.body}</p>
+        <li
+          key={msg.id}
+          className="rounded-3xl border border-white/25 bg-white/95 p-4 text-brand-navy shadow-lg backdrop-blur"
+        >
+          <div className="flex items-center justify-between gap-3 text-xs font-semibold uppercase tracking-wide text-brand-navy/70">
+            <span>
+              {msg.sender} → {msg.recipient}
+            </span>
+            <span>{formatTime(msg.created_at)}</span>
+          </div>
+          <p className="mt-2 max-h-14 overflow-hidden text-sm text-brand-navy/80" title={msg.body}>
+            {msg.body}
+          </p>
         </li>
       ))}
     </ul>

--- a/components/dashboard/Revenue.tsx
+++ b/components/dashboard/Revenue.tsx
@@ -40,16 +40,21 @@ export default function Revenue() {
     fetchRevenue()
   }, [])
 
-  if (loading) return <div>Loading...</div>
+  const format = (value: number | null) => (value ?? 0).toFixed(2)
+
+  if (loading) return <div className="text-white/80">Loading...</div>
   return (
-    <div className="flex flex-col space-y-2">
-      <div>
-        <span className="text-3xl font-bold">${todayRevenue?.toFixed(2)}</span>
-        <p className="text-xs text-gray-500">Today&apos;s Revenue</p>
+    <div className="space-y-4 text-white">
+      <div className="rounded-3xl border border-white/20 bg-white/10 p-5 shadow-inner backdrop-blur">
+        <p className="text-xs uppercase tracking-[0.35em] text-white/70">Today</p>
+        <div className="mt-2 flex items-end gap-2">
+          <span className="text-3xl font-bold drop-shadow-sm">${format(todayRevenue)}</span>
+          <span className="text-xs text-white/70">so far</span>
+        </div>
       </div>
-      <div>
-        <span className="text-xl font-semibold">${weekRevenue?.toFixed(2)}</span>
-        <p className="text-xs text-gray-500">This Week</p>
+      <div className="rounded-3xl border border-white/20 bg-white/10 p-5 shadow-inner backdrop-blur">
+        <p className="text-xs uppercase tracking-[0.35em] text-white/70">This Week</p>
+        <div className="mt-2 text-xl font-semibold drop-shadow-sm">${format(weekRevenue)}</div>
       </div>
     </div>
   )

--- a/components/dashboard/TodaysAppointments.tsx
+++ b/components/dashboard/TodaysAppointments.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from 'react'
 import { supabase } from '@/lib/supabase/client'
+import clsx from 'clsx'
 
 interface Appointment {
   id: string
@@ -8,6 +9,14 @@ interface Appointment {
   pet_name: string
   client_name: string
   status: string
+}
+
+const statusStyles: Record<string, string> = {
+  Completed: 'bg-brand-mint/30 text-brand-navy',
+  Upcoming: 'bg-white/40 text-brand-navy',
+  Cancelled: 'bg-brand-bubble/40 text-white',
+  'In Progress': 'bg-brand-sunshine/60 text-brand-navy',
+  'Checked In': 'bg-brand-lavender/40 text-white'
 }
 
 export default function TodaysAppointments() {
@@ -47,37 +56,61 @@ export default function TodaysAppointments() {
   }, [])
 
   if (loading) {
-    return <div>Loading...</div>
+    return <div className="text-white/80">Loading...</div>
   }
 
   if (appointments.length === 0) {
-    return <div>No appointments today.</div>
+    return (
+      <div className="rounded-3xl border border-white/30 bg-white/10 p-6 text-white/80 backdrop-blur-md">
+        No appointments today.
+      </div>
+    )
   }
 
+  const today = new Date().toLocaleDateString(undefined, {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric'
+  })
+
   return (
-    <ul className="space-y-2">
-      {appointments.map((appt) => (
-        <li key={appt.id} className="flex justify-between items-center">
-          <div className="flex flex-col">
-            <span className="font-medium">{appt.time}</span>
-            <span>{appt.pet_name}</span>
-            <span className="text-sm text-gray-500">{appt.client_name}</span>
-          </div>
-          <span className={
-            appt.status === 'Completed'
-              ? 'text-green-600'
-              : appt.status === 'Cancelled'
-              ? 'text-orange-600'
-              : appt.status === 'In Progress'
-              ? 'text-green-500'
-              : appt.status === 'Checked In'
-              ? 'text-blue-600'
-              : 'text-gray-600'
-          }>
-            {appt.status}
-          </span>
-        </li>
-      ))}
-    </ul>
+    <div className="space-y-5">
+      <div className="flex items-center justify-between text-white">
+        <div>
+          <p className="text-xs uppercase tracking-[0.35em] text-white/70">Today</p>
+          <h3 className="text-2xl font-semibold tracking-tight drop-shadow-sm">{today}</h3>
+        </div>
+        <span className="flex h-12 w-12 items-center justify-center rounded-full bg-white/25 text-lg font-semibold text-white shadow-inner">
+          {appointments.length}
+        </span>
+      </div>
+      <ul className="space-y-3">
+        {appointments.map((appt) => (
+          <li
+            key={appt.id}
+            className="grid grid-cols-[auto,1fr,auto] items-center gap-4 rounded-3xl bg-white/95 px-5 py-4 text-brand-navy shadow-lg shadow-primary/10 backdrop-blur"
+          >
+            <div className="grid h-12 w-12 place-items-center rounded-full bg-brand-bubble/20 text-2xl">
+              🐶
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-brand-navy">{appt.pet_name}</p>
+              <p className="text-xs text-brand-navy/70">{appt.client_name}</p>
+            </div>
+            <div className="text-right">
+              <div className="text-sm font-semibold text-brand-navy">{appt.time}</div>
+              <span
+                className={clsx(
+                  'mt-2 inline-flex items-center justify-center rounded-full px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-wide',
+                  statusStyles[appt.status] ?? 'bg-white/40 text-brand-navy'
+                )}
+              >
+                {appt.status}
+              </span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
   )
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,15 +9,38 @@ const config: Config = {
     extend: {
       colors: {
         primary: {
-          light: '#76b2fe',
-          DEFAULT: '#4b79a1',
-          dark: '#283e51'
+          light: '#63C4FF',
+          DEFAULT: '#1E7BFF',
+          dark: '#0F4ED7'
         },
         secondary: {
-          pink: '#f8b4c0',
-          purple: '#dcbcef',
-          green: '#b5e5cf'
+          DEFAULT: '#FF66C4',
+          dark: '#FF3D9E',
+          pink: '#FF66C4',
+          purple: '#7C5CFF',
+          green: '#2CD4A6'
+        },
+        brand: {
+          sky: '#5CC2FF',
+          blue: '#1A6BFF',
+          navy: '#08245A',
+          bubble: '#FF66C4',
+          bubbleDark: '#FF3D9E',
+          mint: '#31D8AF',
+          lavender: '#7C5CFF',
+          sunshine: '#FFD166',
+          cream: '#F9FBFF'
         }
+      },
+      fontFamily: {
+        sans: ['var(--font-sans)', 'system-ui', 'sans-serif']
+      },
+      boxShadow: {
+        soft: '0 24px 55px -25px rgba(20, 90, 200, 0.55)'
+      },
+      borderRadius: {
+        '3xl': '1.75rem',
+        '4xl': '2.5rem'
       }
     }
   },


### PR DESCRIPTION
## Summary
- refresh the Tailwind palette, typography, and global styles to match the Scruffy Butts visual theme
- rebuild navigation, containers, and widget components with glassmorphism gradients and brand colors
- restyle dashboard widgets and auth flows with themed cards, pills, and quick-action buttons that mirror the design reference

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68c88e212e8c8324b48a15fb39cf77bf