### PR TITLE
Improve mobile responsiveness across app pages

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -206,51 +206,51 @@ export default function CalendarPage() {
   return (
     <PageContainer>
       <div className="grid gap-6 md:grid-cols-3">
-        <Card className="md:col-span-2">
-          <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
-          <div className="flex gap-2">
-            {(["day", "week", "month", "list"] as const).map((v) => (
-              <button
-                key={v}
-                className={clsx(
-                  "rounded px-2 py-1 text-sm",
-                  view === v
-                    ? "bg-primary-light text-white"
-                    : "border hover:bg-gray-100"
-                )}
-                onClick={() => handleViewChange(v)}
-              >
-                {v.charAt(0).toUpperCase() + v.slice(1)}
-              </button>
-            ))}
+        <Card className="space-y-6 md:col-span-2">
+          <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
+            <div className="flex w-full gap-2 overflow-x-auto rounded-full bg-brand-bubble/10 p-1 text-sm sm:w-auto sm:overflow-visible sm:bg-transparent sm:p-0">
+              {(["day", "week", "month", "list"] as const).map((v) => (
+                <button
+                  key={v}
+                  className={clsx(
+                    "flex-shrink-0 rounded-full px-3 py-1 text-sm font-semibold transition",
+                    view === v
+                      ? "bg-brand-bubble text-white shadow"
+                      : "bg-white/60 text-primary-dark hover:bg-white"
+                  )}
+                  onClick={() => handleViewChange(v)}
+                >
+                  {v.charAt(0).toUpperCase() + v.slice(1)}
+                </button>
+              ))}
+            </div>
+            <select
+              className="w-full rounded-full border border-gray-200 px-3 py-2 text-sm shadow-sm focus:border-brand-bubble focus:ring-2 focus:ring-brand-bubble/30 sm:w-56"
+              value={groomer}
+              onChange={(e) => setGroomer(e.target.value)}
+            >
+              <option value="All">All Groomers</option>
+              {groomers.map((g) => (
+                <option key={g} value={g}>
+                  {g}
+                </option>
+              ))}
+            </select>
           </div>
-          <select
-            className="rounded border px-2 py-1 text-sm"
-            value={groomer}
-            onChange={(e) => setGroomer(e.target.value)}
-          >
-            <option value="All">All Groomers</option>
-            {groomers.map((g) => (
-              <option key={g} value={g}>
-                {g}
-              </option>
-            ))}
-          </select>
-        </div>
 
         {view !== "list" && (
-          <div className="mb-4 flex items-center justify-between">
-            <div className="flex items-center gap-2">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center justify-between gap-3 sm:justify-start">
               <button
-                className="rounded p-1 hover:bg-gray-100"
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/70 text-primary-dark shadow-sm transition hover:bg-white"
                 onClick={goPrev}
                 aria-label="Previous"
               >
                 <ChevronLeftIcon className="h-5 w-5" />
               </button>
-              <h1 className="text-3xl font-bold text-primary-dark">{label()}</h1>
+              <h1 className="text-2xl font-bold text-primary-dark sm:text-3xl">{label()}</h1>
               <button
-                className="rounded p-1 hover:bg-gray-100"
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/70 text-primary-dark shadow-sm transition hover:bg-white"
                 onClick={goNext}
                 aria-label="Next"
               >
@@ -258,7 +258,7 @@ export default function CalendarPage() {
               </button>
             </div>
             <button
-              className="rounded border px-2 py-1 text-sm hover:bg-gray-100"
+              className="w-full rounded-full border border-gray-200 px-4 py-2 text-sm font-semibold text-primary-dark shadow-sm transition hover:bg-white sm:w-auto"
               onClick={goToday}
             >
               Today
@@ -267,10 +267,10 @@ export default function CalendarPage() {
         )}
 
         {view === "month" && (
-          <>
-            <div className="grid grid-cols-7 gap-2 text-center text-sm">
+          <div className="overflow-x-auto">
+            <div className="grid min-w-[40rem] grid-cols-7 gap-2 text-center text-xs sm:text-sm">
               {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((d) => (
-                <div key={d} className="font-medium">
+                <div key={d} className="font-medium text-primary-dark">
                   {d}
                 </div>
               ))}
@@ -285,16 +285,16 @@ export default function CalendarPage() {
                     key={key}
                     onClick={() => handleDayClick(day)}
                     className={clsx(
-                      "relative h-24 cursor-pointer rounded border p-1 text-left transition-colors hover:bg-secondary-green/40",
+                      "relative h-24 cursor-pointer rounded-xl border p-1 text-left transition-colors hover:bg-secondary-green/40",
                       isCurrentMonth ? "bg-white" : "bg-gray-50 text-gray-400",
                       isToday && "border-primary-light",
                       isSelected && "ring-2 ring-primary-light"
                     )}
                   >
-                    <div className="mb-1 flex justify-between text-xs">
+                    <div className="mb-1 flex justify-between text-[0.65rem] sm:text-xs">
                       <span>{day.getDate()}</span>
                       {appts.length > 0 && (
-                        <span className="rounded bg-primary-light px-1 text-[10px] text-white">
+                        <span className="rounded bg-primary-light px-1 text-[0.6rem] text-white">
                           {appts.length}
                         </span>
                       )}
@@ -302,7 +302,7 @@ export default function CalendarPage() {
                     {appts.slice(0, 2).map((a) => (
                       <div
                         key={a.id}
-                        className="mb-1 truncate rounded bg-primary-light px-1 text-[10px] text-white"
+                        className="mb-1 truncate rounded bg-primary-light/90 px-1 text-[0.6rem] text-white"
                       >
                         {new Date(a.start_time).toLocaleTimeString([], {
                           hour: "2-digit",
@@ -312,7 +312,7 @@ export default function CalendarPage() {
                       </div>
                     ))}
                     {appts.length > 2 && (
-                      <div className="text-[10px] text-primary-dark">
+                      <div className="text-[0.6rem] text-primary-dark">
                         +{appts.length - 2} more
                       </div>
                     )}
@@ -320,15 +320,14 @@ export default function CalendarPage() {
                 );
               })}
             </div>
-
-          </>
+          </div>
         )}
 
         {view === "week" && (
-          <>
-            <div className="grid grid-cols-7 gap-2 text-center text-sm">
+          <div className="overflow-x-auto">
+            <div className="grid min-w-[40rem] grid-cols-7 gap-2 text-center text-xs sm:text-sm">
               {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((d) => (
-                <div key={d} className="font-medium">
+                <div key={d} className="font-medium text-primary-dark">
                   {d}
                 </div>
               ))}
@@ -342,16 +341,16 @@ export default function CalendarPage() {
                     key={key}
                     onClick={() => handleDayClick(day)}
                     className={clsx(
-                      "relative h-24 cursor-pointer rounded border p-1 text-left transition-colors hover:bg-secondary-green/40",
+                      "relative h-24 cursor-pointer rounded-xl border p-1 text-left transition-colors hover:bg-secondary-green/40",
                       "bg-white",
                       isToday && "border-primary-light",
                       isSelected && "ring-2 ring-primary-light"
                     )}
                   >
-                    <div className="mb-1 flex justify-between text-xs">
+                    <div className="mb-1 flex justify-between text-[0.65rem] sm:text-xs">
                       <span>{day.getDate()}</span>
                       {appts.length > 0 && (
-                        <span className="rounded bg-primary-light px-1 text-[10px] text-white">
+                        <span className="rounded bg-primary-light px-1 text-[0.6rem] text-white">
                           {appts.length}
                         </span>
                       )}
@@ -359,7 +358,7 @@ export default function CalendarPage() {
                     {appts.slice(0, 2).map((a) => (
                       <div
                         key={a.id}
-                        className="mb-1 truncate rounded bg-primary-light px-1 text-[10px] text-white"
+                        className="mb-1 truncate rounded bg-primary-light/90 px-1 text-[0.6rem] text-white"
                       >
                         {new Date(a.start_time).toLocaleTimeString([], {
                           hour: "2-digit",
@@ -369,7 +368,7 @@ export default function CalendarPage() {
                       </div>
                     ))}
                     {appts.length > 2 && (
-                      <div className="text-[10px] text-primary-dark">
+                      <div className="text-[0.6rem] text-primary-dark">
                         +{appts.length - 2} more
                       </div>
                     )}
@@ -377,14 +376,13 @@ export default function CalendarPage() {
                 );
               })}
             </div>
-
-          </>
+          </div>
         )}
 
         {view === "day" && (
-          <div className="mt-6">
-            <h2 className="mb-2 text-lg font-semibold">
-              Appointments on{" "}
+          <div className="mt-4 space-y-3">
+            <h2 className="text-lg font-semibold text-primary-dark">
+              Appointments on {" "}
               {current.toLocaleDateString(undefined, {
                 weekday: "long",
                 month: "long",
@@ -392,14 +390,14 @@ export default function CalendarPage() {
               })}
             </h2>
             {dayAppts.length ? (
-              <ul className="space-y-2">
+              <ul className="space-y-3">
                 {dayAppts.map((a) => (
                   <li
                     key={a.id}
-                    className="flex justify-between rounded border p-2 text-sm"
+                    className="flex flex-col gap-3 rounded-2xl border border-gray-200 bg-white/80 p-3 text-sm shadow-sm sm:flex-row sm:items-center sm:justify-between"
                   >
-                    <div>
-                      <div className="font-medium">{a.pets?.[0]?.name ?? "-"}</div>
+                    <div className="space-y-1 text-left">
+                      <div className="font-semibold text-primary-dark">{a.pets?.[0]?.name ?? "-"}</div>
                       <div className="text-xs text-gray-500">
                         {a.clients?.[0]?.full_name ?? "-"}
                       </div>
@@ -408,8 +406,8 @@ export default function CalendarPage() {
                         {a.groomer_name ?? "-"}
                       </div>
                     </div>
-                    <div className="text-right">
-                      <div>
+                    <div className="flex flex-col items-start gap-2 text-xs font-semibold text-primary-dark sm:items-end sm:text-right">
+                      <div className="text-sm">
                         {new Date(a.start_time).toLocaleTimeString([], {
                           hour: "2-digit",
                           minute: "2-digit",
@@ -417,7 +415,7 @@ export default function CalendarPage() {
                       </div>
                       <div
                         className={clsx(
-                          "mt-1 inline-block rounded px-2 text-xs capitalize",
+                          "inline-flex items-center rounded-full px-3 py-1 text-xs capitalize",
                           {
                             pending: "bg-yellow-100 text-yellow-800",
                             scheduled: "bg-blue-100 text-blue-800",
@@ -441,14 +439,14 @@ export default function CalendarPage() {
         {view === "list" && (
           <div className="mt-4">
             {listAppts.length ? (
-              <ul className="space-y-2">
+              <ul className="space-y-3">
                 {listAppts.map((a) => (
                   <li
                     key={a.id}
-                    className="flex justify-between rounded border p-2 text-sm"
+                    className="flex flex-col gap-3 rounded-2xl border border-gray-200 bg-white/80 p-3 text-sm shadow-sm sm:flex-row sm:items-center sm:justify-between"
                   >
-                    <div>
-                      <div className="font-medium">{a.pets?.[0]?.name ?? "-"}</div>
+                    <div className="space-y-1 text-left">
+                      <div className="font-semibold text-primary-dark">{a.pets?.[0]?.name ?? "-"}</div>
                       <div className="text-xs text-gray-500">
                         {a.clients?.[0]?.full_name ?? "-"}
                       </div>
@@ -457,8 +455,8 @@ export default function CalendarPage() {
                         {a.groomer_name ?? "-"}
                       </div>
                     </div>
-                    <div className="text-right">
-                      <div>
+                    <div className="flex flex-col items-start gap-2 text-xs font-semibold text-primary-dark sm:items-end sm:text-right">
+                      <div className="text-sm">
                         {new Date(a.start_time).toLocaleString([], {
                           month: "short",
                           day: "numeric",
@@ -468,7 +466,7 @@ export default function CalendarPage() {
                       </div>
                       <div
                         className={clsx(
-                          "mt-1 inline-block rounded px-2 text-xs capitalize",
+                          "inline-flex items-center rounded-full px-3 py-1 text-xs capitalize",
                           {
                             pending: "bg-yellow-100 text-yellow-800",
                             scheduled: "bg-blue-100 text-blue-800",

--- a/app/clients/page.tsx
+++ b/app/clients/page.tsx
@@ -4,6 +4,7 @@ import Card from "@/components/Card";
 import { useEffect, useState } from "react";
 import { supabase } from "@/lib/supabase/client";
 import Link from "next/link";
+import clsx from "clsx";
 
 // Type definition for a client record
 type Client = {
@@ -42,11 +43,11 @@ export default function ClientsPage() {
     <PageContainer>
       <div className="grid gap-6 md:grid-cols-3">
         <Card className="space-y-4 md:col-span-2">
-          <h1 className="text-3xl font-bold text-primary-dark">Clients</h1>
+          <h1 className="text-2xl font-bold text-primary-dark sm:text-3xl">Clients</h1>
           <div>
             <Link
               href="/clients/new"
-              className="inline-block rounded-full bg-primary px-4 py-2 text-white shadow hover:bg-primary-dark"
+              className="inline-flex w-full items-center justify-center rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-primary-dark sm:w-auto"
             >
               Add Client
             </Link>
@@ -55,7 +56,7 @@ export default function ClientsPage() {
             value={q}
             onChange={(e) => setQ(e.target.value)}
             placeholder="Search clients…"
-            className="mb-4 w-full max-w-md rounded-full border border-gray-300 px-4 py-2 focus:border-primary focus:ring-2 focus:ring-primary-light"
+            className="mb-4 w-full rounded-full border border-gray-300 px-4 py-2 shadow-sm focus:border-primary focus:ring-2 focus:ring-primary-light"
           />
           {loading ? (
             <p>Loading…</p>
@@ -65,7 +66,10 @@ export default function ClientsPage() {
                 <li
                   key={c.id}
                   onClick={() => setSelected(c)}
-                  className="relative flex cursor-pointer items-center justify-between py-3"
+                  className={clsx(
+                    "flex cursor-pointer flex-col gap-2 rounded-2xl px-2 py-3 transition sm:flex-row sm:items-center sm:justify-between",
+                    selected?.id === c.id ? "bg-brand-bubble/15" : "hover:bg-white/60"
+                  )}
                 >
                   <div>
                     <div className="font-medium">{c.full_name}</div>
@@ -76,7 +80,7 @@ export default function ClientsPage() {
                   {selected?.id === c.id && (
                     <Link
                       href={`/clients/${c.id}`}
-                      className="absolute inset-0 flex items-center justify-center bg-primary/80 text-lg font-semibold text-white"
+                      className="inline-flex w-full items-center justify-center rounded-full bg-primary px-4 py-2 text-sm font-semibold text-white shadow transition hover:bg-primary-dark sm:w-auto"
                     >
                       Client Page
                     </Link>

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -17,25 +17,25 @@ export default async function DashboardPage() {
   if (!user) redirect('/login')
   return (
     <PageContainer>
-      <div className="grid gap-6 md:grid-cols-3">
+      <div className="flex snap-x snap-mandatory gap-4 overflow-x-auto pb-6 md:grid md:grid-cols-3 md:gap-6 md:overflow-visible md:pb-0">
         <Widget
           title="Today's Appointments"
           color="blue"
-          className="md:col-span-2 md:row-span-4"
+          className="min-w-full snap-center md:min-w-0 md:col-span-2 md:row-span-4"
           hideHeader
         >
           <TodaysAppointments />
         </Widget>
-        <Widget title="Employee Workload" color="purple" className="md:col-start-3">
+        <Widget title="Employee Workload" color="purple" className="min-w-full snap-center md:min-w-0 md:col-start-3">
           <EmployeeWorkload />
         </Widget>
-        <Widget title="Revenue" color="green" className="md:col-start-3">
+        <Widget title="Revenue" color="green" className="min-w-full snap-center md:min-w-0 md:col-start-3">
           <Revenue />
         </Widget>
-        <Widget title="Messages" color="purple" className="md:col-start-3">
+        <Widget title="Messages" color="purple" className="min-w-full snap-center md:min-w-0 md:col-start-3">
           <Messages />
         </Widget>
-        <Widget title="Quick Actions" color="pink" className="md:col-start-3">
+        <Widget title="Quick Actions" color="pink" className="min-w-full snap-center md:min-w-0 md:col-start-3">
           <div className="flex flex-col space-y-3">
             {[
               'Book Appointment',

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -5,7 +5,7 @@ export default function Card({ children, className = '' }: { children: ReactNode
   return (
     <div
       className={clsx(
-        'rounded-[2rem] border border-white/30 bg-white/85 p-6 text-brand-navy shadow-soft backdrop-blur-xl',
+        'rounded-[2rem] border border-white/30 bg-white/85 p-5 text-brand-navy shadow-soft backdrop-blur-xl sm:p-6',
         className
       )}
     >

--- a/components/PageContainer.tsx
+++ b/components/PageContainer.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx'
 
 export default function PageContainer({ children, className = '' }: { children: ReactNode; className?: string }) {
   return (
-    <div className="relative z-10 flex w-full justify-center px-4 pb-24 pt-10 md:px-8">
+    <div className="relative z-10 flex w-full justify-center px-4 pb-24 pt-10 sm:px-6 md:px-8">
       <div className="pointer-events-none absolute inset-0 -z-10">
         <div className="absolute left-0 top-10 h-72 w-72 rounded-full bg-white/10 blur-3xl" />
         <div className="absolute bottom-0 right-0 h-[28rem] w-[28rem] rounded-full bg-brand-bubble/10 blur-[160px]" />

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -2,7 +2,9 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useEffect, useState } from "react";
 import clsx from "clsx";
+import { Bars3Icon, XMarkIcon } from "@heroicons/react/24/outline";
 
 const navLinks = [
   { href: "/dashboard", label: "Dashboard" },
@@ -16,22 +18,43 @@ const navLinks = [
 
 export default function TopNav() {
   const pathname = usePathname();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+
+  useEffect(() => {
+    setIsMenuOpen(false);
+  }, [pathname]);
 
   return (
     <header className="sticky top-0 z-40 flex justify-center px-4 pt-6">
-      <div className="glass-panel flex w-full max-w-6xl items-center justify-between px-6 py-4">
+      <div className="glass-panel relative flex w-full max-w-6xl items-center justify-between px-5 py-4 sm:px-6">
         <Link href="/" className="group flex items-center gap-4 text-white">
-          <span className="grid h-12 w-12 place-items-center rounded-full bg-white/90 text-2xl shadow-inner ring-4 ring-white/40 transition-transform duration-300 group-hover:-rotate-12">
+          <span className="grid h-11 w-11 place-items-center rounded-full bg-white/90 text-2xl shadow-inner ring-4 ring-white/40 transition-transform duration-300 group-hover:-rotate-12 sm:h-12 sm:w-12">
             🐾
           </span>
           <div className="flex flex-col leading-tight">
-            <span className="text-xs font-semibold uppercase tracking-[0.4em] text-white/70">Scruffy</span>
-            <span className="text-2xl font-black text-white transition-colors duration-300 group-hover:text-brand-cream">
+            <span className="text-[0.6rem] font-semibold uppercase tracking-[0.4em] text-white/70 sm:text-xs">Scruffy</span>
+            <span className="text-xl font-black text-white transition-colors duration-300 group-hover:text-brand-cream sm:text-2xl">
               Butts
             </span>
           </div>
         </Link>
-        <nav className="flex flex-wrap items-center justify-end gap-2 text-sm">
+        <button
+          type="button"
+          aria-label="Toggle navigation"
+          aria-expanded={isMenuOpen}
+          onClick={() => setIsMenuOpen((open) => !open)}
+          className="ml-auto inline-flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white transition hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white md:hidden"
+        >
+          {isMenuOpen ? <XMarkIcon className="h-6 w-6" /> : <Bars3Icon className="h-6 w-6" />}
+        </button>
+        <nav
+          className={clsx(
+            "md:static md:flex md:flex-wrap md:items-center md:justify-end md:gap-2 md:text-sm",
+            isMenuOpen
+              ? "absolute left-0 right-0 top-full z-30 mt-3 flex flex-col gap-2 rounded-3xl border border-white/20 bg-brand-navy/90 p-4 text-base shadow-xl backdrop-blur md:relative md:mt-0 md:flex md:flex-row md:rounded-full md:border-0 md:bg-transparent md:p-0 md:text-sm md:shadow-none"
+              : "hidden md:flex"
+          )}
+        >
           {navLinks.map((link) => {
             const isActive = pathname?.startsWith(link.href);
             return (
@@ -39,7 +62,7 @@ export default function TopNav() {
                 key={link.href}
                 href={link.href}
                 className={clsx(
-                  "nav-link",
+                  "nav-link w-full text-center md:w-auto",
                   isActive
                     ? "bg-white/25 text-white shadow-sm"
                     : "text-white/80 hover:text-white"

--- a/components/Widget.tsx
+++ b/components/Widget.tsx
@@ -38,12 +38,17 @@ export default function Widget({
       <div className="pointer-events-none absolute -right-16 -top-24 h-64 w-64 rounded-full bg-white/25 blur-[120px]" />
       <div className="pointer-events-none absolute bottom-[-30%] left-[-20%] h-80 w-80 rounded-full bg-white/10 blur-[160px]" />
       {!hideHeader && (
-        <div className="relative flex items-center justify-between px-6 pt-6">
+        <div className="relative flex flex-col gap-3 px-5 pt-5 sm:flex-row sm:items-center sm:justify-between sm:px-6 sm:pt-6">
           <h2 className="text-lg font-semibold tracking-tight drop-shadow-md">{title}</h2>
           {headerContent}
         </div>
       )}
-      <div className={clsx('relative px-6 pb-6', hideHeader ? 'pt-6' : 'pt-4')}>
+      <div
+        className={clsx(
+          'relative px-5 pb-5 sm:px-6 sm:pb-6',
+          hideHeader ? 'pt-5 sm:pt-6' : 'pt-4'
+        )}
+      >
         {children}
       </div>
     </div>

--- a/components/dashboard/TodaysAppointments.tsx
+++ b/components/dashboard/TodaysAppointments.tsx
@@ -75,12 +75,12 @@ export default function TodaysAppointments() {
 
   return (
     <div className="space-y-5">
-      <div className="flex items-center justify-between text-white">
+      <div className="flex flex-col gap-3 text-white sm:flex-row sm:items-center sm:justify-between">
         <div>
           <p className="text-xs uppercase tracking-[0.35em] text-white/70">Today</p>
           <h3 className="text-2xl font-semibold tracking-tight drop-shadow-sm">{today}</h3>
         </div>
-        <span className="flex h-12 w-12 items-center justify-center rounded-full bg-white/25 text-lg font-semibold text-white shadow-inner">
+        <span className="flex h-10 w-10 items-center justify-center rounded-full bg-white/25 text-base font-semibold text-white shadow-inner sm:h-12 sm:w-12 sm:text-lg">
           {appointments.length}
         </span>
       </div>
@@ -88,7 +88,7 @@ export default function TodaysAppointments() {
         {appointments.map((appt) => (
           <li
             key={appt.id}
-            className="grid grid-cols-[auto,1fr,auto] items-center gap-4 rounded-3xl bg-white/95 px-5 py-4 text-brand-navy shadow-lg shadow-primary/10 backdrop-blur"
+            className="flex flex-col gap-3 rounded-3xl bg-white/95 px-5 py-4 text-brand-navy shadow-lg shadow-primary/10 backdrop-blur sm:grid sm:grid-cols-[auto,1fr,auto] sm:items-center sm:gap-4"
           >
             <div className="grid h-12 w-12 place-items-center rounded-full bg-brand-bubble/20 text-2xl">
               🐶
@@ -97,11 +97,11 @@ export default function TodaysAppointments() {
               <p className="text-sm font-semibold text-brand-navy">{appt.pet_name}</p>
               <p className="text-xs text-brand-navy/70">{appt.client_name}</p>
             </div>
-            <div className="text-right">
-              <div className="text-sm font-semibold text-brand-navy">{appt.time}</div>
+            <div className="flex flex-wrap items-center gap-2 text-sm font-semibold text-brand-navy sm:flex-col sm:items-end sm:gap-3 sm:text-right">
+              <div>{appt.time}</div>
               <span
                 className={clsx(
-                  'mt-2 inline-flex items-center justify-center rounded-full px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-wide',
+                  'inline-flex items-center justify-center rounded-full px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-wide',
                   statusStyles[appt.status] ?? 'bg-white/40 text-brand-navy'
                 )}
               >


### PR DESCRIPTION
## Summary
- add a collapsible mobile navigation toggle and responsive spacing for the top bar
- refactor dashboard widgets and cards for swipeable mobile layouts and tighter padding
- rework calendar and clients screens with stacked controls and mobile-friendly cards

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68c897fd68508324bf57c2cc391f63b6