### PR TITLE
Allow manage staff permission to edit staff settings

### DIFF
--- a/app/employees/[id]/EmployeeDetailClient.tsx
+++ b/app/employees/[id]/EmployeeDetailClient.tsx
@@ -196,6 +196,7 @@ export default function EmployeeDetailClient({ children, employee, goals }: Prop
     const perms = viewer.app_permissions ?? {};
     if (typeof perms === "object" && perms !== null) {
       const flags = perms as Record<string, unknown>;
+      if (flags.can_manage_staff === true) return true;
       if (flags.can_edit_schedule === true) return true;
       if (flags.can_manage_discounts === true) return true;
       if (flags.can_view_reports === true) return true;


### PR DESCRIPTION
## Summary
- allow the `can_manage_staff` permission flag to enable editing of employee settings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbbdf92dcc8324bba71dcbb8a61459