### PR TITLE
Add resilient staff detail data loading

### DIFF
--- a/app/employees/[id]/data-helpers.ts
+++ b/app/employees/[id]/data-helpers.ts
@@ -1,0 +1,93 @@
+import type { PostgrestError } from "@supabase/supabase-js";
+
+export function isMissingColumnError(error: PostgrestError | null) {
+  if (!error) return false;
+  if (error.code === "42703") return true;
+  return error.message?.toLowerCase().includes("column") && error.message?.toLowerCase().includes("does not exist");
+}
+
+export function isMissingRelationError(error: PostgrestError | null) {
+  if (!error) return false;
+  if (error.code === "42P01") return true;
+  return error.message?.toLowerCase().includes("relation") && error.message?.toLowerCase().includes("does not exist");
+}
+
+export function isMissingFunctionError(error: PostgrestError | null) {
+  if (!error) return false;
+  if (error.code === "42883") return true;
+  return error.message?.toLowerCase().includes("function") && error.message?.toLowerCase().includes("does not exist");
+}
+
+export function isPermissionError(error: PostgrestError | null) {
+  if (!error) return false;
+  if (error.code === "42501") return true;
+  return error.message?.toLowerCase().includes("permission denied");
+}
+
+export function shouldFallbackToAppointments(error: PostgrestError | null) {
+  return isMissingFunctionError(error) || isMissingRelationError(error) || isPermissionError(error);
+}
+
+export function toNumber(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+export function readMoney(record: Record<string, unknown>, keys: string[]): number | null {
+  for (const key of keys) {
+    if (!Object.prototype.hasOwnProperty.call(record, key)) continue;
+    const value = (record as Record<string, unknown>)[key];
+    const numeric = toNumber(value);
+    if (numeric === null) continue;
+    if (key.endsWith("_cents")) {
+      return numeric / 100;
+    }
+    return numeric;
+  }
+  return null;
+}
+
+export function parseDate(value: unknown) {
+  if (typeof value !== "string") return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date;
+}
+
+export function computeDurationHours(startValue: unknown, endValue: unknown) {
+  const start = parseDate(startValue);
+  if (!start) return 0;
+  const end = parseDate(endValue) ?? start;
+  const diff = (end.getTime() - start.getTime()) / (60 * 60 * 1000);
+  return diff > 0 ? diff : 0;
+}
+
+export function getUtcDayRange(base: Date) {
+  const start = new Date(Date.UTC(base.getUTCFullYear(), base.getUTCMonth(), base.getUTCDate()));
+  const end = new Date(start.getTime() + 24 * 60 * 60 * 1000);
+  return { start, end };
+}
+
+export function getUtcWeekRange(base: Date) {
+  const day = base.getUTCDay();
+  const diff = day === 0 ? -6 : 1 - day; // Monday as start of week
+  const start = new Date(Date.UTC(base.getUTCFullYear(), base.getUTCMonth(), base.getUTCDate()));
+  start.setUTCDate(start.getUTCDate() + diff);
+  const end = new Date(start.getTime() + 7 * 24 * 60 * 60 * 1000);
+  return { start, end };
+}
+
+export function computeBiweeklyWeekIndex(value: unknown): number | null {
+  const date = parseDate(value);
+  if (!date) return null;
+  const startOfYear = new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
+  const diffDays = Math.floor((date.getTime() - startOfYear.getTime()) / (24 * 60 * 60 * 1000));
+  const weekNumber = Math.floor(diffDays / 7);
+  return (weekNumber % 2) + 1;
+}

--- a/app/employees/[id]/page.tsx
+++ b/app/employees/[id]/page.tsx
@@ -2,7 +2,19 @@
 
 import { useEffect, useState } from "react";
 
+import type { PostgrestError } from "@supabase/supabase-js";
+
 import { supabase } from "@/lib/supabase/client";
+
+import {
+  computeDurationHours,
+  getUtcDayRange,
+  getUtcWeekRange,
+  isMissingColumnError,
+  readMoney,
+  shouldFallbackToAppointments,
+  toNumber,
+} from "./data-helpers";
 
 import OverviewWidgets, { OverviewMetrics } from "./components/OverviewWidgets";
 import RecentJobs, { RecentJobRow } from "./components/RecentJobs";
@@ -34,52 +46,57 @@ export default function EmployeeOverviewPage() {
     const load = async () => {
       setLoading(true);
       setError(null);
-      const [todayRes, weekRes, lifetimeRes, recentRes] = await Promise.all([
-        supabase.rpc("staff_today_metrics", { staff_id: employee.id }),
-        supabase.rpc("staff_week_metrics", { staff_id: employee.id }),
-        supabase.rpc("staff_lifetime_metrics", { staff_id: employee.id }),
-        supabase
-          .from("appointments")
-          .select("id,start_time,service,status,price,price_cents,pet_name")
-          .eq("employee_id", employee.id)
-          .order("start_time", { ascending: false })
-          .limit(8),
-      ]);
+      try {
+        const [todayRes, weekRes, lifetimeRes, recentRes] = await Promise.all([
+          supabase.rpc("staff_today_metrics", { staff_id: employee.id }),
+          supabase.rpc("staff_week_metrics", { staff_id: employee.id }),
+          supabase.rpc("staff_lifetime_metrics", { staff_id: employee.id }),
+          supabase
+            .from("appointments")
+            .select("id,start_time,service,status,price,price_cents,pet_name")
+            .eq("employee_id", employee.id)
+            .order("start_time", { ascending: false })
+            .limit(8),
+        ]);
 
-      if (!active) return;
+        const today = await resolveTodayMetrics(todayRes, employee.id);
+        const week = await resolveWeekMetrics(weekRes, employee.id, employee.commission_rate);
+        const lifetime = await resolveLifetimeMetrics(lifetimeRes, employee.id);
+        const recentRows = await resolveRecentAppointments(recentRes, employee.id);
 
-      if (todayRes.error || weekRes.error || lifetimeRes.error || recentRes.error) {
+        if (!active) return;
+
+        setMetrics({
+          todayDogs: today.dogs ?? 0,
+          todayHours: today.hours ?? 0,
+          weekDogs: week.dogs ?? 0,
+          weekRevenue: week.revenue ?? 0,
+          weekCommission: week.commission ?? 0,
+          lifetimeDogs: lifetime.dogs ?? 0,
+          lifetimeRevenue: lifetime.revenue ?? 0,
+        });
+
+        const rows = recentRows.map((row: any) => ({
+          id: row.id,
+          start: row.start_time,
+          pet: row.pet_name ?? null,
+          service: row.service ?? null,
+          price: readMoney(row, ["price", "price_cents", "price_amount", "price_amount_cents"]),
+          status: row.status ?? null,
+        }));
+
+        setRecent(rows as RecentJobRow[]);
+      } catch (cause) {
+        if (!active) return;
+        console.error("Failed to load staff overview", cause);
         setError("Unable to load staff overview");
-        setLoading(false);
-        return;
+        setMetrics(emptyMetrics);
+        setRecent([]);
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
       }
-
-      setMetrics({
-        todayDogs: todayRes.data?.dogs ?? 0,
-        todayHours: todayRes.data?.hours ?? 0,
-        weekDogs: weekRes.data?.dogs ?? 0,
-        weekRevenue: weekRes.data?.revenue ?? 0,
-        weekCommission: weekRes.data?.commission ?? 0,
-        lifetimeDogs: lifetimeRes.data?.dogs ?? 0,
-        lifetimeRevenue: lifetimeRes.data?.revenue ?? 0,
-      });
-
-      const rows = (recentRes.data ?? []).map((row: any) => ({
-        id: row.id,
-        start: row.start_time,
-        pet: row.pet_name ?? null,
-        service: row.service ?? null,
-        price:
-          typeof row.price === "number"
-            ? row.price
-            : typeof row.price_cents === "number"
-            ? row.price_cents / 100
-            : null,
-        status: row.status ?? null,
-      }));
-
-      setRecent(rows as RecentJobRow[]);
-      setLoading(false);
     };
 
     load();
@@ -87,7 +104,7 @@ export default function EmployeeOverviewPage() {
     return () => {
       active = false;
     };
-  }, [employee.id, refreshKey]);
+  }, [employee.commission_rate, employee.id, refreshKey]);
 
   return (
     <div className="space-y-6">
@@ -103,4 +120,173 @@ export default function EmployeeOverviewPage() {
       )}
     </div>
   );
