### PR TITLE
feat: align calendar staff IDs with employees

### DIFF
--- a/app/(app)/calendar/components/CalendarEventCard.tsx
+++ b/app/(app)/calendar/components/CalendarEventCard.tsx
@@ -6,7 +6,7 @@ export interface CalendarEvent {
   end: string | Date;
   type: "appointment" | "shift" | "timeOff";
   notes?: string | null;
-  staffId?: string | null;
+  staffId?: number | null;
   petId?: string | null;
   allDay?: boolean;
 }

--- a/app/(app)/calendar/components/EventDialog.tsx
+++ b/app/(app)/calendar/components/EventDialog.tsx
@@ -14,7 +14,7 @@ type Props = {
     end?: string;
     notes?: string|null;
     allDay?: boolean;
-    staffId?: string | null;
+    staffId?: number | null;
     petId?: string | null;
   };
   staffOptions?: Option[];
@@ -38,7 +38,9 @@ export default function EventDialog({ open, mode, initial, staffOptions = [], on
   const [end, setEnd] = useState<string>(toInputValue(initial?.end ?? initial?.start));
   const [notes, setNotes] = useState(initial?.notes ?? "");
   const [allDay, setAllDay] = useState(initial?.allDay ?? false);
-  const [staffId, setStaffId] = useState(initial?.staffId ?? "");
+  const [staffId, setStaffId] = useState(
+    initial?.staffId != null ? String(initial.staffId) : ""
+  );
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const firstFieldRef = useRef<HTMLInputElement | null>(null);
@@ -51,7 +53,7 @@ export default function EventDialog({ open, mode, initial, staffOptions = [], on
       setEnd(toInputValue(initial?.end ?? initial?.start));
       setNotes(initial?.notes ?? "");
       setAllDay(initial?.allDay ?? false);
-      setStaffId(initial?.staffId ?? "");
+      setStaffId(initial?.staffId != null ? String(initial.staffId) : "");
       setError(null);
       setSaving(false);
       setTimeout(() => firstFieldRef.current?.focus(), 0);
@@ -92,6 +94,11 @@ export default function EventDialog({ open, mode, initial, staffOptions = [], on
     }
     setSaving(true);
     try {
+      const trimmedStaff = staffId.trim();
+      const parsedStaffId = trimmedStaff ? Number(trimmedStaff) : null;
+      const normalizedStaffId = parsedStaffId !== null && Number.isFinite(parsedStaffId)
+        ? parsedStaffId
+        : null;
       await onSubmit({
         title: title.trim(),
         type,
@@ -99,7 +106,7 @@ export default function EventDialog({ open, mode, initial, staffOptions = [], on
         end: normalizedEnd,
         notes: notes.trim() ? notes.trim() : null,
         allDay,
-        staffId: staffId || null,
+        staffId: normalizedStaffId,
       });
       onClose();
     } catch (e: any) {

--- a/app/(app)/calendar/hooks/useCalendarEvents.ts
+++ b/app/(app)/calendar/hooks/useCalendarEvents.ts
@@ -34,15 +34,15 @@ export type NewEvent = {
   start: string | Date;
   end: string | Date;
   notes?: string | null;
-  staffId?: string | null;
+  staffId?: number | null;
   petId?: string | null;
   allDay?: boolean;
 };
 
-export function useCalendarEvents(from: Date, to: Date, q?: { staffId?: string; type?: string }) {
+export function useCalendarEvents(from: Date, to: Date, q?: { staffId?: number; type?: string }) {
   const params = new URLSearchParams();
   params.set("from", fmt(from)); params.set("to", fmt(to));
-  if (q?.staffId) params.set("staffId", q.staffId);
+  if (q?.staffId !== undefined && Number.isFinite(q.staffId)) params.set("staffId", String(q.staffId));
   if (q?.type) params.set("type", q.type);
 
   const { data, error: swrError, isLoading, mutate, isValidating } = useSWR(`/api/calendar?${params.toString()}`, fetcher, {

--- a/app/(app)/calendar/page.tsx
+++ b/app/(app)/calendar/page.tsx
@@ -193,7 +193,7 @@ export default function CalendarPage() {
       start: base.toISOString(),
       end: end.toISOString(),
       allDay: true,
-      staffId: filters.staffId ?? "",
+      staffId: filters.staffId,
     });
     setDialogOpen(true);
   };
@@ -318,8 +318,11 @@ export default function CalendarPage() {
             <select
               id="calendar-staff"
               className="rounded border border-gray-300 px-2 py-1"
-              value={filters.staffId ?? ""}
-              onChange={(event) => setFilters({ ...filters, staffId: event.target.value || undefined })}
+              value={filters.staffId !== undefined ? String(filters.staffId) : ""}
+              onChange={(event) => {
+                const value = event.target.value.trim();
+                setFilters({ ...filters, staffId: value ? Number(value) : undefined });
+              }}
             >
               <option value="">All staff</option>
               {staffOptions.map((option) => (

--- a/app/(app)/calendar/state/calendarStore.ts
+++ b/app/(app)/calendar/state/calendarStore.ts
@@ -3,7 +3,7 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 type View = "month" | "week" | "day";
-type Filters = { staffId?: string; type?: "appointment"|"shift"|"timeOff" };
+type Filters = { staffId?: number; type?: "appointment"|"shift"|"timeOff" };
 
 type CalendarState = {
   view: View;
@@ -30,6 +30,10 @@ export const useCalendarStore = create<CalendarState>()(
       merge: (persisted: any, current) => {
         const hydrated = { ...current, ...persisted } as CalendarState;
         if (persisted?.selectedDate) hydrated.selectedDate = new Date(persisted.selectedDate);
+        if (persisted?.filters?.staffId !== undefined) {
+          const id = Number(persisted.filters.staffId);
+          hydrated.filters.staffId = Number.isFinite(id) ? id : undefined;
+        }
         return hydrated;
       },
     }

--- a/app/api/calendar/route.ts
+++ b/app/api/calendar/route.ts
@@ -5,10 +5,15 @@ export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
   const from = searchParams.get("from") ?? undefined;
   const to = searchParams.get("to") ?? undefined;
-  const staffId = searchParams.get("staffId") ?? undefined;
+  const staffIdParam = searchParams.get("staffId");
+  const staffId = staffIdParam && staffIdParam.trim() !== ""
+    ? Number(staffIdParam)
+    : undefined;
   const type = searchParams.get("type") ?? undefined;
   try {
-    const data = await listEvents({ from, to, staffId, type });
+    const params: { from?: string; to?: string; staffId?: number; type?: string } = { from, to, type };
+    if (staffId !== undefined && Number.isFinite(staffId)) params.staffId = staffId;
+    const data = await listEvents(params);
     return NextResponse.json({ data });
   } catch (e: any) {
     return NextResponse.json({ error: e.message ?? "Failed to list events" }, { status: 400 });

--- a/lib/supabase/calendar.ts
+++ b/lib/supabase/calendar.ts
@@ -3,12 +3,12 @@ import { CalendarEvent, CalendarEventCreate, CalendarEventUpdate, normalizeDate 
 
 const TABLE = "calendar_events";
 
-export async function listEvents(params: { from?: string; to?: string; staffId?: string; type?: string } = {}) {
+export async function listEvents(params: { from?: string; to?: string; staffId?: number; type?: string } = {}) {
   const client = getSupabaseAdmin();
   let q = client.from(TABLE).select("*").order("start", { ascending: true });
   if (params.from) q = q.gte("end", params.from);
   if (params.to) q = q.lte("start", params.to);
-  if (params.staffId) q = q.eq("staffId", params.staffId);
+  if (params.staffId !== undefined) q = q.eq("staffId", params.staffId);
   if (params.type) q = q.eq("type", params.type);
   const { data, error } = await q;
   if (error) throw error;
@@ -29,6 +29,7 @@ export async function createEvent(payload: any) {
     start: normalizeDate(parsed.start),
     end: normalizeDate(parsed.end),
   };
+  body.staffId = parsed.staffId ?? null;
   const client = getSupabaseAdmin();
   const { data, error } = await client.from(TABLE).insert(body).select().single();
   if (error) throw error;
@@ -40,6 +41,7 @@ export async function updateEvent(id: string, payload: any) {
   const body: Record<string, any> = { ...parsed };
   if (parsed.start) body.start = normalizeDate(parsed.start);
   if (parsed.end) body.end = normalizeDate(parsed.end);
+  if (parsed.staffId !== undefined) body.staffId = parsed.staffId ?? null;
   const client = getSupabaseAdmin();
   const { data, error } = await client.from(TABLE).update(body).eq("id", id).select().single();
   if (error) throw error;

--- a/lib/validation/calendar.ts
+++ b/lib/validation/calendar.ts
@@ -1,5 +1,21 @@
 import { z } from "zod";
 
+const StaffIdSchema = z.preprocess(
+  (value) => {
+    if (value === "" || value === undefined) return undefined;
+    if (value === null) return null;
+    if (typeof value === "number") return value;
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (!trimmed) return undefined;
+      const num = Number(trimmed);
+      return Number.isFinite(num) ? num : value;
+    }
+    return value;
+  },
+  z.union([z.number().int().positive(), z.null()]).optional()
+);
+
 export const CalendarEventType = z.enum(["appointment", "shift", "timeOff"]);
 
 export const CalendarEventBase = z.object({
@@ -8,7 +24,7 @@ export const CalendarEventBase = z.object({
   start: z.string().or(z.date()),
   end: z.string().or(z.date()),
   notes: z.string().optional().nullable(),
-  staffId: z.string().optional().nullable(),
+  staffId: StaffIdSchema,
   petId: z.string().optional().nullable(),
   allDay: z.boolean().optional().default(false),
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "zustand": "^5.0.8"
       },
       "devDependencies": {
+        "@types/jsdom": "^21.1.7",
         "@types/node": "^20.5.0",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
@@ -942,6 +943,18 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/jsdom": {
+      "version": "21.1.7",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-21.1.7.tgz",
+      "integrity": "sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
+      }
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -1001,6 +1014,13 @@
         "hoist-non-react-statics": "^3.3.0",
         "redux": "^4.0.0"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",

--- a/package.json
+++ b/package.json
@@ -31,16 +31,17 @@
     "zustand": "^5.0.8"
   },
   "devDependencies": {
+    "@types/jsdom": "^21.1.7",
     "@types/node": "^20.5.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "autoprefixer": "^10.4.14",
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.0.0",
+    "jsdom": "^23.2.0",
     "postcss": "^8.4.21",
     "tailwindcss": "^3.3.2",
     "ts-node": "^10.9.2",
-    "typescript": "^5.1.6",
-    "jsdom": "^23.2.0"
+    "typescript": "^5.1.6"
   }
 }

--- a/supabase/migrations/20251018_calendar_events_staff_bigint.sql
+++ b/supabase/migrations/20251018_calendar_events_staff_bigint.sql
@@ -1,0 +1,18 @@
+-- Alter calendar_events.staffId to bigint and add optional FK to employees
+alter table if exists public.calendar_events
+  alter column "staffId" drop not null;
+
+alter table if exists public.calendar_events
+  alter column "staffId" type bigint using case
+    when "staffId" is null then null
+    when ("staffId"::text ~ '^[0-9]+$') then ("staffId"::text)::bigint
+    else null
+  end;
+
+drop constraint if exists calendar_events_staffid_fkey;
+
+alter table if exists public.calendar_events
+  add constraint calendar_events_staffid_fkey
+  foreign key ("staffId")
+  references public.employees(id)
+  on delete set null;


### PR DESCRIPTION
## Summary
- add a Supabase migration to convert calendar event staff IDs to `bigint` and reference employees
- update calendar validation and Supabase helpers to coerce staff IDs to numbers/null
- adjust calendar UI state and API handling to work with numeric staff IDs
- add missing jsdom type definitions so type-checking succeeds

## Testing
- npm run typecheck
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb3c7ce8788324b75b076743e42016