### PR TITLE
Ensure Supabase service role key is detected at runtime

### DIFF
--- a/lib/supabase/calendar.ts
+++ b/lib/supabase/calendar.ts
@@ -9,8 +9,13 @@ import {
 } from "../validation/calendar";
 
 const TABLE = "calendar_events";
-const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-const usingMockData = !serviceRoleKey || serviceRoleKey.trim() === "";
+const serviceRoleKey = (() => {
+  const value = process.env["SUPABASE_SERVICE_ROLE_KEY"];
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+})();
+const usingMockData = !serviceRoleKey;
 
 type CalendarStore = { events: TCalendarEvent[] };
 

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -5,7 +5,12 @@ import { createClient as createSupabaseJs, type SupabaseClient } from '@supabase
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+const serviceKey = (() => {
+  const value = process.env['SUPABASE_SERVICE_ROLE_KEY']
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed ? trimmed : undefined
+})()
 
 if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY')


### PR DESCRIPTION
## Summary
- Normalize the Supabase service role key lookup so runtime access isn't lost to build-time inlining and blank values, keeping the calendar on real data when configured.
- Reuse the trimmed service key when constructing the Supabase admin client to avoid treating whitespace-only secrets as valid.

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb5d93680483249efcf8d751ea9449