### PR TITLE
Remove calendar mock metadata from API routes

### DIFF
--- a/app/api/calendar/[id]/route.ts
+++ b/app/api/calendar/[id]/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { calendarUsesMockData, getEvent, updateEvent, deleteEvent } from "@/lib/supabase/calendar";
+import { getEvent, updateEvent, deleteEvent } from "@/lib/supabase/calendar";
 
 export async function GET(_: NextRequest, { params }: { params: { id: string } }) {
   try {
     const data = await getEvent(params.id);
-    return NextResponse.json({ data, meta: { usingMockData: calendarUsesMockData() } });
+    return NextResponse.json({ data });
   } catch (e: any) {
     return NextResponse.json({ error: e.message ?? "Not found" }, { status: 404 });
   }
@@ -14,7 +14,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
   try {
     const json = await req.json();
     const data = await updateEvent(params.id, json);
-    return NextResponse.json({ data, meta: { usingMockData: calendarUsesMockData() } });
+    return NextResponse.json({ data });
   } catch (e: any) {
     return NextResponse.json({ error: e.message ?? "Failed to update" }, { status: 400 });
   }
@@ -23,7 +23,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
 export async function DELETE(_: NextRequest, { params }: { params: { id: string } }) {
   try {
     await deleteEvent(params.id);
-    return NextResponse.json({ ok: true, meta: { usingMockData: calendarUsesMockData() } });
+    return NextResponse.json({ ok: true });
   } catch (e: any) {
     return NextResponse.json({ error: e.message ?? "Failed to delete" }, { status: 400 });
   }

--- a/app/api/calendar/route.ts
+++ b/app/api/calendar/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { calendarUsesMockData, listEvents, createEvent } from "@/lib/supabase/calendar";
+import { listEvents, createEvent } from "@/lib/supabase/calendar";
 
 export async function GET(req: NextRequest) {
   const { searchParams } = new URL(req.url);
@@ -7,17 +7,14 @@ export async function GET(req: NextRequest) {
   const to = searchParams.get("to") ?? undefined;
   const staffIdParam = searchParams.get("staffId");
   const staffId = staffIdParam && staffIdParam.trim() !== ""
-    ? Number(staffIdParam)
+    ? staffIdParam
     : undefined;
   const type = searchParams.get("type") ?? undefined;
   try {
-    const params: { from?: string; to?: string; staffId?: number; type?: string } = { from, to, type };
-    if (staffId !== undefined && Number.isFinite(staffId)) params.staffId = staffId;
+    const params: { from?: string; to?: string; staffId?: string; type?: string } = { from, to, type };
+    if (staffId !== undefined) params.staffId = staffId;
     const data = await listEvents(params);
-    return NextResponse.json({
-      data,
-      meta: { usingMockData: calendarUsesMockData() },
-    });
+    return NextResponse.json({ data });
   } catch (e: any) {
     return NextResponse.json({ error: e.message ?? "Failed to list events" }, { status: 400 });
   }
@@ -27,7 +24,7 @@ export async function POST(req: NextRequest) {
   try {
     const json = await req.json();
     const data = await createEvent(json);
-    return NextResponse.json({ data, meta: { usingMockData: calendarUsesMockData() } }, { status: 201 });
+    return NextResponse.json({ data }, { status: 201 });
   } catch (e: any) {
     return NextResponse.json({ error: e.message ?? "Failed to create" }, { status: 400 });
   }


### PR DESCRIPTION
## Summary
- remove calendar mock metadata usage from calendar API routes
- ensure calendar list request preserves string staff IDs

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cb910156848324a7f723f8e12dd706