### PR TITLE
Improve staff settings editing workflow

### DIFF
--- a/app/employees/[id]/EmployeeDetailClient.tsx
+++ b/app/employees/[id]/EmployeeDetailClient.tsx
@@ -101,6 +101,8 @@ type Toast = {
 type EmployeeDetailContextValue = {
   employee: StaffRecord;
   goals: StaffGoals | null;
+  updateEmployee: (updates: Partial<StaffRecord>) => void;
+  updateGoals: (updates: Partial<StaffGoals> | null) => void;
   viewer: ViewerRecord | null;
   viewerCanManageDiscounts: boolean;
   viewerCanEditStaff: boolean;
@@ -142,6 +144,9 @@ export default function EmployeeDetailClient({ children, employee, goals }: Prop
   const router = useRouter();
   const { email } = useAuth();
 
+  const [employeeState, setEmployeeState] = useState(employee);
+  const [goalsState, setGoalsState] = useState<StaffGoals | null>(goals ?? null);
+
   const [viewer, setViewer] = useState<ViewerRecord | null>(null);
   const [viewerLoaded, setViewerLoaded] = useState(false);
   useEffect(() => {
@@ -179,6 +184,14 @@ export default function EmployeeDetailClient({ children, employee, goals }: Prop
   const [discountDraft, setDiscountDraft] = useState<DiscountDraft | null>(null);
   const [refreshKey, setRefreshKey] = useState(0);
   const [drawerOpen, setDrawerOpen] = useState(false);
+
+  useEffect(() => {
+    setEmployeeState(employee);
+  }, [employee]);
+
+  useEffect(() => {
+    setGoalsState(goals ?? null);
+  }, [goals]);
 
   const viewerCanManageDiscounts = useMemo(() => {
     if (!viewer) return false;
@@ -325,13 +338,31 @@ export default function EmployeeDetailClient({ children, employee, goals }: Prop
     setDiscountDraft(draft);
   }, []);
 
+  const updateEmployee = useCallback((updates: Partial<StaffRecord>) => {
+    setEmployeeState((prev) => ({ ...prev, ...updates }));
+  }, []);
+
+  const updateGoals = useCallback(
+    (updates: Partial<StaffGoals> | null) => {
+      if (updates === null) {
+        setGoalsState(null);
+        return;
+      }
+      setGoalsState((prev) => ({
+        ...(prev ?? { weekly_revenue_target: null, desired_dogs_per_day: null }),
+        ...updates,
+      }));
+    },
+    []
+  );
+
   const tabs = useMemo(
     () =>
       subtabs.map((tab) => ({
         label: tab.label,
-        href: tab.path(employee.id),
+        href: tab.path(employeeState.id),
       })),
-    [employee.id]
+    [employeeState.id]
   );
 
   const sanitizePhone = (value: string | null) => {
@@ -340,34 +371,36 @@ export default function EmployeeDetailClient({ children, employee, goals }: Prop
   };
 
   const handleCallClick = () => {
-    if (!employee.phone) {
+    if (!employeeState.phone) {
       pushToast("No phone number on file", "error");
       return;
     }
-    window.open(`tel:${sanitizePhone(employee.phone)}`);
+    window.open(`tel:${sanitizePhone(employeeState.phone)}`);
   };
 
   const handleTextClick = () => {
-    if (!employee.phone) {
+    if (!employeeState.phone) {
       pushToast("No phone number on file", "error");
       return;
     }
-    window.open(`sms:${sanitizePhone(employee.phone)}`);
+    window.open(`sms:${sanitizePhone(employeeState.phone)}`);
   };
 
   const handleEmailClick = () => {
-    if (!employee.email) {
+    if (!employeeState.email) {
       pushToast("No email address on file", "error");
       return;
     }
-    window.open(`mailto:${employee.email}`);
+    window.open(`mailto:${employeeState.email}`);
   };
 
   return (
     <EmployeeDetailContext.Provider
       value={{
-        employee,
-        goals,
+        employee: employeeState,
+        goals: goalsState,
+        updateEmployee,
+        updateGoals,
         viewer: viewerLoaded ? viewer : null,
         viewerCanManageDiscounts,
         viewerCanEditStaff,

--- a/app/employees/[id]/settings/page.tsx
+++ b/app/employees/[id]/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 import { useEmployeeDetail } from "../EmployeeDetailClient";
 import {
@@ -27,7 +27,7 @@ const PERMISSION_OPTIONS: PermissionOption[] = [
 const STATUS_OPTIONS = ["Active", "Inactive", "On leave"];
 
 export default function EmployeeSettingsPage() {
-  const { employee, goals, viewerCanEditStaff, pushToast } = useEmployeeDetail();
+  const { employee, goals, viewerCanEditStaff, pushToast, updateEmployee, updateGoals } = useEmployeeDetail();
 
   const permissionState = useMemo(() => {
     const base: Record<PermissionKey, boolean> = {
@@ -63,70 +63,291 @@ export default function EmployeeSettingsPage() {
 
   const [compensation, setCompensation] = useState({
     pay_type: employee.pay_type ?? "hourly",
-    commission_rate: employee.commission_rate ?? 0,
-    hourly_rate: employee.hourly_rate ?? 0,
-    salary_rate: employee.salary_rate ?? 0,
+    commission_rate:
+      typeof employee.commission_rate === "number" && Number.isFinite(employee.commission_rate)
+        ? employee.commission_rate
+        : 0,
+    hourly_rate:
+      typeof employee.hourly_rate === "number" && Number.isFinite(employee.hourly_rate)
+        ? employee.hourly_rate
+        : 0,
+    salary_rate:
+      typeof employee.salary_rate === "number" && Number.isFinite(employee.salary_rate)
+        ? employee.salary_rate
+        : 0,
     app_permissions: permissionState,
   });
 
   const [preferences, setPreferences] = useState({
-    preferred_breeds: [...(employee.preferred_breeds ?? [])],
-    not_accepted_breeds: [...(employee.not_accepted_breeds ?? [])],
-    specialties: [...(employee.specialties ?? [])],
-    weekly_revenue_target: goals?.weekly_revenue_target ?? 0,
-    desired_dogs_per_day: goals?.desired_dogs_per_day ?? 0,
+    preferred_breeds: Array.isArray(employee.preferred_breeds) ? [...employee.preferred_breeds] : [],
+    not_accepted_breeds: Array.isArray(employee.not_accepted_breeds) ? [...employee.not_accepted_breeds] : [],
+    specialties: Array.isArray(employee.specialties) ? [...employee.specialties] : [],
+    weekly_revenue_target:
+      typeof goals?.weekly_revenue_target === "number" && Number.isFinite(goals.weekly_revenue_target)
+        ? Number(goals.weekly_revenue_target)
+        : 0,
+    desired_dogs_per_day:
+      typeof goals?.desired_dogs_per_day === "number" && Number.isFinite(goals.desired_dogs_per_day)
+        ? Number(goals.desired_dogs_per_day)
+        : 0,
   });
 
   const [notes, setNotes] = useState(employee.manager_notes ?? "");
 
-  const disabled = !viewerCanEditStaff;
+  const [editingProfile, setEditingProfile] = useState(false);
+  const [editingCompensation, setEditingCompensation] = useState(false);
+  const [editingPreferences, setEditingPreferences] = useState(false);
+  const [editingNotes, setEditingNotes] = useState(false);
+
+  const [profileSaving, setProfileSaving] = useState(false);
+  const [compensationSaving, setCompensationSaving] = useState(false);
+  const [preferencesSaving, setPreferencesSaving] = useState(false);
+  const [notesSaving, setNotesSaving] = useState(false);
+
+  const canEdit = viewerCanEditStaff;
+  const readOnly = !canEdit;
+
+  useEffect(() => {
+    if (!editingProfile) {
+      setProfile({
+        name: employee.name ?? "",
+        role: employee.role ?? "",
+        email: employee.email ?? "",
+        phone: employee.phone ?? "",
+        avatar_url: employee.avatar_url ?? "",
+        status: employee.status ?? (employee.active ? "Active" : "Inactive"),
+        address_street: employee.address_street ?? "",
+        address_city: employee.address_city ?? "",
+        address_state: employee.address_state ?? "",
+        address_zip: employee.address_zip ?? "",
+        emergency_contact_name: employee.emergency_contact_name ?? "",
+        emergency_contact_phone: employee.emergency_contact_phone ?? "",
+      });
+    }
+  }, [employee, editingProfile]);
+
+  useEffect(() => {
+    if (!editingCompensation) {
+      setCompensation({
+        pay_type: employee.pay_type ?? "hourly",
+        commission_rate:
+          typeof employee.commission_rate === "number" && Number.isFinite(employee.commission_rate)
+            ? employee.commission_rate
+            : 0,
+        hourly_rate:
+          typeof employee.hourly_rate === "number" && Number.isFinite(employee.hourly_rate)
+            ? employee.hourly_rate
+            : 0,
+        salary_rate:
+          typeof employee.salary_rate === "number" && Number.isFinite(employee.salary_rate)
+            ? employee.salary_rate
+            : 0,
+        app_permissions: { ...permissionState },
+      });
+    }
+  }, [employee, permissionState, editingCompensation]);
+
+  useEffect(() => {
+    if (!editingPreferences) {
+      setPreferences({
+        preferred_breeds: Array.isArray(employee.preferred_breeds) ? [...employee.preferred_breeds] : [],
+        not_accepted_breeds: Array.isArray(employee.not_accepted_breeds) ? [...employee.not_accepted_breeds] : [],
+        specialties: Array.isArray(employee.specialties) ? [...employee.specialties] : [],
+        weekly_revenue_target:
+          typeof goals?.weekly_revenue_target === "number" && Number.isFinite(goals.weekly_revenue_target)
+            ? Number(goals.weekly_revenue_target)
+            : 0,
+        desired_dogs_per_day:
+          typeof goals?.desired_dogs_per_day === "number" && Number.isFinite(goals.desired_dogs_per_day)
+            ? Number(goals.desired_dogs_per_day)
+            : 0,
+      });
+    }
+  }, [employee, goals, editingPreferences]);
+
+  useEffect(() => {
+    if (!editingNotes) {
+      setNotes(employee.manager_notes ?? "");
+    }
+  }, [employee.manager_notes, editingNotes]);
+
+  const toNullIfEmpty = (value: string) => {
+    const trimmed = value.trim();
+    return trimmed ? trimmed : null;
+  };
+
+  const toNumberOrZero = (value: unknown) => {
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : 0;
+  };
+
+  const toNullableNumber = (value: unknown) => {
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : null;
+  };
 
   const handleProfileSave = async () => {
+    if (!canEdit || profileSaving) return;
+    setProfileSaving(true);
     const result = await saveProfileAction(employee.id, profile);
     if (!result.success) {
       pushToast(result.error ?? "Failed to save profile", "error");
+      setProfileSaving(false);
       return;
     }
+    const status = profile.status || "Active";
+    updateEmployee({
+      name: toNullIfEmpty(profile.name),
+      role: toNullIfEmpty(profile.role),
+      email: toNullIfEmpty(profile.email),
+      phone: toNullIfEmpty(profile.phone),
+      avatar_url: toNullIfEmpty(profile.avatar_url),
+      status,
+      active: status.toLowerCase().includes("active"),
+      address_street: toNullIfEmpty(profile.address_street),
+      address_city: toNullIfEmpty(profile.address_city),
+      address_state: toNullIfEmpty(profile.address_state),
+      address_zip: toNullIfEmpty(profile.address_zip),
+      emergency_contact_name: toNullIfEmpty(profile.emergency_contact_name),
+      emergency_contact_phone: toNullIfEmpty(profile.emergency_contact_phone),
+    });
     pushToast("Profile updated", "success");
+    setProfileSaving(false);
+    setEditingProfile(false);
+  };
+
+  const handleProfileCancel = () => {
+    setProfile({
+      name: employee.name ?? "",
+      role: employee.role ?? "",
+      email: employee.email ?? "",
+      phone: employee.phone ?? "",
+      avatar_url: employee.avatar_url ?? "",
+      status: employee.status ?? (employee.active ? "Active" : "Inactive"),
+      address_street: employee.address_street ?? "",
+      address_city: employee.address_city ?? "",
+      address_state: employee.address_state ?? "",
+      address_zip: employee.address_zip ?? "",
+      emergency_contact_name: employee.emergency_contact_name ?? "",
+      emergency_contact_phone: employee.emergency_contact_phone ?? "",
+    });
+    setEditingProfile(false);
   };
 
   const handleCompensationSave = async () => {
-    const result = await saveCompensationAction(employee.id, {
+    if (!canEdit || compensationSaving) return;
+    setCompensationSaving(true);
+    const payload = {
       pay_type: compensation.pay_type,
-      commission_rate: Number(compensation.commission_rate) || 0,
-      hourly_rate: Number(compensation.hourly_rate) || 0,
-      salary_rate: Number(compensation.salary_rate) || 0,
+      commission_rate: toNumberOrZero(compensation.commission_rate),
+      hourly_rate: toNumberOrZero(compensation.hourly_rate),
+      salary_rate: toNumberOrZero(compensation.salary_rate),
       app_permissions: compensation.app_permissions,
-    });
+    };
+    const result = await saveCompensationAction(employee.id, payload);
     if (!result.success) {
       pushToast(result.error ?? "Failed to save compensation", "error");
+      setCompensationSaving(false);
       return;
     }
+    updateEmployee({
+      pay_type: payload.pay_type,
+      commission_rate: payload.commission_rate,
+      hourly_rate: payload.hourly_rate,
+      salary_rate: payload.salary_rate,
+      app_permissions: { ...payload.app_permissions },
+    });
     pushToast("Compensation updated", "success");
+    setCompensationSaving(false);
+    setEditingCompensation(false);
+  };
+
+  const handleCompensationCancel = () => {
+    setCompensation({
+      pay_type: employee.pay_type ?? "hourly",
+      commission_rate:
+        typeof employee.commission_rate === "number" && Number.isFinite(employee.commission_rate)
+          ? employee.commission_rate
+          : 0,
+      hourly_rate:
+        typeof employee.hourly_rate === "number" && Number.isFinite(employee.hourly_rate)
+          ? employee.hourly_rate
+          : 0,
+      salary_rate:
+        typeof employee.salary_rate === "number" && Number.isFinite(employee.salary_rate)
+          ? employee.salary_rate
+          : 0,
+      app_permissions: { ...permissionState },
+    });
+    setEditingCompensation(false);
   };
 
   const handlePreferencesSave = async () => {
-    const result = await savePreferencesAction(employee.id, {
-      preferred_breeds: preferences.preferred_breeds,
-      not_accepted_breeds: preferences.not_accepted_breeds,
-      specialties: preferences.specialties,
-      weeklyTarget: Number(preferences.weekly_revenue_target) || null,
-      dogsPerDay: Number(preferences.desired_dogs_per_day) || null,
-    });
+    if (!canEdit || preferencesSaving) return;
+    setPreferencesSaving(true);
+    const payload = {
+      preferred_breeds: [...preferences.preferred_breeds],
+      not_accepted_breeds: [...preferences.not_accepted_breeds],
+      specialties: [...preferences.specialties],
+      weeklyTarget: toNullableNumber(preferences.weekly_revenue_target),
+      dogsPerDay: toNullableNumber(preferences.desired_dogs_per_day),
+    };
+    const result = await savePreferencesAction(employee.id, payload);
     if (!result.success) {
       pushToast(result.error ?? "Failed to save preferences", "error");
+      setPreferencesSaving(false);
       return;
     }
+    updateEmployee({
+      preferred_breeds: [...payload.preferred_breeds],
+      not_accepted_breeds: [...payload.not_accepted_breeds],
+      specialties: [...payload.specialties],
+    });
+    updateGoals({
+      weekly_revenue_target: payload.weeklyTarget,
+      desired_dogs_per_day: payload.dogsPerDay,
+    });
     pushToast("Preferences updated", "success");
+    setPreferencesSaving(false);
+    setEditingPreferences(false);
+  };
+
+  const handlePreferencesCancel = () => {
+    setPreferences({
+      preferred_breeds: Array.isArray(employee.preferred_breeds) ? [...employee.preferred_breeds] : [],
+      not_accepted_breeds: Array.isArray(employee.not_accepted_breeds) ? [...employee.not_accepted_breeds] : [],
+      specialties: Array.isArray(employee.specialties) ? [...employee.specialties] : [],
+      weekly_revenue_target:
+        typeof goals?.weekly_revenue_target === "number" && Number.isFinite(goals.weekly_revenue_target)
+          ? Number(goals.weekly_revenue_target)
+          : 0,
+      desired_dogs_per_day:
+        typeof goals?.desired_dogs_per_day === "number" && Number.isFinite(goals.desired_dogs_per_day)
+          ? Number(goals.desired_dogs_per_day)
+          : 0,
+    });
+    setEditingPreferences(false);
   };
 
   const handleNotesSave = async () => {
+    if (!canEdit || notesSaving) return;
+    setNotesSaving(true);
     const result = await saveManagerNotesAction(employee.id, notes);
     if (!result.success) {
       pushToast(result.error ?? "Failed to save notes", "error");
+      setNotesSaving(false);
       return;
     }
+    const trimmed = notes.trim();
+    updateEmployee({ manager_notes: trimmed ? trimmed : null });
     pushToast("Notes updated", "success");
+    setNotesSaving(false);
+    setEditingNotes(false);
+  };
+
+  const handleNotesCancel = () => {
+    setNotes(employee.manager_notes ?? "");
+    setEditingNotes(false);
   };
 
   return (
@@ -137,52 +358,73 @@ export default function EmployeeSettingsPage() {
             <h2 className="text-lg font-semibold text-brand-navy">Profile</h2>
             <p className="text-sm text-slate-500">Contact and status details for this staff member.</p>
           </div>
-          <button
-            type="button"
-            onClick={handleProfileSave}
-            disabled={disabled}
-            className="rounded-lg bg-brand-blue px-4 py-2 text-sm font-semibold text-white shadow hover:bg-brand-blue/90 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            Save
-          </button>
+          {editingProfile ? (
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={handleProfileCancel}
+                disabled={profileSaving}
+                className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleProfileSave}
+                disabled={readOnly || profileSaving}
+                className="rounded-lg bg-brand-blue px-4 py-2 text-sm font-semibold text-white shadow hover:bg-brand-blue/90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {profileSaving ? "Saving..." : "Save"}
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setEditingProfile(true)}
+              disabled={readOnly}
+              className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-brand-blue hover:bg-brand-blue/10 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              Edit
+            </button>
+          )}
         </header>
         <div className="mt-4 grid gap-4 md:grid-cols-2">
           <TextField
             label="Name"
             value={profile.name}
             onChange={(value) => setProfile((prev) => ({ ...prev, name: value }))}
-            disabled={disabled}
+            disabled={readOnly || !editingProfile}
           />
           <TextField
             label="Role"
             value={profile.role}
             onChange={(value) => setProfile((prev) => ({ ...prev, role: value }))}
-            disabled={disabled}
+            disabled={readOnly || !editingProfile}
           />
           <TextField
             label="Email"
             value={profile.email}
             onChange={(value) => setProfile((prev) => ({ ...prev, email: value }))}
-            disabled={disabled}
+            disabled={readOnly || !editingProfile}
           />
           <TextField
             label="Phone"
             value={profile.phone}
             onChange={(value) => setProfile((prev) => ({ ...prev, phone: value }))}
-            disabled={disabled}
+            disabled={readOnly || !editingProfile}
           />
           <TextField
             label="Avatar URL"
             value={profile.avatar_url}
             onChange={(value) => setProfile((prev) => ({ ...prev, avatar_url: value }))}
-            disabled={disabled}
+            disabled={readOnly || !editingProfile}
           />
           <SelectField
             label="Status"
             value={profile.status}
             options={STATUS_OPTIONS}
             onChange={(value) => setProfile((prev) => ({ ...prev, status: value }))}
-            disabled={disabled}
+            disabled={readOnly || !editingProfile}
           />
         </div>
         <div className="mt-4 grid gap-4 md:grid-cols-2">
@@ -190,25 +432,25 @@ export default function EmployeeSettingsPage() {
             label="Street"
             value={profile.address_street}
             onChange={(value) => setProfile((prev) => ({ ...prev, address_street: value }))}
-            disabled={disabled}
+            disabled={readOnly || !editingProfile}
           />
           <TextField
             label="City"
             value={profile.address_city}
             onChange={(value) => setProfile((prev) => ({ ...prev, address_city: value }))}
-            disabled={disabled}
+            disabled={readOnly || !editingProfile}
           />
           <TextField
             label="State"
             value={profile.address_state}
             onChange={(value) => setProfile((prev) => ({ ...prev, address_state: value }))}
-            disabled={disabled}
+            disabled={readOnly || !editingProfile}
           />
           <TextField
             label="Zip"
             value={profile.address_zip}
             onChange={(value) => setProfile((prev) => ({ ...prev, address_zip: value }))}
-            disabled={disabled}
+            disabled={readOnly || !editingProfile}
           />
         </div>
         <div className="mt-4 grid gap-4 md:grid-cols-2">
@@ -216,13 +458,13 @@ export default function EmployeeSettingsPage() {
             label="Emergency Contact Name"
             value={profile.emergency_contact_name}
             onChange={(value) => setProfile((prev) => ({ ...prev, emergency_contact_name: value }))}
-            disabled={disabled}
+            disabled={readOnly || !editingProfile}
           />
           <TextField
             label="Emergency Contact Phone"
             value={profile.emergency_contact_phone}
             onChange={(value) => setProfile((prev) => ({ ...prev, emergency_contact_phone: value }))}
-            disabled={disabled}
+            disabled={readOnly || !editingProfile}
           />
         </div>
       </section>
@@ -233,14 +475,35 @@ export default function EmployeeSettingsPage() {
             <h2 className="text-lg font-semibold text-brand-navy">Compensation & Permissions</h2>
             <p className="text-sm text-slate-500">Control pay structures and access for this employee.</p>
           </div>
-          <button
-            type="button"
-            onClick={handleCompensationSave}
-            disabled={disabled}
-            className="rounded-lg bg-brand-blue px-4 py-2 text-sm font-semibold text-white shadow hover:bg-brand-blue/90 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            Save
-          </button>
+          {editingCompensation ? (
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={handleCompensationCancel}
+                disabled={compensationSaving}
+                className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleCompensationSave}
+                disabled={readOnly || compensationSaving}
+                className="rounded-lg bg-brand-blue px-4 py-2 text-sm font-semibold text-white shadow hover:bg-brand-blue/90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {compensationSaving ? "Saving..." : "Save"}
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setEditingCompensation(true)}
+              disabled={readOnly}
+              className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-brand-blue hover:bg-brand-blue/10 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              Edit
+            </button>
+          )}
         </header>
         <div className="mt-4 grid gap-4 md:grid-cols-2">
           <SelectField
@@ -248,25 +511,25 @@ export default function EmployeeSettingsPage() {
             value={compensation.pay_type}
             options={["hourly", "commission", "salary", "hybrid"]}
             onChange={(value) => setCompensation((prev) => ({ ...prev, pay_type: value }))}
-            disabled={disabled}
+            disabled={readOnly || !editingCompensation}
           />
           <NumberField
             label="Commission %"
             value={Number(compensation.commission_rate ?? 0) * 100}
             onChange={(value) => setCompensation((prev) => ({ ...prev, commission_rate: value / 100 }))}
-            disabled={disabled}
+            disabled={readOnly || !editingCompensation}
           />
           <NumberField
             label="Hourly rate"
             value={Number(compensation.hourly_rate ?? 0)}
             onChange={(value) => setCompensation((prev) => ({ ...prev, hourly_rate: value }))}
-            disabled={disabled}
+            disabled={readOnly || !editingCompensation}
           />
           <NumberField
             label="Salary rate"
             value={Number(compensation.salary_rate ?? 0)}
             onChange={(value) => setCompensation((prev) => ({ ...prev, salary_rate: value }))}
-            disabled={disabled}
+            disabled={readOnly || !editingCompensation}
           />
         </div>
         <div className="mt-6">
@@ -286,7 +549,7 @@ export default function EmployeeSettingsPage() {
                       },
                     }))
                   }
-                  disabled={disabled}
+                  disabled={readOnly || !editingCompensation}
                 />
                 {option.label}
               </label>
@@ -301,28 +564,49 @@ export default function EmployeeSettingsPage() {
             <h2 className="text-lg font-semibold text-brand-navy">Preferences & Goals</h2>
             <p className="text-sm text-slate-500">Track favorite breeds, specialties, and performance goals.</p>
           </div>
-          <button
-            type="button"
-            onClick={handlePreferencesSave}
-            disabled={disabled}
-            className="rounded-lg bg-brand-blue px-4 py-2 text-sm font-semibold text-white shadow hover:bg-brand-blue/90 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            Save
-          </button>
+          {editingPreferences ? (
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={handlePreferencesCancel}
+                disabled={preferencesSaving}
+                className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handlePreferencesSave}
+                disabled={readOnly || preferencesSaving}
+                className="rounded-lg bg-brand-blue px-4 py-2 text-sm font-semibold text-white shadow hover:bg-brand-blue/90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {preferencesSaving ? "Saving..." : "Save"}
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setEditingPreferences(true)}
+              disabled={readOnly}
+              className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-brand-blue hover:bg-brand-blue/10 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              Edit
+            </button>
+          )}
         </header>
         <div className="mt-4 grid gap-4 md:grid-cols-2">
           <TagInput
             label="Preferred breeds"
             values={preferences.preferred_breeds}
             onChange={(values) => setPreferences((prev) => ({ ...prev, preferred_breeds: values }))}
-            disabled={disabled}
+            disabled={readOnly || !editingPreferences}
             placeholder="Add breed"
           />
           <TagInput
             label="Not accepted breeds"
             values={preferences.not_accepted_breeds}
             onChange={(values) => setPreferences((prev) => ({ ...prev, not_accepted_breeds: values }))}
-            disabled={disabled}
+            disabled={readOnly || !editingPreferences}
             placeholder="Add breed"
           />
         </div>
@@ -331,7 +615,7 @@ export default function EmployeeSettingsPage() {
             label="Specialties"
             values={preferences.specialties}
             onChange={(values) => setPreferences((prev) => ({ ...prev, specialties: values }))}
-            disabled={disabled}
+            disabled={readOnly || !editingPreferences}
             placeholder="Add specialty"
           />
         </div>
@@ -340,13 +624,13 @@ export default function EmployeeSettingsPage() {
             label="Weekly revenue target"
             value={Number(preferences.weekly_revenue_target ?? 0)}
             onChange={(value) => setPreferences((prev) => ({ ...prev, weekly_revenue_target: value }))}
-            disabled={disabled}
+            disabled={readOnly || !editingPreferences}
           />
           <NumberField
             label="Desired dogs per day"
             value={Number(preferences.desired_dogs_per_day ?? 0)}
             onChange={(value) => setPreferences((prev) => ({ ...prev, desired_dogs_per_day: value }))}
-            disabled={disabled}
+            disabled={readOnly || !editingPreferences}
           />
         </div>
       </section>
@@ -357,19 +641,40 @@ export default function EmployeeSettingsPage() {
             <h2 className="text-lg font-semibold text-brand-navy">Manager Notes</h2>
             <p className="text-sm text-slate-500">Private notes for leadership. Visible to managers only.</p>
           </div>
-          <button
-            type="button"
-            onClick={handleNotesSave}
-            disabled={disabled}
-            className="rounded-lg bg-brand-blue px-4 py-2 text-sm font-semibold text-white shadow hover:bg-brand-blue/90 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            Save
-          </button>
+          {editingNotes ? (
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={handleNotesCancel}
+                disabled={notesSaving}
+                className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleNotesSave}
+                disabled={readOnly || notesSaving}
+                className="rounded-lg bg-brand-blue px-4 py-2 text-sm font-semibold text-white shadow hover:bg-brand-blue/90 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {notesSaving ? "Saving..." : "Save"}
+              </button>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => setEditingNotes(true)}
+              disabled={readOnly}
+              className="rounded-lg border border-slate-200 px-4 py-2 text-sm font-semibold text-brand-blue hover:bg-brand-blue/10 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              Edit
+            </button>
+          )}
         </header>
         <textarea
           value={notes}
           onChange={(event) => setNotes(event.target.value)}
-          disabled={disabled}
+          disabled={readOnly || !editingNotes}
           className="mt-4 h-40 w-full rounded-xl border border-slate-300 px-4 py-3 text-sm text-slate-700 disabled:bg-slate-100"
           placeholder="Add private notes for this staff member"
         />


### PR DESCRIPTION
## Summary
- add per-section edit modes and cancel/save flows in the staff settings tab while syncing state with server actions
- update the employee detail context to expose helpers that keep staff data and goals in sync across the staff experience

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cb991ceaac83249ddd9f16cc6151d8