### PR TITLE
Amplify login celebration with confetti and sound

### DIFF
--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { supabase } from '@/lib/supabase/client';
 
@@ -11,6 +11,143 @@ export default function LoginForm() {
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const [err, setErr] = useState<string | null>(null);
+  const celebrationAudioRef = useRef<AudioContext | null>(null);
+
+  const playCelebrationSound = async () => {
+    try {
+      if (typeof window === 'undefined') return;
+
+      type WindowWithWebkitAudio = Window & {
+        webkitAudioContext?: typeof AudioContext;
+      };
+
+      const AudioContextClass =
+        window.AudioContext || (window as WindowWithWebkitAudio).webkitAudioContext;
+
+      if (!AudioContextClass) return;
+
+      if (!celebrationAudioRef.current) {
+        celebrationAudioRef.current = new AudioContextClass();
+      }
+
+      const audioContext = celebrationAudioRef.current;
+      if (!audioContext) return;
+
+      if (audioContext.state === 'suspended') {
+        await audioContext.resume();
+      }
+
+      const now = audioContext.currentTime;
+      const masterGain = audioContext.createGain();
+      masterGain.gain.setValueAtTime(0, now);
+      masterGain.gain.linearRampToValueAtTime(0.75, now + 0.05);
+      masterGain.gain.linearRampToValueAtTime(0.45, now + 0.25);
+      masterGain.gain.exponentialRampToValueAtTime(0.0001, now + 1.7);
+      masterGain.connect(audioContext.destination);
+
+      const playTone = (
+        frequency: number,
+        delay: number,
+        duration: number,
+        type: OscillatorType = 'sine',
+      ) => {
+        const oscillator = audioContext.createOscillator();
+        oscillator.type = type;
+        oscillator.frequency.setValueAtTime(frequency, now + delay);
+
+        const gain = audioContext.createGain();
+        const startTime = now + delay;
+        gain.gain.setValueAtTime(0, startTime);
+        gain.gain.linearRampToValueAtTime(1, startTime + 0.04);
+        gain.gain.exponentialRampToValueAtTime(0.001, startTime + duration);
+
+        oscillator.connect(gain);
+        gain.connect(masterGain);
+        oscillator.start(startTime);
+        oscillator.stop(startTime + duration + 0.3);
+      };
+
+      const flourish: Array<[number, number, number, OscillatorType?]> = [
+        [523.25, 0, 1.4, 'triangle'],
+        [659.25, 0.06, 1.35, 'triangle'],
+        [783.99, 0.12, 1.3, 'triangle'],
+        [1046.5, 0.42, 1.1, 'triangle'],
+      ];
+
+      flourish.forEach(([freq, delay, duration, type]) => playTone(freq, delay, duration, type));
+
+      playTone(392, 0.18, 1.3, 'sine');
+      playTone(1567.98, 0.24, 1.2, 'sine');
+
+      window.setTimeout(() => {
+        masterGain.disconnect();
+      }, 1900);
+    } catch {
+      // Ignore playback failures (e.g., browser autoplay restrictions).
+    }
+  };
+
+  const launchConfetti = async () => {
+    const { default: confetti } = await import('canvas-confetti');
+
+    const defaults = {
+      startVelocity: 65,
+      spread: 360,
+      ticks: 160,
+      gravity: 0.9,
+      decay: 0.92,
+      zIndex: 2000,
+      colors: ['#f472b6', '#38bdf8', '#facc15', '#34d399', '#a855f7', '#f97316', '#fbbf24'],
+    } as const;
+
+    type ConfettiOptions = NonNullable<Parameters<typeof confetti>[0]>;
+
+    const fire = (particleCount: number, options: ConfettiOptions = {}) =>
+      confetti({ ...defaults, particleCount, ...options });
+
+    fire(420, { scalar: 1.6, startVelocity: 85, origin: { x: 0.5, y: 0.45 } });
+    fire(260, { angle: 60, spread: 70, startVelocity: 75, scalar: 1.3, origin: { x: 0, y: 0.8 } });
+    fire(260, { angle: 120, spread: 70, startVelocity: 75, scalar: 1.3, origin: { x: 1, y: 0.8 } });
+
+    await new Promise<void>((resolve) => {
+      const duration = 3200;
+      const animationEnd = Date.now() + duration;
+
+      const interval = window.setInterval(() => {
+        const timeLeft = animationEnd - Date.now();
+        const progress = Math.max(0, 1 - timeLeft / duration);
+
+        fire(180 + Math.round(120 * progress), {
+          startVelocity: 60,
+          scalar: 1.2 + progress * 0.3,
+          ticks: 140,
+          origin: { x: Math.random() * 0.6 + 0.2, y: 0.1 + Math.random() * 0.3 },
+        });
+
+        fire(160, {
+          angle: 60,
+          spread: 90,
+          startVelocity: 55,
+          origin: { x: Math.random() * 0.15, y: 0.85 + Math.random() * 0.05 },
+        });
+
+        fire(160, {
+          angle: 120,
+          spread: 90,
+          startVelocity: 55,
+          origin: { x: 0.85 + Math.random() * 0.15, y: 0.85 + Math.random() * 0.05 },
+        });
+
+        if (timeLeft <= 0) {
+          window.clearInterval(interval);
+          fire(520, { scalar: 1.7, startVelocity: 90, ticks: 200, origin: { x: 0.5, y: 0.45 } });
+          fire(360, { spread: 120, decay: 0.9, scalar: 1.4, origin: { x: 0.1, y: 0.92 } });
+          fire(360, { spread: 120, decay: 0.9, scalar: 1.4, origin: { x: 0.9, y: 0.92 } });
+          window.setTimeout(resolve, 700);
+        }
+      }, 170);
+    });
+  };
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -19,11 +156,12 @@ export default function LoginForm() {
     try {
       const { error } = await supabase.auth.signInWithPassword({ email, password });
       if (error) throw error;
+      void playCelebrationSound().catch(() => undefined);
+      await launchConfetti().catch(() => undefined);
       // Use a full page reload so server components can pick up the new session.
       window.location.href = '/';
     } catch (e: any) {
       setErr(e?.message || 'Sign in failed');
-    } finally {
       setLoading(false);
     }
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@supabase/auth-helpers-nextjs": "^0.9.0",
         "@supabase/ssr": "^0.3.0",
         "@supabase/supabase-js": "^2.0.0",
+        "canvas-confetti": "^1.9.3",
         "clsx": "^2.0.0",
         "next": "^14.0.0",
         "react": "^18.2.0",
@@ -1905,6 +1906,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.3.tgz",
+      "integrity": "sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@supabase/auth-helpers-nextjs": "^0.9.0",
     "@supabase/ssr": "^0.3.0",
     "@supabase/supabase-js": "^2.0.0",
+    "canvas-confetti": "^1.9.3",
     "clsx": "^2.0.0",
     "next": "^14.0.0",
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- add a client-side confetti launcher that now fires massive sustained bursts before redirecting
- add the `canvas-confetti` dependency to power the celebration effect
- synthesize the happy celebration chime with Web Audio so no binary asset is required
- fix the confetti options typing so the Next.js build succeeds under TypeScript strictness

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c8c3d42e9c8324a340331d24966b66