### PR TITLE
Improve calendar month interactions

### DIFF
--- a/app/(app)/calendar/components/CalendarEventCard.tsx
+++ b/app/(app)/calendar/components/CalendarEventCard.tsx
@@ -32,19 +32,28 @@ export default function CalendarEventCard({ event, onClick }: { event: CalendarE
           minute: "2-digit",
         })}`
     : "";
+  const fallbackTitle = event.type === "shift" ? "Shift" : event.type === "timeOff" ? "Time off" : "Appointment";
+  const displayTitle = (event.title?.trim() || fallbackTitle).trim();
+  const tooltip = [displayTitle, time].filter(Boolean).join(" • ");
 
   return (
     <button
       type="button"
       onClick={onClick}
       className={`group w-full rounded-md border border-transparent border-l-4 px-3 py-2 text-left text-sm shadow-sm transition focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-300 ${colorClasses}`}
+      draggable
+      onDragStart={(dragEvent) => {
+        dragEvent.dataTransfer.effectAllowed = "move";
+        dragEvent.dataTransfer.setData("text/event-id", String(event.id));
+      }}
+      title={tooltip}
     >
       <div className="flex items-center justify-between gap-2">
-        <span className="truncate font-semibold" title={event.title}>{event.title}</span>
-        {time && <span className="shrink-0 text-xs font-medium opacity-80">{time}</span>}
+        <span className="truncate font-semibold leading-snug" title={displayTitle}>{displayTitle}</span>
+        {time && <span className="shrink-0 text-xs font-semibold leading-snug opacity-80">{time}</span>}
       </div>
       {event.notes && event.notes.trim() && (
-        <p className="mt-1 truncate text-xs opacity-80" title={event.notes ?? undefined}>
+        <p className="mt-1 truncate text-xs leading-snug opacity-80" title={event.notes ?? undefined}>
           {event.notes}
         </p>
       )}

--- a/app/(app)/calendar/page.tsx
+++ b/app/(app)/calendar/page.tsx
@@ -699,6 +699,15 @@ function CalendarPageContent() {
               setDate(day);
               setView("day");
             }}
+            onMoveEvent={async (eventId, newStart, newEnd) => {
+              try {
+                await update(eventId, { start: newStart.toISOString(), end: newEnd.toISOString() });
+                pushToast("Event moved");
+              } catch (err) {
+                console.error(err);
+                pushToast("Could not move event", "error");
+              }
+            }}
           />
         )}
         {view === "week" && (


### PR DESCRIPTION
## Summary
- polish calendar event chips with better labeling, tooltips, and drag handles
- suppress out-of-month events in the month grid and wire up drag targets for valid days
- persist dragged moves via the calendar hook and surface success/error toasts

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cca37a2b248324bedb33a0d3ff4ebc