### PR TITLE
Allow staff editors to use settings edit controls

### DIFF
--- a/app/employees/[id]/EmployeeDetailClient.tsx
+++ b/app/employees/[id]/EmployeeDetailClient.tsx
@@ -196,6 +196,7 @@ export default function EmployeeDetailClient({ children, employee, goals }: Prop
     const perms = viewer.app_permissions ?? {};
     if (typeof perms === "object" && perms !== null) {
       const flags = perms as Record<string, unknown>;
+      if (flags.can_manage_staff === true) return true;
       if (flags.can_edit_schedule === true) return true;
       if (flags.can_manage_discounts === true) return true;
       if (flags.can_view_reports === true) return true;


### PR DESCRIPTION
## Summary
- treat the can_manage_staff application permission as sufficient for enabling staff editing actions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd4507f5908324aaae807a7e2ebb1d