### PR TITLE
Improve calendar reliability and styling with mock data

### DIFF
--- a/app/(app)/calendar/components/CalendarEventCard.tsx
+++ b/app/(app)/calendar/components/CalendarEventCard.tsx
@@ -13,25 +13,41 @@ export interface CalendarEvent {
 export default function CalendarEventCard({ event, onClick }: { event: CalendarEvent; onClick?: () => void }) {
   const colorClasses =
     event.type === "appointment"
-      ? "bg-blue-100 border-blue-400 text-blue-800"
+      ? "border-l-blue-500/80 bg-blue-50 text-blue-900 hover:border-blue-400/90"
       : event.type === "shift"
-        ? "bg-green-100 border-green-400 text-green-800"
-        : "bg-yellow-100 border-yellow-400 text-yellow-800";
+        ? "border-l-emerald-500/80 bg-emerald-50 text-emerald-900 hover:border-emerald-400/90"
+        : "border-l-amber-500/80 bg-amber-50 text-amber-900 hover:border-amber-400/90";
 
   const s = event.start instanceof Date ? event.start : new Date(event.start);
   const e = event.end instanceof Date ? event.end : new Date(event.end);
   const valid = !Number.isNaN(s.valueOf()) && !Number.isNaN(e.valueOf());
-  const allDayTime = event.allDay || (valid && s.getHours()===0 && s.getMinutes()===0 && e.getHours()===0 && e.getMinutes()===0);
+  const allDayTime =
+    event.allDay ||
+    (valid && s.getHours() === 0 && s.getMinutes() === 0 && e.getHours() === 0 && e.getMinutes() === 0);
   const time = valid
-    ? (allDayTime
-      ? "All Day"
-      : `${s.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })} – ${e.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })}`)
+    ? allDayTime
+      ? "All day"
+      : `${s.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" })} – ${e.toLocaleTimeString([], {
+          hour: "numeric",
+          minute: "2-digit",
+        })}`
     : "";
 
   return (
-    <div className={`border rounded px-2 py-1 text-sm cursor-pointer ${colorClasses}`} onClick={onClick} draggable={false}>
-      <div className="font-medium line-clamp-1">{event.title}</div>
-      {time && <div className="text-xs">{time}</div>}
-    </div>
+    <button
+      type="button"
+      onClick={onClick}
+      className={`group w-full rounded-md border border-transparent border-l-4 px-3 py-2 text-left text-sm shadow-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300 ${colorClasses}`}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <span className="truncate font-semibold" title={event.title}>{event.title}</span>
+        {time && <span className="shrink-0 text-xs font-medium opacity-80">{time}</span>}
+      </div>
+      {event.notes && event.notes.trim() && (
+        <p className="mt-1 truncate text-xs opacity-80" title={event.notes ?? undefined}>
+          {event.notes}
+        </p>
+      )}
+    </button>
   );
 }

--- a/app/(app)/calendar/components/CalendarGrid.tsx
+++ b/app/(app)/calendar/components/CalendarGrid.tsx
@@ -26,52 +26,61 @@ export default function CalendarGrid({ date, events, onSelectDay, onSelectEvent,
   const monthStart = startOfMonth(date);
   const gridStart = startOfWeek(monthStart);
   const cells: Date[] = [];
-  for (let i=0;i<42;i++) cells.push(addDays(gridStart, i));
+  for (let i = 0; i < 42; i += 1) cells.push(addDays(gridStart, i));
+  const dayLabels = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
   return (
-    <div className="grid grid-cols-7 gap-px bg-gray-200 rounded overflow-hidden">
-      {["Mon","Tue","Wed","Thu","Fri","Sat","Sun"].map((d)=>(
-        <div key={d} className="bg-white p-2 text-xs font-semibold">{d}</div>
-      ))}
-      {cells.map((d, idx) => {
-        const inMonth = d.getMonth() === date.getMonth();
-        const items = eventsForDay(d, events);
-        const dayEvents = items.slice(0,3);
-        const more = Math.max(items.length - dayEvents.length, 0);
+    <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+      <div className="grid grid-cols-7 border-b border-gray-200 bg-slate-50 text-[0.65rem] font-semibold uppercase tracking-wide text-slate-600 sm:text-xs">
+        {dayLabels.map((label) => (
+          <div key={label} className="px-3 py-2 text-center">{label}</div>
+        ))}
+      </div>
+      <div className="grid grid-cols-7">
+        {cells.map((d, idx) => {
+          const inMonth = d.getMonth() === date.getMonth();
+          const items = eventsForDay(d, events);
+          const dayEvents = items.slice(0, 3);
+          const more = Math.max(items.length - dayEvents.length, 0);
+          const isToday = sameDay(d, new Date());
+          const isWeekend = idx % 7 >= 5;
+          const isEndOfWeek = (idx + 1) % 7 === 0;
+          let backgroundClass = inMonth ? "bg-white" : "bg-slate-50 text-slate-400";
+          if (inMonth && isWeekend) backgroundClass = "bg-slate-50";
 
-        return (
-          <div
-            key={idx}
-            className={`bg-white min-h-[100px] p-2 ${inMonth ? "" : "bg-gray-50 text-gray-400"} ${sameDay(d, new Date()) ? "border border-blue-500" : ""}`}
-          >
-            <div className="flex justify-between items-center">
-              <button
-                type="button"
-                className="text-xs font-medium hover:underline"
-                onClick={()=>onSelectDay(d)}
-              >
-                {d.getDate()}
-              </button>
-            </div>
-            <div className="mt-2 space-y-1">
-              {dayEvents.map((ev)=>(
-                <div key={ev.id}>
-                  <CalendarEventCard event={ev} onClick={()=>onSelectEvent(ev)} />
-                </div>
-              ))}
-              {more>0 && (
+          return (
+            <div
+              key={`${d.toISOString()}-${idx}`}
+              className={`relative min-h-[140px] border-b border-r border-gray-200 p-3 text-xs transition-colors ${backgroundClass} hover:bg-sky-50 focus-within:bg-sky-50 ${isToday ? "ring-2 ring-inset ring-blue-500" : ""} ${isEndOfWeek ? "border-r-0" : ""}`}
+            >
+              <div className="flex items-start justify-between">
                 <button
                   type="button"
-                  onClick={()=>onShowOverflow(d)}
-                  className="text-xs text-blue-600 hover:underline"
+                  aria-label={`Create event on ${d.toLocaleDateString()}`}
+                  onClick={() => onSelectDay(d)}
+                  className={`flex h-7 w-7 items-center justify-center rounded-full text-xs font-semibold transition ${isToday ? "bg-blue-600 text-white shadow" : inMonth ? "text-slate-700 hover:bg-blue-50" : "text-slate-400"}`}
                 >
-                  +{more} more
+                  {d.getDate()}
                 </button>
-              )}
+              </div>
+              <div className="mt-3 flex flex-col gap-1">
+                {dayEvents.map((ev) => (
+                  <CalendarEventCard key={ev.id} event={ev} onClick={() => onSelectEvent(ev)} />
+                ))}
+                {more > 0 && (
+                  <button
+                    type="button"
+                    onClick={() => onShowOverflow(d)}
+                    className="text-left text-xs font-semibold text-blue-600 hover:text-blue-700"
+                  >
+                    +{more} more
+                  </button>
+                )}
+              </div>
             </div>
-          </div>
-        );
-      })}
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/app/(app)/calendar/components/DayView.tsx
+++ b/app/(app)/calendar/components/DayView.tsx
@@ -1,21 +1,44 @@
 "use client";
 import CalendarEventCard, { type CalendarEvent } from "./CalendarEventCard";
+import { startOfDay, endOfDay } from "../utils/date";
+
+const dayHeaderFormatter = new Intl.DateTimeFormat(undefined, {
+  weekday: "long",
+  month: "long",
+  day: "numeric",
+  year: "numeric",
+});
 
 export default function DayView({ date, events, onSelectEvent }: { date: Date; events: CalendarEvent[]; onSelectEvent: (e: CalendarEvent)=>void }) {
   const list = events
-    .filter((ev)=>{
-      const s = new Date(ev.start); const e = new Date(ev.end);
-      const d0 = new Date(date); d0.setHours(0,0,0,0);
-      const d1 = new Date(date); d1.setHours(23,59,59,999);
-      return s <= d1 && e >= d0;
+    .filter((ev) => {
+      const s = new Date(ev.start);
+      const e = new Date(ev.end);
+      return s <= endOfDay(date) && e >= startOfDay(date);
     })
     .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
+
+  const countLabel = `${list.length} ${list.length === 1 ? "event" : "events"}`;
+
   return (
-    <div className="bg-white rounded border p-3 space-y-2">
-      {list.length===0 && <div className="text-sm text-gray-500">No events</div>}
-      {list.map((ev)=>(
-        <CalendarEventCard key={ev.id} event={ev} onClick={()=>onSelectEvent(ev)} />
-      ))}
+    <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm">
+      <div className="flex flex-col gap-2 border-b border-gray-100 pb-3 sm:flex-row sm:items-center sm:justify-between">
+        <h2 className="text-lg font-semibold text-slate-800">{dayHeaderFormatter.format(date)}</h2>
+        <span className="inline-flex items-center rounded-full border border-slate-200 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-600">
+          {countLabel}
+        </span>
+      </div>
+      <div className="mt-4 space-y-3">
+        {list.length === 0 ? (
+          <p className="rounded border border-dashed border-slate-200 bg-slate-50 px-3 py-3 text-sm text-slate-500">
+            Nothing scheduled for this day yet.
+          </p>
+        ) : (
+          list.map((ev) => (
+            <CalendarEventCard key={ev.id} event={ev} onClick={() => onSelectEvent(ev)} />
+          ))
+        )}
+      </div>
     </div>
   );
 }

--- a/app/(app)/calendar/components/WeekView.tsx
+++ b/app/(app)/calendar/components/WeekView.tsx
@@ -1,31 +1,63 @@
 "use client";
 import CalendarEventCard, { type CalendarEvent } from "./CalendarEventCard";
-import { addDays, startOfWeek } from "../utils/date";
+import { addDays, startOfDay, endOfDay, startOfWeek } from "../utils/date";
+
+const weekdayFormatter = new Intl.DateTimeFormat(undefined, { weekday: "short" });
+const monthDayFormatter = new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" });
 
 export default function WeekView({ date, events, onSelectEvent }: { date: Date; events: CalendarEvent[]; onSelectEvent: (e: CalendarEvent)=>void }) {
   const weekStart = startOfWeek(date);
-  const days: Date[] = []; for (let i=0;i<7;i++) days.push(addDays(weekStart,i));
+  const days: Date[] = [];
+  for (let i = 0; i < 7; i += 1) days.push(addDays(weekStart, i));
+
   return (
-    <div className="grid grid-cols-7 gap-px bg-gray-200 rounded overflow-hidden">
-      {["Mon","Tue","Wed","Thu","Fri","Sat","Sun"].map((d)=>(
-        <div key={d} className="bg-white p-2 text-xs font-semibold">{d}</div>
-      ))}
-      {days.map((d, idx)=>(
-        <div key={idx} className="bg-white min-h-[200px] p-2">
-          <div className="text-xs font-medium">{d.getMonth()+1}/{d.getDate()}</div>
-          <div className="mt-2 space-y-1">
-            {events
-              .filter(ev=>{
-                const s = new Date(ev.start); const e = new Date(ev.end);
-                return d >= new Date(s.setHours(0,0,0,0)) && d <= new Date(e.setHours(23,59,59,999));
-              })
-              .sort((a,b)=> new Date(a.start).getTime() - new Date(b.start).getTime())
-              .map(ev=>(
-              <CalendarEventCard key={ev.id} event={ev} onClick={()=>onSelectEvent(ev)} />
-            ))}
+    <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+      <div className="grid grid-cols-7 border-b border-gray-200 bg-slate-50 text-[0.65rem] font-semibold uppercase tracking-wide text-slate-600 sm:text-xs">
+        {days.map((day) => (
+          <div key={`weekday-${day.toISOString()}`} className="px-3 py-2 text-center">
+            <div>{weekdayFormatter.format(day)}</div>
           </div>
-        </div>
-      ))}
+        ))}
+      </div>
+      <div className="grid grid-cols-7">
+        {days.map((day, index) => {
+          const rangeStart = startOfDay(day);
+          const rangeEnd = endOfDay(day);
+          const dayEvents = events
+            .filter((event) => {
+              const start = new Date(event.start);
+              const end = new Date(event.end);
+              return start <= rangeEnd && end >= rangeStart;
+            })
+            .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime());
+
+          return (
+            <div
+              key={`week-cell-${day.toISOString()}`}
+              className={`min-h-[220px] border-b border-r border-gray-200 p-4 ${index === 6 ? "border-r-0" : ""}`}
+            >
+              <div className="flex items-baseline justify-between">
+                <div>
+                  <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                    {weekdayFormatter.format(day)}
+                  </div>
+                  <div className="text-sm font-semibold text-slate-800">{monthDayFormatter.format(day)}</div>
+                </div>
+              </div>
+              <div className="mt-3 flex flex-col gap-2">
+                {dayEvents.length === 0 && (
+                  <p className="rounded border border-dashed border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-500">
+                    No events scheduled.
+                  </p>
+                )}
+                {dayEvents.map((event) => (
+                  <CalendarEventCard key={event.id} event={event} onClick={() => onSelectEvent(event)} />
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/app/(app)/calendar/hooks/useCalendarEvents.ts
+++ b/app/(app)/calendar/hooks/useCalendarEvents.ts
@@ -39,6 +39,8 @@ export type NewEvent = {
   allDay?: boolean;
 };
 
+type CalendarMeta = { usingMockData?: boolean };
+
 export function useCalendarEvents(from: Date, to: Date, q?: { staffId?: number; type?: string }) {
   const params = new URLSearchParams();
   params.set("from", fmt(from)); params.set("to", fmt(to));
@@ -49,6 +51,7 @@ export function useCalendarEvents(from: Date, to: Date, q?: { staffId?: number; 
     revalidateOnFocus: false,
   });
   const events = useMemo<TCalendarEvent[]>(() => data?.data ?? [], [data]);
+  const meta = useMemo<CalendarMeta>(() => (data?.meta ?? {}) as CalendarMeta, [data]);
 
   const error = useMemo(() => {
     if (!swrError) return undefined;
@@ -90,5 +93,5 @@ export function useCalendarEvents(from: Date, to: Date, q?: { staffId?: number; 
 
   const refresh = useCallback(() => mutate(), [mutate]);
 
-  return { events, error, isLoading: isLoading || isValidating, create, update, remove, refresh };
+  return { events, error, isLoading: isLoading || isValidating, create, update, remove, refresh, meta };
 }

--- a/app/(app)/calendar/page.tsx
+++ b/app/(app)/calendar/page.tsx
@@ -30,6 +30,13 @@ const typeOptions: { value: "appointment" | "shift" | "timeOff" | ""; label: str
 
 type StaffOption = { id: string; label: string };
 
+const mockStaffOptions: StaffOption[] = [
+  { id: "101", label: "Sammy Clippers" },
+  { id: "102", label: "Jules Bubbles" },
+  { id: "103", label: "Marla Snoot" },
+  { id: "104", label: "Avery Whiskers" },
+];
+
 type Toast = { id: number; message: string; tone: "success" | "error" | "info" };
 
 type View = "month" | "week" | "day";
@@ -268,6 +275,14 @@ function CalendarPageContent() {
 
   useEffect(() => {
     let cancelled = false;
+
+    if (usingMockData) {
+      setStaffOptions(mockStaffOptions);
+      return () => {
+        cancelled = true;
+      };
+    }
+
     (async () => {
       try {
         const { data, error } = await supabase
@@ -291,14 +306,15 @@ function CalendarPageContent() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [usingMockData]);
 
   const range = useMemo(() => computeRange(view, selectedDate), [view, selectedDate]);
 
-  const { events, error, isLoading, create, update, remove, refresh } = useCalendarEvents(range.from, range.to, {
+  const { events, error, isLoading, create, update, remove, refresh, meta } = useCalendarEvents(range.from, range.to, {
     staffId: filters.staffId,
     type: filters.type,
   });
+  const usingMockData = Boolean(meta?.usingMockData);
 
   const loadErrorMessage = error?.message?.trim();
 
@@ -606,10 +622,26 @@ function CalendarPageContent() {
             <button
               type="button"
               onClick={refresh}
-              className="rounded border border-red-200 px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-100"
+              className="rounded border border-red-200 bg-white px-2 py-1 text-xs font-semibold text-red-700 hover:bg-red-50"
             >
               Retry
             </button>
+          </div>
+        )}
+        {usingMockData && !error && (
+          <div className="mb-3 flex items-start gap-3 rounded border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+            <span aria-hidden="true" className="text-lg">💡</span>
+            <div>
+              <p className="font-semibold">Showing sample appointments</p>
+              <p className="text-xs text-amber-800 sm:text-sm">
+                We could not find a Supabase service role key, so the calendar is using demo data. Add your key to see live appointments and enable saving changes.
+              </p>
+            </div>
+          </div>
+        )}
+        {!isLoading && !error && viewEvents.length === 0 && (
+          <div className="mb-3 rounded border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-600">
+            No events match the filters yet. Try choosing another staff member, event type, or date range.
           </div>
         )}
 

--- a/app/api/calendar/[id]/route.ts
+++ b/app/api/calendar/[id]/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { getEvent, updateEvent, deleteEvent } from "@/lib/supabase/calendar";
+import { calendarUsesMockData, getEvent, updateEvent, deleteEvent } from "@/lib/supabase/calendar";
 
 export async function GET(_: NextRequest, { params }: { params: { id: string } }) {
   try {
     const data = await getEvent(params.id);
-    return NextResponse.json({ data });
+    return NextResponse.json({ data, meta: { usingMockData: calendarUsesMockData() } });
   } catch (e: any) {
     return NextResponse.json({ error: e.message ?? "Not found" }, { status: 404 });
   }
@@ -14,7 +14,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
   try {
     const json = await req.json();
     const data = await updateEvent(params.id, json);
-    return NextResponse.json({ data });
+    return NextResponse.json({ data, meta: { usingMockData: calendarUsesMockData() } });
   } catch (e: any) {
     return NextResponse.json({ error: e.message ?? "Failed to update" }, { status: 400 });
   }
@@ -23,7 +23,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
 export async function DELETE(_: NextRequest, { params }: { params: { id: string } }) {
   try {
     await deleteEvent(params.id);
-    return NextResponse.json({ ok: true });
+    return NextResponse.json({ ok: true, meta: { usingMockData: calendarUsesMockData() } });
   } catch (e: any) {
     return NextResponse.json({ error: e.message ?? "Failed to delete" }, { status: 400 });
   }

--- a/app/api/calendar/route.ts
+++ b/app/api/calendar/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { listEvents, createEvent } from "@/lib/supabase/calendar";
+import { calendarUsesMockData, listEvents, createEvent } from "@/lib/supabase/calendar";
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
@@ -14,7 +14,10 @@ export async function GET(req: NextRequest) {
     const params: { from?: string; to?: string; staffId?: number; type?: string } = { from, to, type };
     if (staffId !== undefined && Number.isFinite(staffId)) params.staffId = staffId;
     const data = await listEvents(params);
-    return NextResponse.json({ data });
+    return NextResponse.json({
+      data,
+      meta: { usingMockData: calendarUsesMockData() },
+    });
   } catch (e: any) {
     return NextResponse.json({ error: e.message ?? "Failed to list events" }, { status: 400 });
   }
@@ -24,7 +27,7 @@ export async function POST(req: NextRequest) {
   try {
     const json = await req.json();
     const data = await createEvent(json);
-    return NextResponse.json({ data }, { status: 201 });
+    return NextResponse.json({ data, meta: { usingMockData: calendarUsesMockData() } }, { status: 201 });
   } catch (e: any) {
     return NextResponse.json({ error: e.message ?? "Failed to create" }, { status: 400 });
   }

--- a/lib/supabase/calendar.ts
+++ b/lib/supabase/calendar.ts
@@ -1,9 +1,148 @@
+import { randomUUID } from "crypto";
 import { getSupabaseAdmin } from "./server";
-import { CalendarEvent, CalendarEventCreate, CalendarEventUpdate, normalizeDate } from "../validation/calendar";
+import {
+  CalendarEvent,
+  CalendarEventCreate,
+  CalendarEventUpdate,
+  normalizeDate,
+  type TCalendarEvent,
+} from "../validation/calendar";
 
 const TABLE = "calendar_events";
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const usingMockData = !serviceRoleKey || serviceRoleKey.trim() === "";
+
+type CalendarStore = { events: TCalendarEvent[] };
+
+const globalCalendar = globalThis as typeof globalThis & {
+  __scruffyCalendarStore?: CalendarStore;
+};
+
+function generateId() {
+  if (typeof randomUUID === "function") return randomUUID();
+  return `mock-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function atStartOfDay(date: Date) {
+  const copy = new Date(date);
+  copy.setHours(0, 0, 0, 0);
+  return copy;
+}
+
+function buildMockEvent(
+  title: string,
+  type: "appointment" | "shift" | "timeOff",
+  dayOffset: number,
+  startHour: number,
+  durationHours: number,
+  options: { notes?: string; staffId?: number | null; allDay?: boolean } = {},
+): TCalendarEvent {
+  const today = new Date();
+  const start = atStartOfDay(today);
+  start.setDate(start.getDate() + dayOffset);
+  if (!options.allDay) {
+    start.setHours(startHour, 0, 0, 0);
+  }
+  const end = new Date(start);
+  if (options.allDay) {
+    end.setDate(end.getDate() + durationHours);
+    end.setHours(0, 0, 0, 0);
+  } else {
+    end.setHours(start.getHours() + durationHours, start.getMinutes(), 0, 0);
+  }
+
+  const timestamp = new Date().toISOString();
+
+  return CalendarEvent.parse({
+    id: `mock-${generateId()}`,
+    title,
+    type,
+    start: start.toISOString(),
+    end: end.toISOString(),
+    notes: options.notes ?? null,
+    staffId: options.staffId ?? null,
+    petId: null,
+    allDay: options.allDay ?? false,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  });
+}
+
+function createInitialMockEvents(): TCalendarEvent[] {
+  const seed: TCalendarEvent[] = [
+    buildMockEvent("Poodle Spa – Bella", "appointment", 0, 9, 2, {
+      notes: "Full groom with blueberry facial.",
+      staffId: 101,
+    }),
+    buildMockEvent("Evening Shift", "shift", 1, 12, 6, {
+      notes: "Front desk coverage",
+      staffId: 102,
+    }),
+    buildMockEvent("Team Training", "appointment", -2, 14, 1, {
+      notes: "Safety & CPR refresher",
+      staffId: 101,
+    }),
+    buildMockEvent("Day off – Marla", "timeOff", 3, 0, 1, {
+      allDay: true,
+      notes: "Approved PTO",
+      staffId: 103,
+    }),
+    buildMockEvent("Doodle Trim – Gus", "appointment", 5, 10, 1, {
+      staffId: 102,
+    }),
+    buildMockEvent("Giant Breed Bath", "appointment", -5, 11, 3, {
+      staffId: 101,
+    }),
+  ];
+
+  const additional = buildMockEvent("New Client Intake", "appointment", 8, 15, 1, {
+    notes: "Meet & greet for Sparky",
+    staffId: 104,
+  });
+
+  return [...seed, additional].map((event) => CalendarEvent.parse(event));
+}
+
+function ensureMockStore(): CalendarStore {
+  if (!globalCalendar.__scruffyCalendarStore) {
+    globalCalendar.__scruffyCalendarStore = { events: createInitialMockEvents() };
+  }
+  return globalCalendar.__scruffyCalendarStore;
+}
+
+function cloneEvent(event: TCalendarEvent): TCalendarEvent {
+  return { ...event };
+}
+
+function matchesFilters(event: TCalendarEvent, params: { from?: string; to?: string; staffId?: number; type?: string }) {
+  if (params.from) {
+    const fromDate = new Date(params.from);
+    if (new Date(event.end) < fromDate) return false;
+  }
+  if (params.to) {
+    const toDate = new Date(params.to);
+    if (new Date(event.start) > toDate) return false;
+  }
+  if (params.staffId !== undefined) {
+    if (event.staffId !== params.staffId) return false;
+  }
+  if (params.type && event.type !== params.type) return false;
+  return true;
+}
+
+export function calendarUsesMockData() {
+  return usingMockData;
+}
 
 export async function listEvents(params: { from?: string; to?: string; staffId?: number; type?: string } = {}) {
+  if (usingMockData) {
+    const store = ensureMockStore();
+    return store.events
+      .filter((event) => matchesFilters(event, params))
+      .sort((a, b) => new Date(a.start).getTime() - new Date(b.start).getTime())
+      .map((event) => cloneEvent(event));
+  }
+
   const client = getSupabaseAdmin();
   let q = client.from(TABLE).select("*").order("start", { ascending: true });
   if (params.from) q = q.gte("end", params.from);
@@ -16,6 +155,13 @@ export async function listEvents(params: { from?: string; to?: string; staffId?:
 }
 
 export async function getEvent(id: string) {
+  if (usingMockData) {
+    const store = ensureMockStore();
+    const found = store.events.find((event) => event.id === id);
+    if (!found) throw new Error("Not found");
+    return cloneEvent(found);
+  }
+
   const client = getSupabaseAdmin();
   const { data, error } = await client.from(TABLE).select("*").eq("id", id).single();
   if (error) throw error;
@@ -23,6 +169,27 @@ export async function getEvent(id: string) {
 }
 
 export async function createEvent(payload: any) {
+  if (usingMockData) {
+    const parsed = CalendarEventCreate.parse(payload);
+    const now = new Date().toISOString();
+    const next: TCalendarEvent = CalendarEvent.parse({
+      id: `mock-${generateId()}`,
+      title: parsed.title,
+      type: parsed.type,
+      start: normalizeDate(parsed.start),
+      end: normalizeDate(parsed.end),
+      notes: parsed.notes ?? null,
+      staffId: parsed.staffId ?? null,
+      petId: parsed.petId ?? null,
+      allDay: parsed.allDay ?? false,
+      createdAt: now,
+      updatedAt: now,
+    });
+    const store = ensureMockStore();
+    store.events = [...store.events, next];
+    return cloneEvent(next);
+  }
+
   const parsed = CalendarEventCreate.parse(payload);
   const body = {
     ...parsed,
@@ -37,6 +204,28 @@ export async function createEvent(payload: any) {
 }
 
 export async function updateEvent(id: string, payload: any) {
+  if (usingMockData) {
+    const parsed = CalendarEventUpdate.parse(payload);
+    const store = ensureMockStore();
+    const index = store.events.findIndex((event) => event.id === id);
+    if (index === -1) throw new Error("Not found");
+
+    const existing = store.events[index];
+    const next: TCalendarEvent = {
+      ...existing,
+      ...parsed,
+      start: parsed.start ? normalizeDate(parsed.start) : existing.start,
+      end: parsed.end ? normalizeDate(parsed.end) : existing.end,
+      notes: parsed.notes === undefined ? existing.notes : parsed.notes ?? null,
+      staffId: parsed.staffId === undefined ? existing.staffId : parsed.staffId ?? null,
+      petId: parsed.petId === undefined ? existing.petId : parsed.petId ?? null,
+      allDay: parsed.allDay === undefined ? existing.allDay : parsed.allDay,
+      updatedAt: new Date().toISOString(),
+    };
+    store.events[index] = CalendarEvent.parse(next);
+    return cloneEvent(store.events[index]);
+  }
+
   const parsed = CalendarEventUpdate.parse(payload);
   const body: Record<string, any> = { ...parsed };
   if (parsed.start) body.start = normalizeDate(parsed.start);
@@ -49,6 +238,14 @@ export async function updateEvent(id: string, payload: any) {
 }
 
 export async function deleteEvent(id: string) {
+  if (usingMockData) {
+    const store = ensureMockStore();
+    const index = store.events.findIndex((event) => event.id === id);
+    if (index === -1) throw new Error("Not found");
+    store.events.splice(index, 1);
+    return { id };
+  }
+
   const client = getSupabaseAdmin();
   const { error } = await client.from(TABLE).delete().eq("id", id);
   if (error) throw error;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     "types": [
       "node",
       "react",
-      "react-dom"
+      "react-dom",
+      "jsdom"
     ],
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
## Summary
- add a mock calendar data store when the Supabase service role key is missing and expose the mode via API metadata
- restyle the month, week, and day views plus event cards to look more like a real calendar and highlight sample data usage
- fall back to demo staff options, show informative banners, and enable jsdom typings for the test suite

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb51cda3a88324ae2d2998044322ba