+}
+
+type TodayMetrics = { dogs: number | null; hours: number | null };
+type WeekMetrics = { dogs: number | null; revenue: number | null; commission: number | null };
+type LifetimeMetrics = { dogs: number | null; revenue: number | null };
+
+type SimpleResponse<T> = { data: T | null; error: PostgrestError | null };
+
+async function resolveTodayMetrics(
+  response: SimpleResponse<any>,
+  employeeId: number
+): Promise<TodayMetrics> {
+  if (!response.error && response.data) {
+    const payload = Array.isArray(response.data) ? response.data[0] ?? {} : response.data;
+    return {
+      dogs: toNumber(payload?.dogs),
+      hours: toNumber(payload?.hours),
+    };
+  }
+
+  if (response.error && shouldFallbackToAppointments(response.error)) {
+    return computeTodayMetricsFromAppointments(employeeId);
+  }
+
+  if (response.error) {
+    throw response.error;
+  }
+
+  return { dogs: 0, hours: 0 };
+}
+
+async function resolveWeekMetrics(
+  response: SimpleResponse<any>,
+  employeeId: number,
+  commissionRate: number | string | null | undefined
+): Promise<WeekMetrics> {
+  if (!response.error && response.data) {
+    const payload = Array.isArray(response.data) ? response.data[0] ?? {} : response.data;
+    return {
+      dogs: toNumber(payload?.dogs),
+      revenue: toNumber(payload?.revenue),
+      commission: toNumber(payload?.commission),
+    };
+  }
+
+  if (response.error && shouldFallbackToAppointments(response.error)) {
+    return computeWeekMetricsFromAppointments(employeeId, commissionRate);
+  }
+
+  if (response.error) {
+    throw response.error;
+  }
+
+  return { dogs: 0, revenue: 0, commission: 0 };
+}
+
+async function resolveLifetimeMetrics(
+  response: SimpleResponse<any>,
+  employeeId: number
+): Promise<LifetimeMetrics> {
+  if (!response.error && response.data) {
+    const payload = Array.isArray(response.data) ? response.data[0] ?? {} : response.data;
+    return {
+      dogs: toNumber(payload?.dogs),
+      revenue: toNumber(payload?.revenue),
+    };
+  }
+
+  if (response.error && shouldFallbackToAppointments(response.error)) {
+    return computeLifetimeMetricsFromAppointments(employeeId);
+  }
+
+  if (response.error) {
+    throw response.error;
+  }
+
+  return { dogs: 0, revenue: 0 };
+}
+
+async function resolveRecentAppointments(
+  response: SimpleResponse<any>,
+  employeeId: number
+) {
+  if (!response.error) {
+    return (response.data as any[]) ?? [];
+  }
+
+  if (isMissingColumnError(response.error)) {
+    const fallback = await buildRecentAppointmentsQuery(employeeId, "*");
+    if (!fallback.error) {
+      return (fallback.data as any[]) ?? [];
+    }
+    throw fallback.error;
+  }
+
+  throw response.error;
+}
+
+async function computeTodayMetricsFromAppointments(employeeId: number): Promise<TodayMetrics> {
+  const { start, end } = getUtcDayRange(new Date());
+  const { data, error } = await supabase
+    .from("appointments")
+    .select("start_time,end_time")
+    .eq("employee_id", employeeId)
+    .gte("start_time", start.toISOString())
+    .lt("start_time", end.toISOString());
+
+  if (error) {
+    throw error;
+  }
+
+  const rows = (data as any[]) ?? [];
+  const hours = rows.reduce((total, row) => total + computeDurationHours(row?.start_time, row?.end_time), 0);
+  return { dogs: rows.length, hours };
+}
+
+async function computeWeekMetricsFromAppointments(
+  employeeId: number,
+  commissionRate: number | string | null | undefined
+): Promise<WeekMetrics> {
+  const { start, end } = getUtcWeekRange(new Date());
+  const { data, error } = await supabase
+    .from("appointments")
+    .select("start_time,price,price_cents,price_amount,price_amount_cents")
+    .eq("employee_id", employeeId)
+    .gte("start_time", start.toISOString())
+    .lt("start_time", end.toISOString());
+
+  if (error) {
+    throw error;
+  }
+
+  const rate = toNumber(commissionRate) ?? 0;
+  const rows = (data as any[]) ?? [];
+  let revenue = 0;
+  let commission = 0;
+  rows.forEach((row) => {
+    const price = readMoney(row, ["price", "price_cents", "price_amount", "price_amount_cents"]) ?? 0;
+    revenue += price;
+    commission += price * rate;
+  });
+  return { dogs: rows.length, revenue, commission };
+}
+
+async function computeLifetimeMetricsFromAppointments(employeeId: number): Promise<LifetimeMetrics> {
+  const { data, error } = await supabase
+    .from("appointments")
+    .select("price,price_cents,price_amount,price_amount_cents")
+    .eq("employee_id", employeeId);
+
+  if (error) {
+    throw error;
+  }
+
+  const rows = (data as any[]) ?? [];
+  const revenue = rows.reduce(
+    (sum, row) => sum + (readMoney(row, ["price", "price_cents", "price_amount", "price_amount_cents"]) ?? 0),
+    0
+  );
+  return { dogs: rows.length, revenue };
+}
+
+function buildRecentAppointmentsQuery(employeeId: number, columns: string) {
+  return supabase
+    .from("appointments")
+    .select(columns)
+    .eq("employee_id", employeeId)
+    .order("start_time", { ascending: false })
+    .limit(8);
 }


### PR DESCRIPTION
## Summary
- add shared PostgREST helper utilities for handling missing columns, conversions, and date math
- make employee overview metrics and recent appointment widgets fall back to derived data when RPCs or columns are unavailable
- harden employee history and payroll pages with optional column handling and computed payroll fallback when views are inaccessible

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68cd48d01dac8324a2ebd8104b6523b9