### PR TITLE
Improve accessibility semantics and focus styling

### DIFF
--- a/app/employees/[id]/settings/page.tsx
+++ b/app/employees/[id]/settings/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, ChangeEvent, FormEvent } from "react";
+import { useState, useEffect, ChangeEvent, FormEvent, useId } from "react";
 import { useRouter } from "next/navigation";
 import PageContainer from "@/components/PageContainer";
 import { supabase } from "@/supabase/client";
@@ -16,6 +16,10 @@ export default function EmployeeSettings({ params }: { params: Params }) {
     emergency_contact: "",
   });
   const [loading, setLoading] = useState(true);
+  const headingId = useId();
+  const payRateId = useId();
+  const addressId = useId();
+  const emergencyId = useId();
 
   useEffect(() => {
     const fetchData = async () => {
@@ -69,42 +73,57 @@ export default function EmployeeSettings({ params }: { params: Params }) {
 
   return (
     <PageContainer>
-      <h1 className="text-2xl font-bold mb-4">Employee Settings</h1>
-      <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
+      <h1 id={headingId} className="mb-4 text-2xl font-bold">
+        Employee Settings
+      </h1>
+      <form
+        onSubmit={handleSubmit}
+        aria-labelledby={headingId}
+        className="max-w-md space-y-4"
+      >
         <div>
-          <label className="block font-medium mb-1">Pay Rate</label>
+          <label htmlFor={payRateId} className="mb-1 block font-medium">
+            Pay rate
+          </label>
           <input
+            id={payRateId}
             type="number"
             step="0.01"
             name="pay_rate"
             value={form.pay_rate}
             onChange={handleChange}
-            className="border px-3 py-2 rounded w-full"
+            className="w-full rounded border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white"
           />
         </div>
         <div>
-          <label className="block font-medium mb-1">Address</label>
+          <label htmlFor={addressId} className="mb-1 block font-medium">
+            Address
+          </label>
           <input
+            id={addressId}
             type="text"
             name="address"
             value={form.address}
             onChange={handleChange}
-            className="border px-3 py-2 rounded w-full"
+            className="w-full rounded border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white"
           />
         </div>
         <div>
-          <label className="block font-medium mb-1">Emergency Contact</label>
+          <label htmlFor={emergencyId} className="mb-1 block font-medium">
+            Emergency contact
+          </label>
           <input
+            id={emergencyId}
             type="text"
             name="emergency_contact"
             value={form.emergency_contact}
             onChange={handleChange}
-            className="border px-3 py-2 rounded w-full"
+            className="w-full rounded border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white"
           />
         </div>
         <button
           type="submit"
-          className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded"
+          className="focus-ring rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
         >
           Save
         </button>

--- a/app/forgot-password/page.tsx
+++ b/app/forgot-password/page.tsx
@@ -1,13 +1,23 @@
 'use client';
 export const runtime = "nodejs";
 
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { supabase } from '@/lib/supabase/client';
 
 export default function ForgotPasswordPage() {
   const [email, setEmail] = useState('');
   const [msg, setMsg] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
+
+  const headingId = useId();
+  const emailId = useId();
+  const errorId = useId();
+  const messageId = useId();
+  const describedByIds = [
+    err ? errorId : null,
+    msg ? messageId : null,
+  ].filter((value): value is string => Boolean(value));
+  const describedByAttr = describedByIds.length ? describedByIds.join(' ') : undefined;
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -23,13 +33,43 @@ export default function ForgotPasswordPage() {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-primary-light via-primary to-primary-dark p-4">
-      <form onSubmit={onSubmit} className="w-full max-w-md rounded-xl border border-primary-light/30 bg-white/90 p-8 shadow-lg backdrop-blur space-y-3">
-        <h1 className="mb-4 text-2xl font-bold text-primary-dark">Forgot password</h1>
-        <input className="w-full rounded-md border border-gray-300 px-3 py-2 focus:border-primary focus:ring-2 focus:ring-primary-light" type="email" placeholder="Email"
-               value={email} onChange={e=>setEmail(e.target.value)} required />
-        <button className="w-full rounded-md bg-primary px-4 py-2 font-medium text-white transition-colors hover:bg-primary-dark">Send reset link</button>
-        {msg && <p className="mt-3 text-green-700">{msg}</p>}
-        {err && <p className="mt-3 text-red-700">{err}</p>}
+      <form
+        onSubmit={onSubmit}
+        aria-labelledby={headingId}
+        aria-describedby={describedByAttr}
+        className="w-full max-w-md space-y-3 rounded-xl border border-primary-light/30 bg-white/90 p-8 shadow-lg backdrop-blur"
+      >
+        <h1 id={headingId} className="mb-4 text-2xl font-bold text-primary-dark">
+          Forgot password
+        </h1>
+        <div className="space-y-1">
+          <label htmlFor={emailId} className="block text-sm font-medium text-primary-dark">
+            Email
+          </label>
+          <input
+            id={emailId}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            autoComplete="email"
+            required
+            placeholder="you@example.com"
+          />
+        </div>
+        <button className="focus-ring w-full rounded-md bg-primary px-4 py-2 font-medium text-white transition-colors hover:bg-primary-dark">
+          Send reset link
+        </button>
+        {msg && (
+          <p id={messageId} role="status" aria-live="polite" className="mt-3 text-green-700">
+            {msg}
+          </p>
+        )}
+        {err && (
+          <p id={errorId} role="alert" className="mt-3 text-red-700">
+            {err}
+          </p>
+        )}
       </form>
     </div>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -16,7 +16,7 @@
   input:not([type="checkbox"]):not([type="radio"]),
   select,
   textarea {
-    @apply rounded-2xl border border-white/40 bg-white/90 px-4 py-3 text-brand-navy placeholder:text-brand-navy/50 shadow-sm transition focus:border-brand-bubble focus:outline-none focus:ring-2 focus:ring-brand-bubble/40;
+    @apply rounded-2xl border border-white/40 bg-white/90 px-4 py-3 text-brand-navy placeholder:text-brand-navy/50 shadow-sm transition focus:border-brand-navy focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white;
   }
 
   label {
@@ -34,6 +34,14 @@
   }
 
   .nav-link {
-    @apply rounded-full px-4 py-2 text-sm font-semibold text-white/90 transition hover:bg-white/15;
+    @apply rounded-full px-4 py-2 text-sm font-semibold text-white/90 transition hover:bg-white/15 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-sunshine;
+  }
+
+  .focus-ring {
+    @apply focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-navy;
+  }
+
+  .focus-ring-muted {
+    @apply focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-sunshine;
   }
 }

--- a/app/reset-password/ResetPasswordClient.tsx
+++ b/app/reset-password/ResetPasswordClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { supabase } from '@/lib/supabase/client';
 
@@ -14,6 +14,19 @@ export default function ResetPasswordClient() {
   const [confirm, setConfirm] = useState('');
   const [msg, setMsg] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
+
+  const requestHeadingId = useId();
+  const requestEmailId = useId();
+  const resetHeadingId = useId();
+  const newPasswordId = useId();
+  const confirmPasswordId = useId();
+  const feedbackErrorId = useId();
+  const feedbackMessageId = useId();
+  const describedByIds = [
+    err ? feedbackErrorId : null,
+    msg ? feedbackMessageId : null,
+  ].filter((value): value is string => Boolean(value));
+  const describedByAttr = describedByIds.length ? describedByIds.join(' ') : undefined;
 
   const origin =
     typeof window !== 'undefined' ? window.location.origin : process.env.NEXT_PUBLIC_SITE_URL;
@@ -55,27 +68,107 @@ export default function ResetPasswordClient() {
   return (
     <>
       {stage === 'request' ? (
-        <form onSubmit={sendEmail} className="w-full max-w-sm rounded border bg-white p-6">
-          <h1 className="text-xl font-semibold mb-4">Reset your password</h1>
-          {err && <div className="mb-3 rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700">{err}</div>}
-          {msg && <div className="mb-3 rounded border border-green-300 bg-green-50 px-3 py-2 text-sm text-green-700">{msg}</div>}
-          <label className="block text-sm font-medium">Email</label>
-          <input className="mt-1 mb-4 w-full rounded border px-3 py-2" type="email" required
-                 value={email} onChange={(e) => setEmail(e.target.value)} placeholder="you@example.com" />
-          <button className="w-full rounded bg-black px-4 py-2 text-white">Send reset link</button>
+        <form
+          onSubmit={sendEmail}
+          aria-labelledby={requestHeadingId}
+          aria-describedby={describedByAttr}
+          className="w-full max-w-sm rounded border bg-white p-6"
+        >
+          <h1 id={requestHeadingId} className="mb-4 text-xl font-semibold">
+            Reset your password
+          </h1>
+          {err && (
+            <div
+              id={feedbackErrorId}
+              role="alert"
+              className="mb-3 rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700"
+            >
+              {err}
+            </div>
+          )}
+          {msg && (
+            <div
+              id={feedbackMessageId}
+              role="status"
+              aria-live="polite"
+              className="mb-3 rounded border border-green-300 bg-green-50 px-3 py-2 text-sm text-green-700"
+            >
+              {msg}
+            </div>
+          )}
+          <label htmlFor={requestEmailId} className="block text-sm font-medium">
+            Email
+          </label>
+          <input
+            id={requestEmailId}
+            className="mt-1 mb-4 w-full rounded border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white"
+            type="email"
+            required
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="you@example.com"
+          />
+          <button className="focus-ring w-full rounded bg-black px-4 py-2 text-white">
+            Send reset link
+          </button>
         </form>
       ) : (
-        <form onSubmit={doReset} className="w-full max-w-sm rounded border bg-white p-6">
-          <h1 className="text-xl font-semibold mb-4">Set a new password</h1>
-          {err && <div className="mb-3 rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700">{err}</div>}
-          {msg && <div className="mb-3 rounded border border-green-300 bg-green-50 px-3 py-2 text-sm text-green-700">{msg}</div>}
-          <label className="block text-sm font-medium">New password</label>
-          <input className="mt-1 mb-3 w-full rounded border px-3 py-2" type="password" required
-                 value={password} onChange={(e) => setPassword(e.target.value)} />
-          <label className="block text-sm font-medium">Confirm password</label>
-          <input className="mt-1 mb-4 w-full rounded border px-3 py-2" type="password" required
-                 value={confirm} onChange={(e) => setConfirm(e.target.value)} />
-          <button className="w-full rounded bg-black px-4 py-2 text-white">Update password</button>
+        <form
+          onSubmit={doReset}
+          aria-labelledby={resetHeadingId}
+          aria-describedby={describedByAttr}
+          className="w-full max-w-sm rounded border bg-white p-6"
+        >
+          <h1 id={resetHeadingId} className="mb-4 text-xl font-semibold">
+            Set a new password
+          </h1>
+          {err && (
+            <div
+              id={feedbackErrorId}
+              role="alert"
+              className="mb-3 rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700"
+            >
+              {err}
+            </div>
+          )}
+          {msg && (
+            <div
+              id={feedbackMessageId}
+              role="status"
+              aria-live="polite"
+              className="mb-3 rounded border border-green-300 bg-green-50 px-3 py-2 text-sm text-green-700"
+            >
+              {msg}
+            </div>
+          )}
+          <label htmlFor={newPasswordId} className="block text-sm font-medium">
+            New password
+          </label>
+          <input
+            id={newPasswordId}
+            className="mt-1 mb-3 w-full rounded border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white"
+            type="password"
+            required
+            autoComplete="new-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <label htmlFor={confirmPasswordId} className="block text-sm font-medium">
+            Confirm password
+          </label>
+          <input
+            id={confirmPasswordId}
+            className="mt-1 mb-4 w-full rounded border px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white"
+            type="password"
+            required
+            autoComplete="new-password"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+          />
+          <button className="focus-ring w-full rounded bg-black px-4 py-2 text-white">
+            Update password
+          </button>
         </form>
       )}
     </>

--- a/app/reset-password/page.tsx
+++ b/app/reset-password/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 export const runtime = "nodejs";
 
-import { useEffect, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabase/client';
 
@@ -13,6 +13,19 @@ export default function ResetPasswordPage() {
   const [confirm, setConfirm] = useState('');
   const [msg, setMsg] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
+
+  const requestHeadingId = useId();
+  const requestEmailId = useId();
+  const resetHeadingId = useId();
+  const newPasswordId = useId();
+  const confirmPasswordId = useId();
+  const feedbackErrorId = useId();
+  const feedbackMessageId = useId();
+  const describedByIds = [
+    err ? feedbackErrorId : null,
+    msg ? feedbackMessageId : null,
+  ].filter((value): value is string => Boolean(value));
+  const describedByAttr = describedByIds.length ? describedByIds.join(' ') : undefined;
 
   const redirectTo = typeof window !== 'undefined'
     ? `${window.location.origin}/reset-password`
@@ -53,27 +66,106 @@ export default function ResetPasswordPage() {
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-primary-light via-primary to-primary-dark p-4">
       {stage === 'request' ? (
-        <form onSubmit={sendEmail} className="w-full max-w-sm rounded-xl border border-primary-light/30 bg-white/90 p-8 shadow-lg backdrop-blur">
-          <h1 className="mb-4 text-xl font-semibold text-primary-dark">Reset your password</h1>
-          {err && <div className="mb-3 rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700">{err}</div>}
-          {msg && <div className="mb-3 rounded border border-green-300 bg-green-50 px-3 py-2 text-sm text-green-700">{msg}</div>}
-          <label className="block text-sm font-medium">Email</label>
-          <input className="mt-1 mb-4 w-full rounded-md border border-gray-300 px-3 py-2 focus:border-primary focus:ring-2 focus:ring-primary-light" type="email" required
-                 value={email} onChange={(e) => setEmail(e.target.value)} />
-          <button className="w-full rounded-md bg-primary px-4 py-2 font-medium text-white transition-colors hover:bg-primary-dark">Send reset link</button>
+        <form
+          onSubmit={sendEmail}
+          aria-labelledby={requestHeadingId}
+          aria-describedby={describedByAttr}
+          className="w-full max-w-sm rounded-xl border border-primary-light/30 bg-white/90 p-8 shadow-lg backdrop-blur"
+        >
+          <h1 id={requestHeadingId} className="mb-4 text-xl font-semibold text-primary-dark">
+            Reset your password
+          </h1>
+          {err && (
+            <div
+              id={feedbackErrorId}
+              role="alert"
+              className="mb-3 rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700"
+            >
+              {err}
+            </div>
+          )}
+          {msg && (
+            <div
+              id={feedbackMessageId}
+              role="status"
+              aria-live="polite"
+              className="mb-3 rounded border border-green-300 bg-green-50 px-3 py-2 text-sm text-green-700"
+            >
+              {msg}
+            </div>
+          )}
+          <label htmlFor={requestEmailId} className="block text-sm font-medium">
+            Email
+          </label>
+          <input
+            id={requestEmailId}
+            className="mt-1 mb-4 w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white"
+            type="email"
+            required
+            autoComplete="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+          />
+          <button className="focus-ring w-full rounded-md bg-primary px-4 py-2 font-medium text-white transition-colors hover:bg-primary-dark">
+            Send reset link
+          </button>
         </form>
       ) : (
-        <form onSubmit={doReset} className="w-full max-w-sm rounded-xl border border-primary-light/30 bg-white/90 p-8 shadow-lg backdrop-blur">
-          <h1 className="mb-4 text-xl font-semibold text-primary-dark">Set a new password</h1>
-          {err && <div className="mb-3 rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700">{err}</div>}
-          {msg && <div className="mb-3 rounded border border-green-300 bg-green-50 px-3 py-2 text-sm text-green-700">{msg}</div>}
-          <label className="block text-sm font-medium">New password</label>
-          <input className="mt-1 mb-3 w-full rounded-md border border-gray-300 px-3 py-2 focus:border-primary focus:ring-2 focus:ring-primary-light" type="password" required
-                 value={password} onChange={(e) => setPassword(e.target.value)} />
-          <label className="block text-sm font-medium">Confirm password</label>
-          <input className="mt-1 mb-4 w-full rounded-md border border-gray-300 px-3 py-2 focus:border-primary focus:ring-2 focus:ring-primary-light" type="password" required
-                 value={confirm} onChange={(e) => setConfirm(e.target.value)} />
-          <button className="w-full rounded-md bg-primary px-4 py-2 font-medium text-white transition-colors hover:bg-primary-dark">Update password</button>
+        <form
+          onSubmit={doReset}
+          aria-labelledby={resetHeadingId}
+          aria-describedby={describedByAttr}
+          className="w-full max-w-sm rounded-xl border border-primary-light/30 bg-white/90 p-8 shadow-lg backdrop-blur"
+        >
+          <h1 id={resetHeadingId} className="mb-4 text-xl font-semibold text-primary-dark">
+            Set a new password
+          </h1>
+          {err && (
+            <div
+              id={feedbackErrorId}
+              role="alert"
+              className="mb-3 rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700"
+            >
+              {err}
+            </div>
+          )}
+          {msg && (
+            <div
+              id={feedbackMessageId}
+              role="status"
+              aria-live="polite"
+              className="mb-3 rounded border border-green-300 bg-green-50 px-3 py-2 text-sm text-green-700"
+            >
+              {msg}
+            </div>
+          )}
+          <label htmlFor={newPasswordId} className="block text-sm font-medium">
+            New password
+          </label>
+          <input
+            id={newPasswordId}
+            className="mt-1 mb-3 w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white"
+            type="password"
+            required
+            autoComplete="new-password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+          <label htmlFor={confirmPasswordId} className="block text-sm font-medium">
+            Confirm password
+          </label>
+          <input
+            id={confirmPasswordId}
+            className="mt-1 mb-4 w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white"
+            type="password"
+            required
+            autoComplete="new-password"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+          />
+          <button className="focus-ring w-full rounded-md bg-primary px-4 py-2 font-medium text-white transition-colors hover:bg-primary-dark">
+            Update password
+          </button>
         </form>
       )}
     </div>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 export const runtime = "nodejs";
 
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { supabase } from '@/lib/supabase/client';
 
@@ -12,6 +12,18 @@ export default function SignUpPage() {
   const [msg, setMsg] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const router = useRouter();
+
+  const headingId = useId();
+  const fullNameId = useId();
+  const emailId = useId();
+  const passwordId = useId();
+  const errorId = useId();
+  const messageId = useId();
+  const describedByIds = [
+    err ? errorId : null,
+    msg ? messageId : null,
+  ].filter((value): value is string => Boolean(value));
+  const describedByAttr = describedByIds.length ? describedByIds.join(' ') : undefined;
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -32,20 +44,76 @@ export default function SignUpPage() {
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-primary-light via-primary to-primary-dark p-4">
-      <form onSubmit={onSubmit} className="w-full max-w-md rounded-xl border border-primary-light/30 bg-white/90 p-8 shadow-lg backdrop-blur space-y-3">
-        <h1 className="mb-4 text-2xl font-bold text-primary-dark">Create account</h1>
-        <input className="w-full rounded-md border border-gray-300 px-3 py-2 focus:border-primary focus:ring-2 focus:ring-primary-light" placeholder="Full name (optional)"
-               value={fullName} onChange={e=>setFullName(e.target.value)} />
-        <input className="w-full rounded-md border border-gray-300 px-3 py-2 focus:border-primary focus:ring-2 focus:ring-primary-light" placeholder="Email" type="email"
-               value={email} onChange={e=>setEmail(e.target.value)} required />
-        <input className="w-full rounded-md border border-gray-300 px-3 py-2 focus:border-primary focus:ring-2 focus:ring-primary-light" placeholder="Password" type="password"
-               value={password} onChange={e=>setPassword(e.target.value)} required />
-        <button className="w-full rounded-md bg-primary px-4 py-2 font-medium text-white transition-colors hover:bg-primary-dark">Sign up</button>
-        <div className="mt-3 text-sm text-center">
-          <a className="text-primary-light underline transition-colors hover:text-primary-dark" href="/login">Already have an account? Log in</a>
+      <form
+        onSubmit={onSubmit}
+        aria-labelledby={headingId}
+        aria-describedby={describedByAttr}
+        className="w-full max-w-md space-y-3 rounded-xl border border-primary-light/30 bg-white/90 p-8 shadow-lg backdrop-blur"
+      >
+        <h1 id={headingId} className="mb-4 text-2xl font-bold text-primary-dark">
+          Create account
+        </h1>
+        <div className="space-y-1">
+          <label htmlFor={fullNameId} className="block text-sm font-medium text-primary-dark">
+            Full name (optional)
+          </label>
+          <input
+            id={fullNameId}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white"
+            value={fullName}
+            onChange={(e) => setFullName(e.target.value)}
+            autoComplete="name"
+            placeholder="Full name"
+          />
         </div>
-        {msg && <p className="mt-3 text-green-700">{msg}</p>}
-        {err && <p className="mt-3 text-red-700">{err}</p>}
+        <div className="space-y-1">
+          <label htmlFor={emailId} className="block text-sm font-medium text-primary-dark">
+            Email
+          </label>
+          <input
+            id={emailId}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            autoComplete="email"
+            required
+            placeholder="you@example.com"
+          />
+        </div>
+        <div className="space-y-1">
+          <label htmlFor={passwordId} className="block text-sm font-medium text-primary-dark">
+            Password
+          </label>
+          <input
+            id={passwordId}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="new-password"
+            required
+            placeholder="Password"
+          />
+        </div>
+        <button className="focus-ring w-full rounded-md bg-primary px-4 py-2 font-medium text-white transition-colors hover:bg-primary-dark">
+          Sign up
+        </button>
+        <div className="mt-3 text-center text-sm">
+          <a className="focus-ring text-primary-light underline transition-colors hover:text-primary-dark" href="/login">
+            Already have an account? Log in
+          </a>
+        </div>
+        {msg && (
+          <p id={messageId} role="status" aria-live="polite" className="mt-3 text-green-700">
+            {msg}
+          </p>
+        )}
+        {err && (
+          <p id={errorId} role="alert" className="mt-3 text-red-700">
+            {err}
+          </p>
+        )}
       </form>
     </div>
   );

--- a/components/BookingForm.tsx
+++ b/components/BookingForm.tsx
@@ -114,168 +114,265 @@ export default function BookingForm() {
   return (
     <form onSubmit={handleSubmit} className="space-y-8">
       {/* Owner info */}
-      <section className="space-y-4">
-        <h2 className="text-xl font-semibold">Owner Information</h2>
+      <fieldset className="space-y-4">
+        <legend className="text-xl font-semibold">Owner information</legend>
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-          <input
-            required
-            placeholder="First name"
-            className="rounded border p-2"
-            value={owner.firstName}
-            onChange={(e) => setOwner({ ...owner, firstName: e.target.value })}
-          />
-          <input
-            required
-            placeholder="Last name"
-            className="rounded border p-2"
-            value={owner.lastName}
-            onChange={(e) => setOwner({ ...owner, lastName: e.target.value })}
-          />
-          <input
-            required
-            placeholder="Address"
-            className="rounded border p-2 sm:col-span-2"
-            value={owner.address}
-            onChange={(e) => setOwner({ ...owner, address: e.target.value })}
-          />
-          <input
-            required
-            placeholder="Phone"
-            className="rounded border p-2"
-            value={owner.phone}
-            onChange={(e) => setOwner({ ...owner, phone: e.target.value })}
-          />
-          <input
-            required
-            type="email"
-            placeholder="Email"
-            className="rounded border p-2"
-            value={owner.email}
-            onChange={(e) => setOwner({ ...owner, email: e.target.value })}
-          />
+          <div className="flex flex-col gap-1">
+            <label htmlFor="owner-first-name" className="text-sm font-medium">
+              First name
+            </label>
+            <input
+              id="owner-first-name"
+              required
+              placeholder="First name"
+              className="rounded border p-2 focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white"
+              value={owner.firstName}
+              autoComplete="given-name"
+              onChange={(e) => setOwner({ ...owner, firstName: e.target.value })}
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label htmlFor="owner-last-name" className="text-sm font-medium">
+              Last name
+            </label>
+            <input
+              id="owner-last-name"
+              required
+              placeholder="Last name"
+              className="rounded border p-2 focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white"
+              value={owner.lastName}
+              autoComplete="family-name"
+              onChange={(e) => setOwner({ ...owner, lastName: e.target.value })}
+            />
+          </div>
+          <div className="flex flex-col gap-1 sm:col-span-2">
+            <label htmlFor="owner-address" className="text-sm font-medium">
+              Address
+            </label>
+            <input
+              id="owner-address"
+              required
+              placeholder="Address"
+              className="rounded border p-2 focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white"
+              value={owner.address}
+              autoComplete="street-address"
+              onChange={(e) => setOwner({ ...owner, address: e.target.value })}
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label htmlFor="owner-phone" className="text-sm font-medium">
+              Phone
+            </label>
+            <input
+              id="owner-phone"
+              required
+              placeholder="Phone"
+              className="rounded border p-2 focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white"
+              value={owner.phone}
+              type="tel"
+              autoComplete="tel"
+              onChange={(e) => setOwner({ ...owner, phone: e.target.value })}
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <label htmlFor="owner-email" className="text-sm font-medium">
+              Email
+            </label>
+            <input
+              id="owner-email"
+              required
+              type="email"
+              placeholder="Email"
+              className="rounded border p-2 focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white"
+              value={owner.email}
+              autoComplete="email"
+              onChange={(e) => setOwner({ ...owner, email: e.target.value })}
+            />
+          </div>
         </div>
-      </section>
+      </fieldset>
 
       {/* Dog sections */}
       {dogs.map((dog, idx) => {
         const expired = dog.vaccineExpiry && new Date(dog.vaccineExpiry) < new Date();
+        const sectionId = `dog-${idx + 1}`;
+        const breedListId = `breed-options-${idx}`;
+        const expiryMessageId = `${sectionId}-expiry`; // used conditionally
+
         return (
-          <section key={idx} className="space-y-4 rounded border p-4">
-            <h3 className="text-lg font-medium">Dog {idx + 1}</h3>
+          <fieldset key={sectionId} className="space-y-4 rounded border p-4">
+            <legend className="text-lg font-medium">Dog {idx + 1}</legend>
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <input
-                required
-                placeholder="Name"
-                className="rounded border p-2"
-                value={dog.name}
-                onChange={(e) => updateDog(idx, { name: e.target.value })}
-              />
-              <select
-                className="rounded border p-2"
-                value={dog.gender}
-                onChange={(e) => updateDog(idx, { gender: e.target.value as 'm' | 'f' })}
-              >
-                <option value="m">Male</option>
-                <option value="f">Female</option>
-              </select>
-              <label className="flex items-center space-x-2">
+              <div className="flex flex-col gap-1">
+                <label htmlFor={`${sectionId}-name`} className="text-sm font-medium">
+                  Name
+                </label>
                 <input
-                  type="checkbox"
-                  checked={dog.fixed}
-                  onChange={(e) => updateDog(idx, { fixed: e.target.checked })}
+                  id={`${sectionId}-name`}
+                  required
+                  placeholder="Name"
+                  className="rounded border p-2 focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white"
+                  value={dog.name}
+                  onChange={(e) => updateDog(idx, { name: e.target.value })}
                 />
-                <span>Fixed/Neutered</span>
-              </label>
-              <select
-                className="rounded border p-2"
-                value={dog.weight}
-                onChange={(e) => updateDog(idx, { weight: e.target.value as Weight })}
-              >
-                <option value="small">Up to 25 lbs</option>
-                <option value="medium">26-50 lbs</option>
-                <option value="large">51+ lbs</option>
-              </select>
-              <div className="sm:col-span-2">
+              </div>
+              <div className="flex flex-col gap-1">
+                <label htmlFor={`${sectionId}-gender`} className="text-sm font-medium">
+                  Gender
+                </label>
+                <select
+                  id={`${sectionId}-gender`}
+                  className="rounded border p-2 focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white"
+                  value={dog.gender}
+                  onChange={(e) => updateDog(idx, { gender: e.target.value as 'm' | 'f' })}
+                >
+                  <option value="m">Male</option>
+                  <option value="f">Female</option>
+                </select>
+              </div>
+              <div className="flex flex-col gap-1">
+                <span className="text-sm font-medium">Fixed or neutered</span>
+                <div className="flex items-center gap-2">
+                  <input
+                    id={`${sectionId}-fixed`}
+                    className="h-4 w-4 rounded border focus-ring"
+                    type="checkbox"
+                    checked={dog.fixed}
+                    onChange={(e) => updateDog(idx, { fixed: e.target.checked })}
+                  />
+                  <label htmlFor={`${sectionId}-fixed`} className="text-sm">
+                    Fixed/Neutered
+                  </label>
+                </div>
+              </div>
+              <div className="flex flex-col gap-1">
+                <label htmlFor={`${sectionId}-weight`} className="text-sm font-medium">
+                  Weight
+                </label>
+                <select
+                  id={`${sectionId}-weight`}
+                  className="rounded border p-2 focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white"
+                  value={dog.weight}
+                  onChange={(e) => updateDog(idx, { weight: e.target.value as Weight })}
+                >
+                  <option value="small">Up to 25 lbs</option>
+                  <option value="medium">26-50 lbs</option>
+                  <option value="large">51+ lbs</option>
+                </select>
+              </div>
+              <div className="flex flex-col gap-1 sm:col-span-2">
+                <label htmlFor={`${sectionId}-breed`} className="text-sm font-medium">
+                  Breed
+                </label>
                 <input
-                  list="breeds"
+                  id={`${sectionId}-breed`}
+                  list={breedListId}
                   placeholder="Breed"
-                  className="w-full rounded border p-2"
+                  className="w-full rounded border p-2 focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white"
                   value={dog.breed}
                   onChange={(e) => updateDog(idx, { breed: e.target.value })}
                 />
-                <datalist id="breeds">
+                <datalist id={breedListId}>
                   {breedOptions.map((b) => (
                     <option key={b} value={b} />
                   ))}
                 </datalist>
               </div>
               <div className="sm:col-span-2">
-                <label className="mb-1 block text-sm">Vaccination record</label>
-                <input type="file" accept="image/*,.pdf" className="block w-full text-sm" />
+                <label htmlFor={`${sectionId}-vaccine-file`} className="mb-1 block text-sm font-medium">
+                  Vaccination record upload
+                </label>
                 <input
+                  id={`${sectionId}-vaccine-file`}
+                  type="file"
+                  accept="image/*,.pdf"
+                  className="block w-full text-sm focus-ring"
+                />
+                <label htmlFor={`${sectionId}-vaccine-expiry`} className="mt-2 block text-sm font-medium">
+                  Vaccination expiry date
+                </label>
+                <input
+                  id={`${sectionId}-vaccine-expiry`}
                   type="date"
-                  className="mt-2 rounded border p-2"
+                  className="rounded border p-2 focus:outline-none focus:ring-2 focus:ring-brand-navy focus:ring-offset-2 focus:ring-offset-white"
                   value={dog.vaccineExpiry}
+                  aria-describedby={expired ? expiryMessageId : undefined}
                   onChange={(e) => updateDog(idx, { vaccineExpiry: e.target.value })}
                 />
                 {expired && (
-                  <p className="mt-1 text-sm text-red-600">
+                  <p id={expiryMessageId} className="mt-1 text-sm text-red-600">
                     Vaccination record expired!
                   </p>
                 )}
               </div>
               <div className="sm:col-span-2">
-                <p className="mb-2 font-medium">Extras</p>
-                <label className="mr-4 inline-flex items-center">
-                  <input
-                    type="checkbox"
-                    checked={dog.extras.nailTrim}
-                    onChange={(e) => updateExtras(idx, { nailTrim: e.target.checked })}
-                  />
-                  <span className="ml-1">Nail trim (+${extraPrices.nailTrim})</span>
-                </label>
-                <label className="mr-4 inline-flex items-center">
-                  <input
-                    type="checkbox"
-                    checked={dog.extras.teethBrush}
-                    onChange={(e) =>
-                      updateExtras(idx, { teethBrush: e.target.checked })
-                    }
-                  />
-                  <span className="ml-1">Teeth brushing (+${extraPrices.teethBrush})</span>
-                </label>
-                <label className="inline-flex items-center">
-                  <input
-                    type="checkbox"
-                    checked={dog.extras.deShedding}
-                    onChange={(e) =>
-                      updateExtras(idx, { deShedding: e.target.checked })
-                    }
-                  />
-                  <span className="ml-1">De-shedding (+${extraPrices.deShedding})</span>
-                </label>
+                <fieldset>
+                  <legend className="mb-2 font-medium">Extras</legend>
+                  <div className="flex flex-wrap gap-4">
+                    <div className="flex items-center gap-2">
+                      <input
+                        id={`${sectionId}-nail-trim`}
+                        className="h-4 w-4 rounded border focus-ring"
+                        type="checkbox"
+                        checked={dog.extras.nailTrim}
+                        onChange={(e) => updateExtras(idx, { nailTrim: e.target.checked })}
+                      />
+                      <label htmlFor={`${sectionId}-nail-trim`} className="text-sm">
+                        Nail trim (+${extraPrices.nailTrim})
+                      </label>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <input
+                        id={`${sectionId}-teeth-brush`}
+                        className="h-4 w-4 rounded border focus-ring"
+                        type="checkbox"
+                        checked={dog.extras.teethBrush}
+                        onChange={(e) =>
+                          updateExtras(idx, { teethBrush: e.target.checked })
+                        }
+                      />
+                      <label htmlFor={`${sectionId}-teeth-brush`} className="text-sm">
+                        Teeth brushing (+${extraPrices.teethBrush})
+                      </label>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <input
+                        id={`${sectionId}-deshedding`}
+                        className="h-4 w-4 rounded border focus-ring"
+                        type="checkbox"
+                        checked={dog.extras.deShedding}
+                        onChange={(e) =>
+                          updateExtras(idx, { deShedding: e.target.checked })
+                        }
+                      />
+                      <label htmlFor={`${sectionId}-deshedding`} className="text-sm">
+                        De-shedding (+${extraPrices.deShedding})
+                      </label>
+                    </div>
+                  </div>
+                </fieldset>
               </div>
             </div>
-          </section>
+          </fieldset>
         );
       })}
 
       <button
         type="button"
         onClick={addDog}
-        className="rounded bg-secondary px-3 py-1 text-sm text-white hover:bg-secondary-dark"
+        className="focus-ring rounded bg-secondary px-3 py-1 text-sm text-white hover:bg-secondary-dark"
       >
         Add another dog
       </button>
 
-      <div className="flex justify-between border-t pt-4 text-lg font-bold">
+      <div className="flex justify-between border-t pt-4 text-lg font-bold" aria-live="polite">
         <span>Total:</span>
         <span>${total.toFixed(2)}</span>
       </div>
 
       <button
         type="submit"
-        className="w-full rounded bg-primary px-4 py-2 font-medium text-white hover:bg-primary-dark"
+        className="focus-ring w-full rounded bg-primary px-4 py-2 font-medium text-white hover:bg-primary-dark"
       >
         Submit Request
       </button>

--- a/components/LoginBanner.tsx
+++ b/components/LoginBanner.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { supabase } from '@/lib/supabase/client';
 
 export default function LoginBanner() {
@@ -8,6 +8,11 @@ export default function LoginBanner() {
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+
+  const titleId = useId();
+  const emailId = useId();
+  const passwordId = useId();
+  const errorId = useId();
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -27,18 +32,33 @@ export default function LoginBanner() {
   return (
     <form
       onSubmit={onSubmit}
+      aria-labelledby={titleId}
+      aria-describedby={err ? errorId : undefined}
       className="glass-panel mb-6 flex flex-wrap items-center gap-3 bg-white/95 p-4 text-sm text-brand-navy"
     >
+      <h2 id={titleId} className="sr-only">
+        Inline login form
+      </h2>
+      <label htmlFor={emailId} className="sr-only">
+        Email address
+      </label>
       <input
+        id={emailId}
         type="email"
         required
+        autoComplete="email"
         placeholder="Email"
         value={email}
         onChange={(e) => setEmail(e.target.value)}
       />
+      <label htmlFor={passwordId} className="sr-only">
+        Password
+      </label>
       <input
+        id={passwordId}
         type="password"
         required
+        autoComplete="current-password"
         placeholder="Password"
         value={password}
         onChange={(e) => setPassword(e.target.value)}
@@ -46,11 +66,15 @@ export default function LoginBanner() {
       <button
         type="submit"
         disabled={loading}
-        className="rounded-full bg-brand-bubble px-4 py-2 font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:bg-brand-bubbleDark disabled:cursor-not-allowed disabled:opacity-60"
+        className="focus-ring rounded-full bg-brand-bubble px-4 py-2 font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:bg-brand-bubbleDark disabled:cursor-not-allowed disabled:opacity-60"
       >
         {loading ? 'Logging in...' : 'Login'}
       </button>
-      {err && <span className="ml-2 font-medium text-red-600">{err}</span>}
+      {err && (
+        <span id={errorId} role="alert" className="ml-2 font-medium text-red-600">
+          {err}
+        </span>
+      )}
     </form>
   );
 }

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { supabase } from '@/lib/supabase/client';
 
@@ -11,6 +11,12 @@ export default function LoginForm() {
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+
+  const headingId = useId();
+  const descriptionId = useId();
+  const errorId = useId();
+  const emailId = useId();
+  const passwordId = useId();
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -31,31 +37,43 @@ export default function LoginForm() {
   return (
     <form
       onSubmit={onSubmit}
+      aria-labelledby={headingId}
+      aria-describedby={err ? `${descriptionId} ${errorId}` : descriptionId}
       className="glass-panel w-full max-w-md space-y-5 bg-white/95 p-10 text-brand-navy"
     >
       <div className="space-y-1">
         <p className="text-xs font-semibold uppercase tracking-[0.35em] text-brand-navy/60">
           Welcome back
         </p>
-        <h1 className="text-3xl font-black tracking-tight text-brand-navy">
+        <h1 id={headingId} className="text-3xl font-black tracking-tight text-brand-navy">
           Scruffy squad <span className="ml-1">🐶</span>
         </h1>
-        <p className="text-sm text-brand-navy/70">Sign in to keep the tails wagging.</p>
+        <p id={descriptionId} className="text-sm text-brand-navy/70">
+          Sign in to keep the tails wagging.
+        </p>
       </div>
 
       {err && (
-        <div className="rounded-2xl border border-red-300/60 bg-red-100/60 px-3 py-2 text-sm text-red-700">
+        <div
+          id={errorId}
+          role="alert"
+          className="rounded-2xl border border-red-300/60 bg-red-100/60 px-3 py-2 text-sm text-red-700"
+        >
           {err}
         </div>
       )}
 
       <div className="space-y-4">
         <div className="space-y-1">
-          <label className="block text-sm font-semibold text-brand-navy">Email</label>
+          <label htmlFor={emailId} className="block text-sm font-semibold text-brand-navy">
+            Email
+          </label>
           <input
+            id={emailId}
             className="w-full"
             type="email"
             required
+            autoComplete="email"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
             placeholder="you@example.com"
@@ -63,11 +81,15 @@ export default function LoginForm() {
         </div>
 
         <div className="space-y-1">
-          <label className="block text-sm font-semibold text-brand-navy">Password</label>
+          <label htmlFor={passwordId} className="block text-sm font-semibold text-brand-navy">
+            Password
+          </label>
           <input
+            id={passwordId}
             className="w-full"
             type="password"
             required
+            autoComplete="current-password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             placeholder="••••••••"
@@ -78,16 +100,22 @@ export default function LoginForm() {
       <button
         type="submit"
         disabled={loading}
-        className="w-full rounded-full bg-brand-bubble px-5 py-3 text-base font-semibold text-white shadow-lg transition-all duration-200 hover:-translate-y-0.5 hover:bg-brand-bubbleDark disabled:cursor-not-allowed disabled:opacity-60"
+        className="focus-ring w-full rounded-full bg-brand-bubble px-5 py-3 text-base font-semibold text-white shadow-lg transition-all duration-200 hover:-translate-y-0.5 hover:bg-brand-bubbleDark disabled:cursor-not-allowed disabled:opacity-60"
       >
         {loading ? 'Signing in…' : 'Sign in'}
       </button>
 
       <div className="flex justify-between text-sm text-brand-navy/70">
-        <a className="font-semibold text-brand-bubble transition-colors hover:text-brand-bubbleDark" href="/signup">
+        <a
+          className="focus-ring font-semibold text-brand-bubble transition-colors hover:text-brand-bubbleDark"
+          href="/signup"
+        >
           Create account
         </a>
-        <a className="font-semibold text-brand-bubble transition-colors hover:text-brand-bubbleDark" href="/reset-password">
+        <a
+          className="focus-ring font-semibold text-brand-bubble transition-colors hover:text-brand-bubbleDark"
+          href="/reset-password"
+        >
           Forgot password?
         </a>
       </div>

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -20,8 +20,15 @@ export default function TopNav() {
   return (
     <header className="sticky top-0 z-40 flex justify-center px-4 pt-6">
       <div className="glass-panel flex w-full max-w-6xl items-center justify-between px-6 py-4">
-        <Link href="/" className="group flex items-center gap-4 text-white">
-          <span className="grid h-12 w-12 place-items-center rounded-full bg-white/90 text-2xl shadow-inner ring-4 ring-white/40 transition-transform duration-300 group-hover:-rotate-12">
+        <Link
+          href="/"
+          aria-label="Scruffy Butts home"
+          className="group flex items-center gap-4 text-white focus-ring-muted"
+        >
+          <span
+            aria-hidden="true"
+            className="grid h-12 w-12 place-items-center rounded-full bg-white/90 text-2xl shadow-inner ring-4 ring-white/40 transition-transform duration-300 group-hover:-rotate-12"
+          >
             🐾
           </span>
           <div className="flex flex-col leading-tight">
@@ -31,24 +38,31 @@ export default function TopNav() {
             </span>
           </div>
         </Link>
-        <nav className="flex flex-wrap items-center justify-end gap-2 text-sm">
-          {navLinks.map((link) => {
-            const isActive = pathname?.startsWith(link.href);
-            return (
-              <Link
-                key={link.href}
-                href={link.href}
-                className={clsx(
-                  "nav-link",
-                  isActive
-                    ? "bg-white/25 text-white shadow-sm"
-                    : "text-white/80 hover:text-white"
-                )}
-              >
-                {link.label}
-              </Link>
-            );
-          })}
+        <nav
+          aria-label="Primary navigation"
+          className="flex flex-wrap items-center justify-end gap-2 text-sm"
+        >
+          <ul className="flex flex-wrap items-center gap-2">
+            {navLinks.map((link) => {
+              const isActive = pathname?.startsWith(link.href);
+              return (
+                <li key={link.href}>
+                  <Link
+                    href={link.href}
+                    aria-current={isActive ? "page" : undefined}
+                    className={clsx(
+                      "nav-link",
+                      isActive
+                        ? "bg-white/25 text-white shadow-sm"
+                        : "text-white/80 hover:text-white"
+                    )}
+                  >
+                    {link.label}
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- add ARIA labeling and focus treatments to the top navigation for clearer keyboard guidance
- label authentication and booking workflows with explicit form controls, live regions, and consistent focus states
- introduce reusable focus ring utilities and upgrade employee settings form semantics for screen-reader support

## Testing
- npm run lint
- npm run typecheck
- npx @axe-core/cli http://127.0.0.1:3000 *(fails: Chrome binary unavailable in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c897ff71dc83248fa1e777d01bcaea