### PR TITLE
Add Scruffy icon library and replace emoji placeholders

### DIFF
--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { supabase } from '@/lib/supabase/client';
+import { ScruffyIcon } from './icons';
 
 export default function LoginForm() {
   const params = useSearchParams();
@@ -37,8 +38,9 @@ export default function LoginForm() {
         <p className="text-xs font-semibold uppercase tracking-[0.35em] text-brand-navy/60">
           Welcome back
         </p>
-        <h1 className="text-3xl font-black tracking-tight text-brand-navy">
-          Scruffy squad <span className="ml-1">🐶</span>
+        <h1 className="flex items-center gap-2 text-3xl font-black tracking-tight text-brand-navy">
+          <span>Scruffy squad</span>
+          <ScruffyIcon name="dog" size={28} className="text-brand-bubble" aria-hidden />
         </h1>
         <p className="text-sm text-brand-navy/70">Sign in to keep the tails wagging.</p>
       </div>

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import clsx from "clsx";
+import { ScruffyIcon } from "./icons";
 
 const navLinks = [
   { href: "/dashboard", label: "Dashboard" },
@@ -21,8 +22,8 @@ export default function TopNav() {
     <header className="sticky top-0 z-40 flex justify-center px-4 pt-6">
       <div className="glass-panel flex w-full max-w-6xl items-center justify-between px-6 py-4">
         <Link href="/" className="group flex items-center gap-4 text-white">
-          <span className="grid h-12 w-12 place-items-center rounded-full bg-white/90 text-2xl shadow-inner ring-4 ring-white/40 transition-transform duration-300 group-hover:-rotate-12">
-            🐾
+          <span className="grid h-12 w-12 place-items-center rounded-full bg-white/90 text-brand-bubble shadow-inner ring-4 ring-white/40 transition-transform duration-300 group-hover:-rotate-12 group-hover:text-brand-bubbleDark">
+            <ScruffyIcon name="logomark" size={28} className="transition-colors duration-300" />
           </span>
           <div className="flex flex-col leading-tight">
             <span className="text-xs font-semibold uppercase tracking-[0.4em] text-white/70">Scruffy</span>

--- a/components/dashboard/TodaysAppointments.tsx
+++ b/components/dashboard/TodaysAppointments.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react'
 import { supabase } from '@/lib/supabase/client'
 import clsx from 'clsx'
+import { ScruffyIcon } from '../icons'
 
 interface Appointment {
   id: string
@@ -90,8 +91,8 @@ export default function TodaysAppointments() {
             key={appt.id}
             className="grid grid-cols-[auto,1fr,auto] items-center gap-4 rounded-3xl bg-white/95 px-5 py-4 text-brand-navy shadow-lg shadow-primary/10 backdrop-blur"
           >
-            <div className="grid h-12 w-12 place-items-center rounded-full bg-brand-bubble/20 text-2xl">
-              🐶
+            <div className="grid h-12 w-12 place-items-center rounded-full bg-brand-bubble/20 text-brand-bubble">
+              <ScruffyIcon name="paw" size={26} aria-hidden />
             </div>
             <div>
               <p className="text-sm font-semibold text-brand-navy">{appt.pet_name}</p>

--- a/components/icons/ScruffyIcon.tsx
+++ b/components/icons/ScruffyIcon.tsx
@@ -1,0 +1,93 @@
+import { forwardRef } from 'react'
+import type { SVGProps, ReactNode } from 'react'
+import clsx from 'clsx'
+
+const createFullPaw = () => (
+  <>
+    <path d="M8.5 15.5C8.5 13.43 10.24 11.75 12 11.75S15.5 13.43 15.5 15.5 13.3 19.25 12 19.95 8.5 17.57 8.5 15.5Z" />
+    <circle cx="7.2" cy="10.3" r="1.75" />
+    <circle cx="10.25" cy="7.65" r="1.6" />
+    <circle cx="13.75" cy="7.65" r="1.6" />
+    <circle cx="16.8" cy="10.3" r="1.75" />
+  </>
+)
+
+const createCompactPaw = () => (
+  <>
+    <path d="M9 14.2C9 12.46 10.43 11 12 11s3 1.46 3 3.2c0 1.64-1.86 3.04-3 3.62-1.14-.58-3-1.98-3-3.62Z" />
+    <circle cx="8.4" cy="11.3" r="1.45" />
+    <circle cx="10.6" cy="9.45" r="1.35" />
+    <circle cx="13.4" cy="9.45" r="1.35" />
+    <circle cx="15.6" cy="11.3" r="1.45" />
+  </>
+)
+
+const createDogFace = () => (
+  <>
+    <path d="M6.9 8.65 4.95 6.72a2.1 2.1 0 0 0-3.55 1.48v1.74c0 1 .5 1.95 1.32 2.52l1.72 1.15" />
+    <path d="M17.1 8.65 19.05 6.72a2.1 2.1 0 0 1 3.55 1.48v1.74c0 1-.5 1.95-1.32 2.52l-1.72 1.15" />
+    <path d="M12 6.25c-2.96 0-5.25 2.29-5.25 5.25v2.9c0 1.9 1.54 3.45 3.45 3.45h3.6c1.9 0 3.45-1.55 3.45-3.45V11.5c0-2.96-2.29-5.25-5.25-5.25Z" />
+    <path d="M9.5 11.75v-.6c0-1.1.9-2 2-2h1c1.1 0 2 .9 2 2v.6" />
+    <circle cx="10" cy="12.2" r=".75" fill="currentColor" stroke="none" />
+    <circle cx="14" cy="12.2" r=".75" fill="currentColor" stroke="none" />
+    <path
+      d="M11.2 13.8h1.6a.8.8 0 0 1 .67 1.23l-.8 1.2a.8.8 0 0 1-1.34 0l-.8-1.2a.8.8 0 0 1 .67-1.23Z"
+      fill="currentColor"
+      stroke="none"
+    />
+    <path d="M10.75 16.3c.4.42.94.65 1.25.65s.85-.23 1.25-.65" />
+  </>
+)
+
+const iconShapes = {
+  paw: createFullPaw,
+  dog: createDogFace,
+  logomark: () => (
+    <>
+      <circle cx="12" cy="12" r="9" fill="currentColor" fillOpacity="0.12" stroke="none" />
+      <circle cx="12" cy="12" r="9" />
+      {createCompactPaw()}
+    </>
+  )
+} as const satisfies Record<string, () => ReactNode>
+
+export type ScruffyIconName = keyof typeof iconShapes
+
+export interface ScruffyIconProps extends Omit<SVGProps<SVGSVGElement>, 'name'> {
+  name: ScruffyIconName
+  size?: number | string
+  title?: string
+}
+
+export const ScruffyIcon = forwardRef<SVGSVGElement, ScruffyIconProps>(
+  ({ name, size = 24, className, strokeWidth = 1.6, title, role = 'img', ...rest }, ref) => {
+    const render = iconShapes[name]
+    const isLabelled = Boolean(title) || 'aria-label' in rest || 'aria-labelledby' in rest
+
+    return (
+      <svg
+        ref={ref}
+        role={role}
+        width={size}
+        height={size}
+        viewBox="0 0 24 24"
+        className={clsx('scruffy-icon inline-block align-middle text-current', className)}
+        strokeWidth={strokeWidth}
+        aria-hidden={isLabelled ? undefined : true}
+        focusable="false"
+        fill="none"
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        {...rest}
+      >
+        {title ? <title>{title}</title> : null}
+        {render()}
+      </svg>
+    )
+  }
+)
+
+ScruffyIcon.displayName = 'ScruffyIcon'
+
+export const SCRUFFY_ICON_NAMES = Object.keys(iconShapes) as ScruffyIconName[]

--- a/components/icons/index.ts
+++ b/components/icons/index.ts
@@ -1,0 +1,3 @@
+export { ScruffyIcon } from './ScruffyIcon'
+export type { ScruffyIconName, ScruffyIconProps } from './ScruffyIcon'
+export { SCRUFFY_ICON_NAMES } from './ScruffyIcon'

--- a/docs/icon-guidelines.md
+++ b/docs/icon-guidelines.md
@@ -1,0 +1,49 @@
+# Icon Library Guidelines
+
+The Scruffy icon library lives in `components/icons/ScruffyIcon.tsx`.  Icons are
+purpose-built for the Scruffy Butts brand so they feel cohesive with the rest of
+our glassmorphic UI.
+
+## Available icons
+
+| Name      | Description & primary use                                              |
+|-----------|------------------------------------------------------------------------|
+| `logomark`| Circular paw badge used for the main navigation brand mark.            |
+| `paw`     | Versatile paw outline for pet-related badges, buttons, and stats.      |
+| `dog`     | Friendly dog face accent for authentication and onboarding surfaces.   |
+
+Import the `ScruffyIcon` component and pass the icon `name` to render any asset:
+
+```tsx
+import { ScruffyIcon } from '@/components/icons';
+
+export function Example() {
+  return (
+    <button className="inline-flex items-center gap-2 rounded-full bg-brand-bubble px-4 py-2 text-white">
+      <ScruffyIcon name="paw" size={20} aria-hidden />
+      Book grooming
+    </button>
+  );
+}
+```
+
+## Design & implementation rules
+
+- **Viewbox:** All icons are drawn on a `24 × 24` artboard and exported as
+  React SVG fragments from `ScruffyIcon.tsx`.
+- **Line weight:** Use a stroke width of `1.6` with rounded caps and joins. This
+  keeps outlines balanced with the typography weights used throughout the app.
+- **Color:** Icons inherit their color from `currentColor`. Apply Tailwind
+  classes such as `text-brand-bubble` on the parent element instead of hardcoded
+  fills. When a fill is required, keep it monochrome and use the same color as
+  the stroke.
+- **Scaling:** Set the `size` prop (or Tailwind width/height utilities) rather
+  than editing the viewbox. This preserves stroke consistency.
+- **Accessibility:** Decorative icons should keep `aria-hidden` (the default).
+  Provide a `title` or `aria-label` when the icon conveys essential meaning.
+- **New icons:** Add the vector to the `iconShapes` map in
+  `ScruffyIcon.tsx`. Match the existing coordinate grid, maintain optical
+  balance, and test the asset at `20px`, `24px`, and `32px` to ensure clarity.
+
+Following these guidelines keeps every pictogram consistent in weight, rhythm,
+and tone so the brand feels intentional across surfaces.


### PR DESCRIPTION
## Summary
- introduce a reusable `ScruffyIcon` component with custom paw, dog, and logomark glyphs
- replace emoji placeholders in the top navigation, login form, and today's appointments list with SVG icons
- document icon usage guidelines to keep vector assets consistent

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68c89800e5d4832487422aef5976572d