### PR TITLE
Stabilize Supabase key detection and polish calendar navigation

### DIFF
--- a/app/(app)/calendar/page.tsx
+++ b/app/(app)/calendar/page.tsx
@@ -399,6 +399,7 @@ function CalendarPageContent() {
       next.setDate(Math.min(currentDay, lastDayOfMonth));
     }
     setDate(next);
+    setShowDatePicker(false);
   };
 
   const handleNext = () => {
@@ -415,6 +416,7 @@ function CalendarPageContent() {
       next.setDate(Math.min(currentDay, lastDayOfMonth));
     }
     setDate(next);
+    setShowDatePicker(false);
   };
 
   const handleViewChange = (newView: View) => {
@@ -423,6 +425,7 @@ function CalendarPageContent() {
 
   const handleToday = () => {
     setDate(new Date());
+    setShowDatePicker(false);
   };
 
   const openCreateDialog = (day?: Date) => {
@@ -481,6 +484,9 @@ function CalendarPageContent() {
   };
 
   const label = useMemo(() => formatLabel(view, selectedDate), [view, selectedDate]);
+  const periodDescriptor = view === "day" ? "day" : view === "week" ? "week" : "month";
+  const previousPeriodLabel = `Previous ${periodDescriptor}`;
+  const nextPeriodLabel = `Next ${periodDescriptor}`;
 
   useEffect(() => {
     if (showDatePicker && dateInputRef.current) {
@@ -492,27 +498,68 @@ function CalendarPageContent() {
     <div className="flex h-full flex-col rounded-md border border-gray-200 bg-white shadow-sm">
       <div className="sticky top-0 z-20 border-b border-gray-200 bg-white px-4 py-3">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={handlePrev}
-              className="rounded border border-gray-300 px-3 py-1 text-sm font-medium hover:bg-gray-50"
-            >
-              Prev
-            </button>
-            <div className="relative">
-              <button
-                type="button"
-                onClick={() => setShowDatePicker((prev) => !prev)}
-                className="min-w-[180px] rounded border border-transparent px-2 py-1 text-sm font-semibold hover:border-gray-300"
-              >
-                {label}
-              </button>
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="relative inline-block">
+              <div className="inline-flex overflow-hidden rounded-lg border border-gray-300 bg-white shadow-sm">
+                <button
+                  type="button"
+                  onClick={handlePrev}
+                  aria-label={previousPeriodLabel}
+                  className="inline-flex items-center gap-1 bg-white px-3 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="h-4 w-4"
+                    viewBox="0 0 20 20"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path d="M12 5l-5 5 5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                  <span>Prev</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setShowDatePicker((prev) => !prev)}
+                  aria-haspopup="dialog"
+                  aria-expanded={showDatePicker}
+                  className="inline-flex min-w-[200px] items-center gap-2 border-x border-gray-200 bg-white px-4 py-2 text-sm font-semibold text-gray-900 transition hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="h-4 w-4"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <rect x="3" y="5" width="18" height="16" rx="2" stroke="currentColor" strokeWidth="1.5" />
+                    <path d="M16 3v4M8 3v4M3 11h18" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                  <span>{label}</span>
+                </button>
+                <button
+                  type="button"
+                  onClick={handleNext}
+                  aria-label={nextPeriodLabel}
+                  className="inline-flex items-center gap-1 border-l border-gray-200 bg-white px-3 py-2 text-sm font-medium text-gray-600 transition hover:bg-gray-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+                >
+                  <span>Next</span>
+                  <svg
+                    aria-hidden="true"
+                    className="h-4 w-4"
+                    viewBox="0 0 20 20"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path d="M8 5l5 5-5 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                  </svg>
+                </button>
+              </div>
               {showDatePicker && (
                 <input
                   ref={dateInputRef}
                   type="date"
-                  className="absolute left-0 top-full mt-1 rounded border border-gray-300 bg-white px-2 py-1 text-sm shadow"
+                  className="absolute left-1/2 top-full z-20 mt-2 w-full min-w-[220px] -translate-x-1/2 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
                   value={toDateInputValue(selectedDate)}
                   onChange={(event) => {
                     const parsed = parseDateInputValue(event.target.value);
@@ -526,13 +573,6 @@ function CalendarPageContent() {
                 />
               )}
             </div>
-            <button
-              type="button"
-              onClick={handleNext}
-              className="rounded border border-gray-300 px-3 py-1 text-sm font-medium hover:bg-gray-50"
-            >
-              Next
-            </button>
           </div>
           <div className="flex items-center gap-2">
             <div className="inline-flex overflow-hidden rounded border border-gray-300 text-sm">

--- a/lib/supabase/calendar.ts
+++ b/lib/supabase/calendar.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "crypto";
-import { getSupabaseAdmin } from "./server";
+import { getSupabaseAdmin, getSupabaseServiceRoleKey } from "./server";
 import {
   CalendarEvent,
   CalendarEventCreate,
@@ -9,8 +9,10 @@ import {
 } from "../validation/calendar";
 
 const TABLE = "calendar_events";
-const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-const usingMockData = !serviceRoleKey || serviceRoleKey.trim() === "";
+
+function shouldUseMockData() {
+  return !getSupabaseServiceRoleKey();
+}
 
 type CalendarStore = { events: TCalendarEvent[] };
 
@@ -131,11 +133,12 @@ function matchesFilters(event: TCalendarEvent, params: { from?: string; to?: str
 }
 
 export function calendarUsesMockData() {
-  return usingMockData;
+  return shouldUseMockData();
 }
 
 export async function listEvents(params: { from?: string; to?: string; staffId?: number; type?: string } = {}) {
-  if (usingMockData) {
+  const useMock = shouldUseMockData();
+  if (useMock) {
     const store = ensureMockStore();
     return store.events
       .filter((event) => matchesFilters(event, params))
@@ -155,7 +158,8 @@ export async function listEvents(params: { from?: string; to?: string; staffId?:
 }
 
 export async function getEvent(id: string) {
-  if (usingMockData) {
+  const useMock = shouldUseMockData();
+  if (useMock) {
     const store = ensureMockStore();
     const found = store.events.find((event) => event.id === id);
     if (!found) throw new Error("Not found");
@@ -169,7 +173,8 @@ export async function getEvent(id: string) {
 }
 
 export async function createEvent(payload: any) {
-  if (usingMockData) {
+  const useMock = shouldUseMockData();
+  if (useMock) {
     const parsed = CalendarEventCreate.parse(payload);
     const now = new Date().toISOString();
     const next: TCalendarEvent = CalendarEvent.parse({
@@ -204,7 +209,8 @@ export async function createEvent(payload: any) {
 }
 
 export async function updateEvent(id: string, payload: any) {
-  if (usingMockData) {
+  const useMock = shouldUseMockData();
+  if (useMock) {
     const parsed = CalendarEventUpdate.parse(payload);
     const store = ensureMockStore();
     const index = store.events.findIndex((event) => event.id === id);
@@ -238,7 +244,8 @@ export async function updateEvent(id: string, payload: any) {
 }
 
 export async function deleteEvent(id: string) {
-  if (usingMockData) {
+  const useMock = shouldUseMockData();
+  if (useMock) {
     const store = ensureMockStore();
     const index = store.events.findIndex((event) => event.id === id);
     if (index === -1) throw new Error("Not found");

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -5,10 +5,23 @@ import { createClient as createSupabaseJs, type SupabaseClient } from '@supabase
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
 const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+function readServiceRoleKey() {
+  const value = process.env['SUPABASE_SERVICE_ROLE_KEY']
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed ? trimmed : undefined
+}
+
+let cachedAdmin: SupabaseClient | null = null
+let cachedAdminKey: string | undefined
 
 if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY')
+}
+
+export function getSupabaseServiceRoleKey() {
+  return readServiceRoleKey()
 }
 
 export function createClient() {
@@ -22,12 +35,13 @@ export function createClient() {
   })
 }
 
-let cachedAdmin: SupabaseClient | null = null
 export function getSupabaseAdmin(): SupabaseClient {
-  if (cachedAdmin) return cachedAdmin
+  const serviceKey = readServiceRoleKey()
   if (!serviceKey) throw new Error('Missing SUPABASE_SERVICE_ROLE_KEY')
+  if (cachedAdmin && cachedAdminKey === serviceKey) return cachedAdmin
   cachedAdmin = createSupabaseJs(supabaseUrl, serviceKey, {
     auth: { persistSession: false, autoRefreshToken: false },
   })
+  cachedAdminKey = serviceKey
   return cachedAdmin
 }


### PR DESCRIPTION
## Summary
- Read and cache the Supabase service role key at call time so API routes stop falling back to mock data once the secret is configured.
- Update the calendar data helpers to check for the key dynamically, keeping the mock store only when no credential exists.
- Restyle the calendar navigation controls with grouped buttons, icons, and better focus handling while closing the date picker when navigating.

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb5d93680483249efcf8d751ea9449