### PR TITLE
Respect auth claims for staff editing

### DIFF
--- a/components/AuthProvider.tsx
+++ b/components/AuthProvider.tsx
@@ -3,49 +3,108 @@
 
 import { createContext, useContext, useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { Session } from '@supabase/supabase-js'
+
 import { supabase } from '@/lib/supabase/client'
 
 type AuthContextValue = {
   email: string | null
+  isManager: boolean
+  claims: Record<string, unknown>
 }
 
-const AuthContext = createContext<AuthContextValue>({ email: null })
+const defaultAuthState: AuthContextValue = {
+  email: null,
+  isManager: false,
+  claims: {},
+}
+
+const STORAGE_KEY = 'sb-auth-state'
+
+const AuthContext = createContext<AuthContextValue>(defaultAuthState)
 
 export function useAuth() {
   return useContext(AuthContext)
 }
 
+const TRUTHY_STRINGS = ['true', '1', 'yes', 'y', 'on', 't']
+
+const coerceBoolean = (value: unknown) => {
+  if (value === true) return true
+  if (value === false || value == null) return false
+  if (typeof value === 'number') return value !== 0
+  if (typeof value === 'string') return TRUTHY_STRINGS.includes(value.trim().toLowerCase())
+  return false
+}
+
+const parseStoredState = (): AuthContextValue => {
+  if (typeof window === 'undefined') return defaultAuthState
+  const raw = window.localStorage.getItem(STORAGE_KEY)
+  if (!raw) return defaultAuthState
+  try {
+    const parsed = JSON.parse(raw) as Partial<AuthContextValue>
+    return {
+      email: parsed.email ?? null,
+      isManager: coerceBoolean(parsed.isManager),
+      claims: parsed.claims && typeof parsed.claims === 'object' ? (parsed.claims as Record<string, unknown>) : {},
+    }
+  } catch (err) {
+    console.warn('Failed to parse stored auth state', err)
+    return defaultAuthState
+  }
+}
+
+const claimsFromSession = (session: Session | null) => {
+  if (!session?.user) return {}
+  return {
+    ...(session.user.app_metadata ?? {}),
+    ...(session.user.user_metadata ?? {}),
+  } as Record<string, unknown>
+}
+
 export default function AuthProvider({ children }: { children: React.ReactNode }) {
   const router = useRouter()
-  const [email, setEmail] = useState<string | null>(() => {
-    if (typeof window !== 'undefined') {
-      return window.localStorage.getItem('sb-email')
-    }
-    return null
-  })
+  const [authState, setAuthState] = useState<AuthContextValue>(() => parseStoredState())
 
   useEffect(() => {
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      const newEmail = session?.user?.email ?? null
-      setEmail(newEmail)
-      if (newEmail) {
-        window.localStorage.setItem('sb-email', newEmail)
-      } else {
-        window.localStorage.removeItem('sb-email')
+    const applySession = (session: Session | null) => {
+      const nextClaims = claimsFromSession(session)
+      const nextState: AuthContextValue = {
+        email: session?.user?.email ?? null,
+        claims: nextClaims,
+        isManager: coerceBoolean(
+          nextClaims?.is_manager ?? session?.user?.app_metadata?.is_manager ?? session?.user?.user_metadata?.is_manager,
+        ),
       }
+      setAuthState((prev) => {
+        const sameEmail = prev.email === nextState.email
+        const sameManager = prev.isManager === nextState.isManager
+        const sameClaims = Object.keys({ ...prev.claims, ...nextState.claims }).every(
+          (key) => prev.claims[key] === nextState.claims[key],
+        )
+        if (sameEmail && sameManager && sameClaims) {
+          return prev
+        }
+        if (typeof window !== 'undefined') {
+          if (nextState.email) {
+            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(nextState))
+          } else {
+            window.localStorage.removeItem(STORAGE_KEY)
+          }
+        }
+        return nextState
+      })
+    }
+
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      applySession(session)
     })
     const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
-      const newEmail = session?.user?.email ?? null
-      setEmail(newEmail)
-      if (newEmail) {
-        window.localStorage.setItem('sb-email', newEmail)
-      } else {
-        window.localStorage.removeItem('sb-email')
-      }
+      applySession(session)
       router.refresh()
     })
     return () => sub.subscription.unsubscribe()
   }, [router])
 
-  return <AuthContext.Provider value={{ email }}>{children}</AuthContext.Provider>
+  return <AuthContext.Provider value={authState}>{children}</AuthContext.Provider>
 }


### PR DESCRIPTION
## Summary
- expand the auth context to persist Supabase session claims and expose an `isManager` flag
- allow employee detail permissions to rely on auth claims so managers without employee records can edit staff settings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cbbdf92dcc8324bba71dcbb8a61459