### PR TITLE
feat: centralize design tokens and apply to ui

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -16,7 +16,7 @@
   input:not([type="checkbox"]):not([type="radio"]),
   select,
   textarea {
-    @apply rounded-2xl border border-white/40 bg-white/90 px-4 py-3 text-brand-navy placeholder:text-brand-navy/50 shadow-sm transition focus:border-brand-bubble focus:outline-none focus:ring-2 focus:ring-brand-bubble/40;
+    @apply rounded-2xl border border-border-highlight bg-surface-strong px-space-md py-space-sm text-brand-navy placeholder:text-brand-navy/50 shadow-elevation-xs transition focus:border-brand-bubble focus:outline-none focus:ring-2 focus:ring-brand-bubble/40;
   }
 
   label {
@@ -30,10 +30,10 @@
 
 @layer components {
   .glass-panel {
-    @apply rounded-[2.25rem] border border-white/20 bg-white/10 shadow-soft backdrop-blur-2xl;
+    @apply rounded-6xl border border-border-subtle bg-surface-glass shadow-elevation-lg backdrop-blur-2xl;
   }
 
   .nav-link {
-    @apply rounded-full px-4 py-2 text-sm font-semibold text-white/90 transition hover:bg-white/15;
+    @apply rounded-full px-space-md py-space-xs text-body-sm font-emphasis transition hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-highlight/60;
   }
 }

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -5,7 +5,7 @@ export default function Card({ children, className = '' }: { children: ReactNode
   return (
     <div
       className={clsx(
-        'rounded-[2rem] border border-white/30 bg-white/85 p-6 text-brand-navy shadow-soft backdrop-blur-xl',
+        'rounded-5xl border border-border-strong bg-surface-frosted p-space-lg text-brand-navy shadow-elevation-md backdrop-blur-xl',
         className
       )}
     >

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -11,27 +11,29 @@ const navLinks = [
   { href: "/employees", label: "Employees" },
   { href: "/reports", label: "Reports" },
   { href: "/messages", label: "Messages" },
-  { href: "/settings", label: "Settings" },
+  { href: "/settings", label: "Settings" }
 ];
 
 export default function TopNav() {
   const pathname = usePathname();
 
   return (
-    <header className="sticky top-0 z-40 flex justify-center px-4 pt-6">
-      <div className="glass-panel flex w-full max-w-6xl items-center justify-between px-6 py-4">
-        <Link href="/" className="group flex items-center gap-4 text-white">
-          <span className="grid h-12 w-12 place-items-center rounded-full bg-white/90 text-2xl shadow-inner ring-4 ring-white/40 transition-transform duration-300 group-hover:-rotate-12">
+    <header className="sticky top-0 z-40 flex justify-center px-space-md pt-space-lg">
+      <div className="glass-panel flex w-full max-w-6xl items-center justify-between px-space-lg py-space-md">
+        <Link href="/" className="group flex items-center gap-space-md text-text-inverse">
+          <span className="grid h-space-3xl w-space-3xl place-items-center rounded-full bg-surface-strong text-title-md shadow-inner ring-4 ring-border-highlight transition-transform duration-300 group-hover:-rotate-12">
             🐾
           </span>
           <div className="flex flex-col leading-tight">
-            <span className="text-xs font-semibold uppercase tracking-[0.4em] text-white/70">Scruffy</span>
-            <span className="text-2xl font-black text-white transition-colors duration-300 group-hover:text-brand-cream">
+            <span className="text-label-xs font-emphasis uppercase tracking-eyebrow text-text-inverse-subtle">
+              Scruffy
+            </span>
+            <span className="text-title-md font-brand tracking-brand text-text-inverse transition-colors duration-300 group-hover:text-brand-cream">
               Butts
             </span>
           </div>
         </Link>
-        <nav className="flex flex-wrap items-center justify-end gap-2 text-sm">
+        <nav className="flex flex-wrap items-center justify-end gap-space-xs text-body-sm">
           {navLinks.map((link) => {
             const isActive = pathname?.startsWith(link.href);
             return (
@@ -41,8 +43,8 @@ export default function TopNav() {
                 className={clsx(
                   "nav-link",
                   isActive
-                    ? "bg-white/25 text-white shadow-sm"
-                    : "text-white/80 hover:text-white"
+                    ? "bg-surface-overlay text-text-inverse shadow-elevation-sm"
+                    : "text-text-inverse-muted hover:text-text-inverse"
                 )}
               >
                 {link.label}

--- a/components/Widget.tsx
+++ b/components/Widget.tsx
@@ -11,10 +11,10 @@ interface WidgetProps {
 }
 
 const backgroundMap: Record<Required<WidgetProps>['color'], string> = {
-  blue: 'bg-gradient-to-br from-[#1D4DFF] via-[#2E8CFF] to-[#55C3FF]',
+  blue: 'bg-gradient-to-br from-brand-oceanDark via-brand-ocean to-brand-oceanLight',
   pink: 'bg-gradient-to-br from-brand-bubble to-brand-bubbleDark',
-  purple: 'bg-gradient-to-br from-brand-lavender via-[#5B7DFF] to-primary',
-  green: 'bg-gradient-to-br from-brand-mint via-[#3CE0B7] to-[#43F0C5]'
+  purple: 'bg-gradient-to-br from-brand-lavender via-brand-indigoGlow to-primary',
+  green: 'bg-gradient-to-br from-brand-mint via-brand-mintBright to-brand-mintLuminous'
 }
 
 export default function Widget({
@@ -30,20 +30,20 @@ export default function Widget({
   return (
     <div
       className={clsx(
-        'relative overflow-hidden rounded-[2rem] border border-white/25 text-white shadow-soft backdrop-blur-xl',
+        'relative overflow-hidden rounded-5xl border border-border-contrast text-text-inverse shadow-elevation-lg backdrop-blur-xl',
         gradient,
         className
       )}
     >
-      <div className="pointer-events-none absolute -right-16 -top-24 h-64 w-64 rounded-full bg-white/25 blur-[120px]" />
-      <div className="pointer-events-none absolute bottom-[-30%] left-[-20%] h-80 w-80 rounded-full bg-white/10 blur-[160px]" />
+      <div className="pointer-events-none absolute -right-space-4xl -top-space-5xl h-space-7xl w-space-7xl rounded-full bg-surface-overlay blur-glow" />
+      <div className="pointer-events-none absolute bottom-[-30%] left-[-20%] h-space-8xl w-space-8xl rounded-full bg-surface-glass blur-halo" />
       {!hideHeader && (
-        <div className="relative flex items-center justify-between px-6 pt-6">
-          <h2 className="text-lg font-semibold tracking-tight drop-shadow-md">{title}</h2>
+        <div className="relative flex items-center justify-between px-space-lg pt-space-lg">
+          <h2 className="text-title-sm font-emphasis tracking-tight drop-shadow-md">{title}</h2>
           {headerContent}
         </div>
       )}
-      <div className={clsx('relative px-6 pb-6', hideHeader ? 'pt-6' : 'pt-4')}>
+      <div className={clsx('relative px-space-lg pb-space-lg', hideHeader ? 'pt-space-lg' : 'pt-space-md')}>
         {children}
       </div>
     </div>

--- a/docs/style-guide.md
+++ b/docs/style-guide.md
@@ -1,0 +1,69 @@
+# UI Style Guide
+
+This project now relies on a shared set of Tailwind tokens to keep our surfaces, typography, and spacing consistent. Tokens are defined in [`tailwind.config.ts`](../tailwind.config.ts) and surfaced as utility classes. You can also import the `designTokens` export when a JavaScript representation is helpful (for example, when configuring charts).
+
+## Color tokens
+
+| Token | Utility prefix | Notes |
+| --- | --- | --- |
+| `colors.primary.*`, `colors.secondary.*`, `colors.brand.*` | `bg-`, `text-`, `from-`, `to-` | Brand palette for gradients, accents, and status messaging. |
+| `colors.surface.glass` | `bg-surface-glass` | Translucent glass backgrounds (used by the glass panel). |
+| `colors.surface.hover` | `bg-surface-hover` | Hover overlays for navigation and interactive elements. |
+| `colors.surface.overlay` | `bg-surface-overlay` | High-contrast overlays such as active navigation states. |
+| `colors.surface.frosted` | `bg-surface-frosted` | Solid frosted cards. |
+| `colors.surface.strong` | `bg-surface-strong` | Opaque chips or avatar backgrounds. |
+| `colors.border.*` | `border-border-*`, `ring-border-*` | Border and ring accents tuned for glass surfaces. |
+| `colors.text.inverse*` | `text-text-inverse*` | Inverse text levels when sitting on dark or gradient surfaces. |
+
+## Spacing tokens
+
+Spacing tokens live under `spacing.space-*` and are available through sizing, padding, margin, gap, and inset utilities (e.g. `px-space-lg`, `gap-space-xs`, `h-space-3xl`).
+
+| Token | Value | Common usage |
+| --- | --- | --- |
+| `space-2xs` | `0.25rem` | Tight gutters and icon paddings. |
+| `space-xs` | `0.5rem` | Small gaps and compact controls. |
+| `space-sm` | `0.75rem` | Input padding and condensed stack spacing. |
+| `space-md` | `1rem` | Default body padding and gaps. |
+| `space-lg` | `1.5rem` | Card padding and section gutters. |
+| `space-xl` | `2rem` | Wider layout gutters. |
+| `space-3xl` | `3rem` | Avatar sizing (e.g. the nav paw icon). |
+| `space-4xl` to `space-8xl` | `4rem` – `20rem` | Large glows and hero layout offsets. |
+
+## Typography tokens
+
+Typography is grouped under `typography`:
+
+- Font sizes: `text-label-xs`, `text-body-sm`, `text-body-md`, `text-title-sm`, `text-title-md`, `text-display-sm`
+- Font weights: `font-regular`, `font-medium`, `font-emphasis`, `font-strong`, `font-display`, `font-brand`
+- Letter spacing helpers: `tracking-eyebrow` for the eyebrow/label treatment and `tracking-brand` for subtle negative spacing on display text.
+
+Combine font-size and weight tokens to match the product voice. For example, the brand wordmark uses `text-title-md font-brand tracking-brand`.
+
+## Elevation tokens
+
+Elevation tokens map to the `shadow-elevation-*` utilities. Use larger values sparingly to maintain depth hierarchy.
+
+| Token | Use case |
+| --- | --- |
+| `shadow-elevation-xs` | Inputs and lightweight controls. |
+| `shadow-elevation-sm` | Active navigation or chips. |
+| `shadow-elevation-md` | Cards and widgets on light surfaces. |
+| `shadow-elevation-lg` | Prominent glass panels and dashboard widgets. |
+
+## Usage examples
+
+```tsx
+// Navigation link (TopNav.tsx)
+<Link
+  href="/dashboard"
+  className="nav-link text-text-inverse-muted hover:text-text-inverse"
+>
+  Dashboard
+</Link>
+
+// Widget container (Widget.tsx)
+<div className="rounded-5xl border border-border-contrast bg-gradient-to-br from-brand-oceanDark ... shadow-elevation-lg" />
+```
+
+Refer back to this guide when building new components so that colors, spacing, typography, and elevation stay consistent across the application.

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,123 @@
 import type { Config } from 'tailwindcss'
 
+export const designTokens = {
+  colors: {
+    primary: {
+      light: '#63C4FF',
+      DEFAULT: '#1E7BFF',
+      dark: '#0F4ED7'
+    },
+    secondary: {
+      DEFAULT: '#FF66C4',
+      dark: '#FF3D9E',
+      pink: '#FF66C4',
+      purple: '#7C5CFF',
+      green: '#2CD4A6'
+    },
+    brand: {
+      sky: '#5CC2FF',
+      blue: '#1A6BFF',
+      navy: '#08245A',
+      bubble: '#FF66C4',
+      bubbleDark: '#FF3D9E',
+      mint: '#31D8AF',
+      lavender: '#7C5CFF',
+      sunshine: '#FFD166',
+      cream: '#F9FBFF',
+      oceanDark: '#1D4DFF',
+      ocean: '#2E8CFF',
+      oceanLight: '#55C3FF',
+      indigoGlow: '#5B7DFF',
+      mintBright: '#3CE0B7',
+      mintLuminous: '#43F0C5'
+    },
+    surface: {
+      glass: 'rgba(255, 255, 255, 0.10)',
+      hover: 'rgba(255, 255, 255, 0.15)',
+      overlay: 'rgba(255, 255, 255, 0.25)',
+      frosted: 'rgba(255, 255, 255, 0.85)',
+      strong: 'rgba(255, 255, 255, 0.90)'
+    },
+    border: {
+      subtle: 'rgba(255, 255, 255, 0.20)',
+      contrast: 'rgba(255, 255, 255, 0.25)',
+      strong: 'rgba(255, 255, 255, 0.30)',
+      highlight: 'rgba(255, 255, 255, 0.40)'
+    },
+    text: {
+      inverse: '#FFFFFF',
+      'inverse-strong': 'rgba(255, 255, 255, 0.90)',
+      'inverse-muted': 'rgba(255, 255, 255, 0.80)',
+      'inverse-subtle': 'rgba(255, 255, 255, 0.70)'
+    }
+  },
+  spacing: {
+    'space-2xs': '0.25rem',
+    'space-xs': '0.5rem',
+    'space-sm': '0.75rem',
+    'space-md': '1rem',
+    'space-lg': '1.5rem',
+    'space-xl': '2rem',
+    'space-2xl': '2.5rem',
+    'space-3xl': '3rem',
+    'space-4xl': '4rem',
+    'space-5xl': '6rem',
+    'space-6xl': '10rem',
+    'space-7xl': '16rem',
+    'space-8xl': '20rem'
+  },
+  typography: {
+    fontSize: {
+      'label-xs': ['0.75rem', { lineHeight: '1rem' }],
+      'body-sm': ['0.875rem', { lineHeight: '1.35rem' }],
+      'body-md': ['1rem', { lineHeight: '1.5rem' }],
+      'title-sm': ['1.125rem', { lineHeight: '1.75rem' }],
+      'title-md': ['1.5rem', { lineHeight: '1.95rem', letterSpacing: '-0.01em' }],
+      'display-sm': ['2rem', { lineHeight: '2.5rem', letterSpacing: '-0.02em' }]
+    },
+    fontWeight: {
+      regular: '400',
+      medium: '500',
+      emphasis: '600',
+      strong: '700',
+      display: '800',
+      brand: '900'
+    },
+    letterSpacing: {
+      eyebrow: '0.4em',
+      brand: '-0.01em',
+      wide: '0.08em'
+    },
+    lineHeight: {
+      snug: '1.35',
+      relaxed: '1.5'
+    }
+  },
+  elevation: {
+    'elevation-xs': '0 6px 18px -10px rgba(8, 36, 90, 0.2)',
+    'elevation-sm': '0 12px 30px -12px rgba(8, 36, 90, 0.25)',
+    'elevation-md': '0 18px 45px -20px rgba(20, 90, 200, 0.35)',
+    'elevation-lg': '0 24px 55px -25px rgba(20, 90, 200, 0.55)'
+  },
+  effects: {
+    blur: {
+      glow: '120px',
+      halo: '160px'
+    }
+  }
+} satisfies {
+  colors: Record<string, unknown>
+  spacing: Record<string, string>
+  typography: {
+    fontSize: Record<string, [string, { lineHeight: string; letterSpacing?: string }]>
+    fontWeight: Record<string, string | number>
+    letterSpacing: Record<string, string>
+    lineHeight: Record<string, string>
+  }
+  elevation: Record<string, string>
+  effects: { blur: Record<string, string> }
+};
+
 const config: Config = {
   content: [
     './app/**/*.{js,ts,jsx,tsx}',
@@ -7,41 +125,21 @@ const config: Config = {
   ],
   theme: {
     extend: {
-      colors: {
-        primary: {
-          light: '#63C4FF',
-          DEFAULT: '#1E7BFF',
-          dark: '#0F4ED7'
-        },
-        secondary: {
-          DEFAULT: '#FF66C4',
-          dark: '#FF3D9E',
-          pink: '#FF66C4',
-          purple: '#7C5CFF',
-          green: '#2CD4A6'
-        },
-        brand: {
-          sky: '#5CC2FF',
-          blue: '#1A6BFF',
-          navy: '#08245A',
-          bubble: '#FF66C4',
-          bubbleDark: '#FF3D9E',
-          mint: '#31D8AF',
-          lavender: '#7C5CFF',
-          sunshine: '#FFD166',
-          cream: '#F9FBFF'
-        }
-      },
+      colors: designTokens.colors,
+      spacing: designTokens.spacing,
+      fontSize: designTokens.typography.fontSize,
+      fontWeight: designTokens.typography.fontWeight,
+      letterSpacing: designTokens.typography.letterSpacing,
+      lineHeight: designTokens.typography.lineHeight,
+      boxShadow: designTokens.elevation,
       fontFamily: {
         sans: ['var(--font-sans)', 'system-ui', 'sans-serif']
       },
-      boxShadow: {
-        soft: '0 24px 55px -25px rgba(20, 90, 200, 0.55)'
-      },
       borderRadius: {
-        '3xl': '1.75rem',
-        '4xl': '2.5rem'
-      }
+        '5xl': '2rem',
+        '6xl': '2.25rem'
+      },
+      blur: designTokens.effects.blur
     }
   },
   plugins: []


### PR DESCRIPTION
## Summary
- define color, spacing, typography, elevation, and blur design tokens in Tailwind and expose them via the designTokens export
- refactor shared surfaces (TopNav, Widget, Card, glass panel) to consume the new token utilities instead of ad-hoc values
- add a style guide documenting how to apply the tokens across the app

## Testing
- npm run lint
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c897eec4b88324a6674e0f328d9b51