### PR TITLE
Add confetti celebration after successful login

### DIFF
--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -12,6 +12,25 @@ export default function LoginForm() {
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
 
+  const launchConfetti = async () => {
+    const { default: confetti } = await import('canvas-confetti');
+
+    const defaults = {
+      startVelocity: 45,
+      spread: 360,
+      ticks: 80,
+      gravity: 0.8,
+      zIndex: 2000,
+      colors: ['#f472b6', '#38bdf8', '#facc15', '#34d399', '#a855f7'],
+    } as const;
+
+    confetti({ ...defaults, particleCount: 140, origin: { x: 0.2, y: 0.6 } });
+    confetti({ ...defaults, particleCount: 140, origin: { x: 0.8, y: 0.6 } });
+    confetti({ ...defaults, particleCount: 220, scalar: 1.1, origin: { x: 0.5, y: 0.45 } });
+
+    await new Promise((resolve) => setTimeout(resolve, 800));
+  };
+
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setErr(null);
@@ -19,11 +38,11 @@ export default function LoginForm() {
     try {
       const { error } = await supabase.auth.signInWithPassword({ email, password });
       if (error) throw error;
+      await launchConfetti().catch(() => undefined);
       // Use a full page reload so server components can pick up the new session.
       window.location.href = '/';
     } catch (e: any) {
       setErr(e?.message || 'Sign in failed');
-    } finally {
       setLoading(false);
     }
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@supabase/auth-helpers-nextjs": "^0.9.0",
         "@supabase/ssr": "^0.3.0",
         "@supabase/supabase-js": "^2.0.0",
+        "canvas-confetti": "^1.9.3",
         "clsx": "^2.0.0",
         "next": "^14.0.0",
         "react": "^18.2.0",
@@ -1905,6 +1906,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.3.tgz",
+      "integrity": "sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@supabase/auth-helpers-nextjs": "^0.9.0",
     "@supabase/ssr": "^0.3.0",
     "@supabase/supabase-js": "^2.0.0",
+    "canvas-confetti": "^1.9.3",
     "clsx": "^2.0.0",
     "next": "^14.0.0",
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- add a client-side confetti launcher that runs on successful logins before redirecting
- add the `canvas-confetti` dependency to power the celebration effect

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8c3d42e9c8324a340331d24966b66