### PR TITLE
Revamp dashboard with neon celebration theme

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -15,6 +15,29 @@ export default async function DashboardPage() {
     data: { user },
   } = await supabase.auth.getUser()
   if (!user) redirect('/login')
+
+  const quickActions = [
+    {
+      label: 'Book Appointment',
+      description: 'Launch a glam session for a fresh-faced pup.',
+      icon: '🎟️'
+    },
+    {
+      label: 'Add Client',
+      description: 'Welcome a brand-new furry friend to the squad.',
+      icon: '🐾'
+    },
+    {
+      label: 'Generate Report',
+      description: 'Pull dazzling numbers for the team celebration.',
+      icon: '📈'
+    },
+    {
+      label: 'Send Message',
+      description: 'Blast a hype note to the crew or a VIP human.',
+      icon: '📣'
+    }
+  ]
   return (
     <PageContainer>
       <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
@@ -31,20 +54,26 @@ export default async function DashboardPage() {
           <Messages />
         </Widget>
         <Widget title="Quick Actions" color="pink">
-          <div className="flex flex-col space-y-3">
-            {[
-              'Book Appointment',
-              'Add Client',
-              'Generate Report',
-            ].map((label) => (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {quickActions.map((action) => (
               <button
-                key={label}
-                className="group flex items-center justify-between rounded-2xl bg-white/95 px-5 py-3 text-left font-semibold text-brand-navy shadow-lg transition duration-200 hover:-translate-y-0.5 hover:bg-white"
+                key={action.label}
+                type="button"
+                className="group relative overflow-hidden rounded-2xl border border-white/25 bg-gradient-to-r from-white/90 via-white/80 to-white/60 p-4 text-left text-brand-navy shadow-[0_24px_50px_-26px_rgba(255,102,196,0.45)] transition duration-300 hover:-translate-y-1 hover:shadow-[0_32px_60px_-24px_rgba(255,102,196,0.55)]"
               >
-                <span>{label}</span>
-                <span className="flex h-9 w-9 items-center justify-center rounded-full bg-brand-bubble text-lg text-white shadow-inner transition-transform duration-200 group-hover:scale-105">
-                  →
-                </span>
+                <div className="pointer-events-none absolute -right-8 -top-8 h-24 w-24 rounded-full bg-brand-bubble/25 blur-3xl transition duration-500 group-hover:scale-125" />
+                <div className="relative flex flex-col gap-2">
+                  <div className="flex items-center justify-between">
+                    <span className="grid h-10 w-10 place-items-center rounded-xl bg-gradient-to-br from-electric-pink via-electric-orange to-electric-purple text-xl text-white shadow-[0_20px_35px_-20px_rgba(120,92,255,0.5)]">
+                      {action.icon}
+                    </span>
+                    <span className="text-sm font-semibold uppercase tracking-[0.35em] text-brand-navy/60">Go</span>
+                  </div>
+                  <span className="font-display text-base uppercase tracking-[0.3em] text-brand-navy">
+                    {action.label}
+                  </span>
+                  <p className="text-sm text-brand-navy/70">{action.description}</p>
+                </div>
               </button>
             ))}
           </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,38 +2,375 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Custom global styles */
 @layer base {
   body {
-    @apply relative min-h-screen;
+    @apply relative min-h-screen overflow-x-hidden;
     background-attachment: fixed;
+  }
+
+  .neon-body {
+    background-color: #05001b;
+    background-image:
+      radial-gradient(circle at 18% 22%, rgba(255, 60, 172, 0.28), transparent 58%),
+      radial-gradient(circle at 82% 18%, rgba(27, 231, 255, 0.23), transparent 60%),
+      radial-gradient(circle at 30% 82%, rgba(255, 138, 5, 0.24), transparent 65%),
+      linear-gradient(135deg, rgba(8, 4, 40, 0.95), rgba(5, 0, 28, 0.98));
+    background-size: 150% 150%, 170% 170%, 190% 190%, cover;
+    animation: cosmicShift 36s ease-in-out infinite;
+    color: #fdfbff;
+  }
+
+  .neon-body::before,
+  .neon-body::after {
+    content: "";
+    position: fixed;
+    inset: -35% -25%;
+    pointer-events: none;
+    z-index: -2;
+    mix-blend-mode: screen;
+    filter: blur(130px);
+    opacity: 0.65;
+    animation: floaty 28s ease-in-out infinite alternate;
+  }
+
+  .neon-body::before {
+    background: radial-gradient(circle at 30% 30%, rgba(255, 60, 172, 0.4), transparent 65%);
+  }
+
+  .neon-body::after {
+    background: radial-gradient(circle at 70% 70%, rgba(27, 231, 255, 0.35), transparent 60%);
+    animation-delay: 12s;
+    opacity: 0.55;
   }
 
   main {
     @apply w-full;
   }
 
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--font-display, var(--font-sans));
+    letter-spacing: 0.04em;
+  }
+
   input:not([type="checkbox"]):not([type="radio"]),
   select,
   textarea {
-    @apply rounded-2xl border border-white/40 bg-white/90 px-4 py-3 text-brand-navy placeholder:text-brand-navy/50 shadow-sm transition focus:border-brand-bubble focus:outline-none focus:ring-2 focus:ring-brand-bubble/40;
+    border-radius: 1.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.25);
+    background: linear-gradient(145deg, rgba(255, 255, 255, 0.98), rgba(240, 240, 255, 0.92));
+    padding: 0.85rem 1.2rem;
+    color: #08245a;
+    box-shadow: 0 26px 55px -28px rgba(120, 92, 255, 0.45);
+    transition: border 0.25s ease, box-shadow 0.25s ease, transform 0.25s ease;
+  }
+
+  input:not([type="checkbox"]):not([type="radio"]):focus,
+  select:focus,
+  textarea:focus {
+    border-color: rgba(255, 60, 172, 0.75);
+    box-shadow: 0 32px 70px -30px rgba(255, 60, 172, 0.55);
+    outline: none;
+    transform: translateY(-1px);
+  }
+
+  input::placeholder,
+  textarea::placeholder {
+    color: rgba(8, 36, 90, 0.5);
   }
 
   label {
-    @apply text-brand-navy;
+    color: #08245a;
+    font-weight: 600;
+    letter-spacing: 0.02em;
   }
 
   ::selection {
-    @apply bg-brand-bubble/70 text-white;
+    background: rgba(255, 60, 172, 0.8);
+    color: #fff;
+  }
+
+  .nebula {
+    position: absolute;
+    border-radius: 9999px;
+    filter: blur(120px);
+    opacity: 0.7;
+    mix-blend-mode: screen;
+    animation: floaty 40s ease-in-out infinite;
+  }
+
+  .nebula--pink {
+    width: 36rem;
+    height: 36rem;
+    top: -12rem;
+    left: -14rem;
+    background: radial-gradient(circle at center, rgba(255, 60, 172, 0.45), transparent 65%);
+  }
+
+  .nebula--teal {
+    width: 28rem;
+    height: 28rem;
+    left: 45%;
+    bottom: -10rem;
+    background: radial-gradient(circle at center, rgba(27, 231, 255, 0.45), transparent 60%);
+    animation-delay: 6s;
+  }
+
+  .nebula--sun {
+    width: 32rem;
+    height: 32rem;
+    top: 10rem;
+    right: -16rem;
+    background: radial-gradient(circle at center, rgba(255, 138, 5, 0.45), transparent 60%);
+    animation-delay: 12s;
+  }
+
+  .cosmic-grid {
+    position: absolute;
+    inset: -20% -12%;
+    background-image:
+      linear-gradient(transparent 0, rgba(255, 255, 255, 0.05) 1px),
+      linear-gradient(90deg, transparent 0, rgba(255, 255, 255, 0.05) 1px);
+    background-size: 130px 130px;
+    opacity: 0.16;
+    transform: rotate(2deg) translateY(-6%);
+    animation: gridPulse 14s ease-in-out infinite alternate;
+  }
+
+  .orb-floating {
+    position: absolute;
+    border-radius: 9999px;
+    filter: blur(110px);
+    opacity: 0.55;
+    mix-blend-mode: screen;
+    animation: floaty 28s ease-in-out infinite;
+  }
+
+  .orb-floating--left {
+    width: 26rem;
+    height: 26rem;
+    top: -6rem;
+    left: -12rem;
+    background: radial-gradient(circle at center, rgba(255, 60, 172, 0.45), transparent 60%);
+  }
+
+  .orb-floating--right {
+    width: 22rem;
+    height: 22rem;
+    right: -10rem;
+    top: 4rem;
+    background: radial-gradient(circle at center, rgba(27, 231, 255, 0.5), transparent 60%);
+    animation-delay: 8s;
+  }
+
+  .orb-floating--bottom {
+    width: 30rem;
+    height: 30rem;
+    left: 30%;
+    bottom: -14rem;
+    background: radial-gradient(circle at center, rgba(255, 138, 5, 0.45), transparent 70%);
+    animation-delay: 14s;
+  }
+
+  .streamer-swish {
+    position: absolute;
+    inset: -25% -20%;
+    background-image: repeating-linear-gradient(120deg, rgba(255, 255, 255, 0.08) 0px, rgba(255, 255, 255, 0.08) 16px, transparent 16px, transparent 36px);
+    opacity: 0.18;
+    animation: streamerDrift 22s linear infinite;
+  }
+
+  .sparkle-field {
+    position: absolute;
+    inset: 12% 6%;
+    background-image: radial-gradient(rgba(255, 255, 255, 0.55) 0, rgba(255, 255, 255, 0.1) 45%, transparent 65%);
+    background-size: 120px 120px;
+    background-repeat: repeat;
+    opacity: 0.2;
+    mix-blend-mode: screen;
+    animation: twinkle 12s ease-in-out infinite;
   }
 }
 
 @layer components {
   .glass-panel {
-    @apply rounded-[2.25rem] border border-white/20 bg-white/10 shadow-soft backdrop-blur-2xl;
+    position: relative;
+    border-radius: 2.5rem;
+    border: 1px solid rgba(255, 255, 255, 0.35);
+    background: rgba(255, 255, 255, 0.94);
+    backdrop-filter: blur(26px);
+    box-shadow: 0 30px 75px -32px rgba(120, 92, 255, 0.45);
+    overflow: hidden;
   }
 
-  .nav-link {
-    @apply rounded-full px-4 py-2 text-sm font-semibold text-white/90 transition hover:bg-white/15;
+  .glass-panel::before {
+    content: "";
+    position: absolute;
+    inset: -25% -15%;
+    background: linear-gradient(140deg, rgba(255, 102, 196, 0.25), rgba(27, 231, 255, 0));
+    opacity: 0.45;
+    pointer-events: none;
+  }
+
+  .glass-panel::after {
+    content: "";
+    position: absolute;
+    inset: auto 20% -30% 20%;
+    height: 55%;
+    background: radial-gradient(circle at 50% 0, rgba(255, 138, 5, 0.18), transparent 70%);
+    opacity: 0.35;
+    pointer-events: none;
+  }
+
+  .neon-card {
+    position: relative;
+    overflow: hidden;
+    border-radius: 2.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    backdrop-filter: blur(28px);
+    box-shadow: 0 28px 65px -20px rgba(120, 92, 255, 0.55);
+  }
+
+  .neon-card::before,
+  .neon-card::after {
+    content: "";
+    position: absolute;
+    inset: -35% -25%;
+    border-radius: inherit;
+    mix-blend-mode: screen;
+    opacity: 0.35;
+    pointer-events: none;
+    animation: auroraPulse 16s ease-in-out infinite;
+  }
+
+  .neon-card::before {
+    background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.35), transparent 65%);
+  }
+
+  .neon-card::after {
+    background: radial-gradient(circle at 70% 70%, rgba(255, 255, 255, 0.25), transparent 65%);
+    animation-delay: 6s;
+  }
+
+  .widget-aurora {
+    position: absolute;
+    inset: -15%;
+    border-radius: inherit;
+    filter: blur(95px);
+    opacity: 0.35;
+    mix-blend-mode: screen;
+    animation: auroraPulse 18s ease-in-out infinite;
+  }
+
+  .widget-sparkle {
+    position: absolute;
+    width: 220px;
+    height: 220px;
+    border-radius: 999px;
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.55) 0, transparent 65%);
+    opacity: 0.28;
+    mix-blend-mode: screen;
+  }
+
+  .widget-sparkle--one {
+    top: -120px;
+    right: -90px;
+    animation: floaty 24s ease-in-out infinite;
+  }
+
+  .widget-sparkle--two {
+    bottom: -130px;
+    left: -100px;
+    animation: floaty 26s ease-in-out infinite reverse;
+  }
+
+  .widget-divider {
+    position: relative;
+    z-index: 10;
+    width: calc(100% - 4rem);
+    height: 1px;
+    margin: 1.5rem auto 0;
+    background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0));
+    opacity: 0.8;
+  }
+}
+
+@layer utilities {
+  .font-display {
+    font-family: var(--font-display, var(--font-sans));
+    letter-spacing: 0.04em;
+  }
+}
+
+@keyframes cosmicShift {
+  0% {
+    background-position: 0% 50%, 80% 20%, 10% 80%, center;
+  }
+  50% {
+    background-position: 100% 50%, 20% 70%, 90% 30%, center;
+  }
+  100% {
+    background-position: 0% 50%, 80% 20%, 10% 80%, center;
+  }
+}
+
+@keyframes floaty {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  50% {
+    transform: translate3d(16px, -20px, 0) scale(1.05);
+  }
+  100% {
+    transform: translate3d(-18px, 22px, 0) scale(0.98);
+  }
+}
+
+@keyframes auroraPulse {
+  0% {
+    opacity: 0.25;
+    transform: rotate(0deg) scale(1);
+  }
+  50% {
+    opacity: 0.45;
+    transform: rotate(8deg) scale(1.08);
+  }
+  100% {
+    opacity: 0.25;
+    transform: rotate(-6deg) scale(1);
+  }
+}
+
+@keyframes gridPulse {
+  0% {
+    opacity: 0.12;
+    transform: rotate(2deg) translateY(-6%);
+  }
+  100% {
+    opacity: 0.22;
+    transform: rotate(1deg) translateY(-2%);
+  }
+}
+
+@keyframes streamerDrift {
+  0% {
+    transform: translateX(0) skewY(-2deg);
+  }
+  100% {
+    transform: translateX(-8%) skewY(-2deg);
+  }
+}
+
+@keyframes twinkle {
+  0%,
+  100% {
+    opacity: 0.08;
+  }
+  50% {
+    opacity: 0.24;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 import TopNav from "@/components/TopNav";
 import "./globals.css";
 import AuthProvider from "@/components/AuthProvider";
-import { Nunito } from "next/font/google";
+import { Bungee, Space_Grotesk } from "next/font/google";
 import { createClient } from "@/lib/supabase/server";
 import { mapEmployeeRowToProfile } from "@/lib/auth/profile";
 import type { EmployeeProfile } from "@/lib/auth/profile";
@@ -12,9 +12,17 @@ export const metadata = {
 };
 export const runtime = "nodejs";
 
-const nunito = Nunito({
+const spaceGrotesk = Space_Grotesk({
   subsets: ["latin"],
   variable: "--font-sans",
+  display: "swap",
+});
+
+const bungee = Bungee({
+  subsets: ["latin"],
+  weight: "400",
+  variable: "--font-display",
+  display: "swap",
 });
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
@@ -46,14 +54,15 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   return (
     <html lang="en" className="scroll-smooth">
       <body
-        className={`${nunito.variable} font-sans text-white/90 antialiased bg-gradient-to-br from-brand-blue via-primary to-brand-sky min-h-screen overflow-x-hidden`}
+        className={`${spaceGrotesk.variable} ${bungee.variable} font-sans text-white antialiased neon-body`}
       >
         <AuthProvider initialSession={session} initialProfile={initialProfile}>
           <div className="relative flex min-h-screen flex-col overflow-hidden">
             <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-              <div className="absolute -left-32 -top-40 h-96 w-96 rounded-full bg-brand-bubble/30 blur-[120px]" />
-              <div className="absolute -right-24 top-24 h-[28rem] w-[28rem] rounded-full bg-brand-lavender/25 blur-[140px]" />
-              <div className="absolute bottom-[-18rem] left-1/2 h-[32rem] w-[32rem] -translate-x-1/2 rounded-full bg-brand-mint/20 blur-[160px]" />
+              <div className="nebula nebula--pink" />
+              <div className="nebula nebula--teal" />
+              <div className="nebula nebula--sun" />
+              <div className="cosmic-grid" />
             </div>
             <TopNav />
             <main className="relative z-10 flex-1">{children}</main>

--- a/components/PageContainer.tsx
+++ b/components/PageContainer.tsx
@@ -3,12 +3,15 @@ import clsx from 'clsx'
 
 export default function PageContainer({ children, className = '' }: { children: ReactNode; className?: string }) {
   return (
-    <div className="relative z-10 flex w-full justify-center px-4 pb-24 pt-10 md:px-8">
+    <div className="relative z-10 flex w-full justify-center px-4 pb-32 pt-28 md:px-12">
       <div className="pointer-events-none absolute inset-0 -z-10">
-        <div className="absolute left-0 top-10 h-72 w-72 rounded-full bg-white/10 blur-3xl" />
-        <div className="absolute bottom-0 right-0 h-[28rem] w-[28rem] rounded-full bg-brand-bubble/10 blur-[160px]" />
+        <div className="orb-floating orb-floating--left" />
+        <div className="orb-floating orb-floating--right" />
+        <div className="orb-floating orb-floating--bottom" />
+        <div className="streamer-swish" />
+        <div className="sparkle-field" />
       </div>
-      <div className={clsx('w-full max-w-6xl space-y-6', className)}>{children}</div>
+      <div className={clsx('w-full max-w-6xl space-y-10', className)}>{children}</div>
     </div>
   )
 }

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -29,19 +29,29 @@ export default function TopNav() {
 
   return (
     <header className="sticky top-0 z-40 flex justify-center px-4 pt-6">
-      <div className="glass-panel flex w-full max-w-6xl items-center justify-between px-6 py-4">
-        <Link href="/" className="group flex items-center gap-4 text-white">
-          <span className="grid h-12 w-12 place-items-center rounded-full bg-white/90 text-2xl shadow-inner ring-4 ring-white/40 transition-transform duration-300 group-hover:-rotate-12">
-            🐾
+      <div className="relative flex w-full max-w-6xl flex-wrap items-center justify-between gap-6 overflow-hidden rounded-[2.75rem] border border-white/25 bg-white/10 px-6 py-5 shadow-hyper backdrop-blur-3xl md:px-10">
+        <div className="pointer-events-none absolute inset-0">
+          <div className="absolute -left-24 top-1/2 h-64 w-64 -translate-y-1/2 rounded-full bg-electric-pink/40 blur-3xl" />
+          <div className="absolute right-[-14rem] top-0 h-72 w-72 rounded-full bg-electric-orange/35 blur-3xl" />
+          <div className="absolute left-1/2 top-0 h-px w-[140%] -translate-x-1/2 bg-gradient-to-r from-transparent via-white/35 to-transparent" />
+          <div className="absolute bottom-0 left-1/2 h-24 w-[120%] -translate-x-1/2 bg-gradient-to-r from-electric-blue/20 via-transparent to-electric-purple/20" />
+        </div>
+        <Link href="/" className="group relative z-10 flex items-center gap-4 text-white no-underline">
+          <span className="grid h-14 w-14 place-items-center rounded-3xl bg-gradient-to-br from-electric-pink via-electric-orange to-electric-purple text-2xl shadow-[0_25px_45px_-25px_rgba(120,92,255,0.55)] transition-transform duration-500 group-hover:-rotate-6 group-hover:scale-105">
+            🎉
           </span>
-          <div className="flex flex-col leading-tight">
-            <span className="text-xs font-semibold uppercase tracking-[0.4em] text-white/70">Scruffy</span>
-            <span className="text-2xl font-black text-white transition-colors duration-300 group-hover:text-brand-cream">
-              Butts
-            </span>
+          <div className="leading-tight">
+            <span className="font-display text-[0.55rem] uppercase tracking-[0.7em] text-white/70">Scruffy</span>
+            <div className="mt-1 flex items-center gap-2">
+              <span className="font-display text-[1.85rem] uppercase tracking-[0.35em] drop-shadow-[0_10px_25px_rgba(0,0,0,0.35)]">Butts</span>
+              <span className="hidden rounded-full bg-white/20 px-3 py-1 text-[0.55rem] font-semibold uppercase tracking-[0.45em] text-white/80 sm:inline-flex">
+                Remix
+              </span>
+            </div>
+            <p className="mt-1 text-[0.6rem] uppercase tracking-[0.5em] text-electric-aqua/80">Grooming Party HQ</p>
           </div>
         </Link>
-        <nav className="flex flex-wrap items-center justify-end gap-2 text-sm">
+        <nav className="relative z-10 order-last flex w-full flex-wrap items-center justify-center gap-2 md:order-none md:w-auto">
           {navLinks.map((link) => {
             const isActive = pathname?.startsWith(link.href);
             return (
@@ -49,31 +59,39 @@ export default function TopNav() {
                 key={link.href}
                 href={link.href}
                 className={clsx(
-                  "nav-link",
+                  'group relative overflow-hidden rounded-full px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] transition-all duration-300',
                   isActive
-                    ? "bg-white/25 text-white shadow-sm"
-                    : "text-white/80 hover:text-white"
+                    ? 'bg-white text-brand-navy shadow-[0_18px_45px_-25px_rgba(255,255,255,0.45)]'
+                    : 'bg-white/10 text-white/75 hover:bg-white/20 hover:text-white'
                 )}
               >
-                {link.label}
+                <span className="relative z-10">{link.label}</span>
+                <span className="pointer-events-none absolute inset-0 translate-y-[110%] bg-gradient-to-r from-white/40 via-transparent to-white/40 opacity-0 transition-all duration-500 group-hover:translate-y-0 group-hover:opacity-100" />
               </Link>
             );
           })}
         </nav>
-        <div className="flex items-center gap-3">
-          <div className="hidden text-right text-xs leading-tight text-white/80 sm:flex sm:flex-col sm:items-end">
+        <div className="relative z-10 flex w-full flex-wrap items-center justify-between gap-4 md:w-auto md:flex-nowrap md:justify-end">
+          <div className="flex flex-col text-xs leading-tight text-white/75 sm:items-end">
             {displayName && (
-              <span className="font-semibold text-white">{displayName}</span>
+              <span className="font-display text-sm uppercase tracking-[0.35em] text-white">
+                {displayName}
+              </span>
             )}
-            {role && <span className="uppercase tracking-[0.22em] text-[11px] text-white/60">{role}</span>}
+            {role && (
+              <span className="mt-1 inline-flex items-center gap-2 rounded-full bg-white/15 px-3 py-1 text-[0.55rem] uppercase tracking-[0.4em] text-white/80">
+                <span className="h-1.5 w-1.5 rounded-full bg-electric-lime" />
+                {role}
+              </span>
+            )}
           </div>
           <button
             type="button"
             onClick={handleSignOut}
-            className="rounded-full bg-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.25em] text-white transition hover:bg-white/30"
+            className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-electric-orange via-electric-pink to-electric-purple px-5 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-white shadow-[0_28px_55px_-25px_rgba(120,92,255,0.55)] transition-transform duration-300 hover:-translate-y-0.5 focus:outline-none focus-visible:ring-4 focus-visible:ring-electric-pink/40 disabled:cursor-not-allowed disabled:opacity-60"
             disabled={loading}
           >
-            Log out
+            Exit Party
           </button>
         </div>
       </div>

--- a/components/Widget.tsx
+++ b/components/Widget.tsx
@@ -10,11 +10,18 @@ interface WidgetProps {
   headerContent?: ReactNode
 }
 
-const backgroundMap: Record<Required<WidgetProps>['color'], string> = {
-  blue: 'bg-gradient-to-br from-[#1D4DFF] via-[#2E8CFF] to-[#55C3FF]',
-  pink: 'bg-gradient-to-br from-brand-bubble to-brand-bubbleDark',
-  purple: 'bg-gradient-to-br from-brand-lavender via-[#5B7DFF] to-primary',
-  green: 'bg-gradient-to-br from-brand-mint via-[#3CE0B7] to-[#43F0C5]'
+const gradientMap: Record<Required<WidgetProps>['color'], string> = {
+  blue: 'from-electric-blue/80 via-electric-aqua/80 to-electric-purple/85',
+  pink: 'from-electric-pink/85 via-electric-orange/80 to-electric-purple/90',
+  purple: 'from-brand-lavender/80 via-electric-purple/85 to-electric-pink/85',
+  green: 'from-electric-lime/80 via-brand-mint/80 to-electric-aqua/80'
+}
+
+const glowMap: Record<Required<WidgetProps>['color'], string> = {
+  blue: 'bg-electric-blue/45',
+  pink: 'bg-electric-pink/45',
+  purple: 'bg-electric-purple/45',
+  green: 'bg-electric-lime/45'
 }
 
 export default function Widget({
@@ -25,25 +32,33 @@ export default function Widget({
   hideHeader = false,
   headerContent
 }: WidgetProps) {
-  const gradient = backgroundMap[color]
+  const gradient = gradientMap[color]
+  const glow = glowMap[color]
 
   return (
     <div
       className={clsx(
-        'relative overflow-hidden rounded-[2rem] border border-white/25 text-white shadow-soft backdrop-blur-xl',
+        'neon-card bg-gradient-to-br text-white',
         gradient,
         className
       )}
     >
-      <div className="pointer-events-none absolute -right-16 -top-24 h-64 w-64 rounded-full bg-white/25 blur-[120px]" />
-      <div className="pointer-events-none absolute bottom-[-30%] left-[-20%] h-80 w-80 rounded-full bg-white/10 blur-[160px]" />
+      <div className={clsx('widget-aurora', glow)} />
+      <div className="widget-sparkle widget-sparkle--one" />
+      <div className="widget-sparkle widget-sparkle--two" />
       {!hideHeader && (
-        <div className="relative flex items-center justify-between px-6 pt-6">
-          <h2 className="text-lg font-semibold tracking-tight drop-shadow-md">{title}</h2>
+        <div className="relative z-10 flex flex-col gap-4 px-8 pt-8 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-[0.65rem] uppercase tracking-[0.55em] text-white/70">Spotlight</p>
+            <h2 className="font-display text-2xl font-black uppercase tracking-[0.3em] drop-shadow-[0_8px_20px_rgba(0,0,0,0.35)]">
+              {title}
+            </h2>
+          </div>
           {headerContent}
         </div>
       )}
-      <div className={clsx('relative px-6 pb-6', hideHeader ? 'pt-6' : 'pt-4')}>
+      {!hideHeader && <div className="widget-divider" />}
+      <div className={clsx('relative z-10 px-8 pb-8', hideHeader ? 'pt-10' : 'pt-6')}>
         {children}
       </div>
     </div>

--- a/components/dashboard/EmployeeWorkload.tsx
+++ b/components/dashboard/EmployeeWorkload.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from 'react'
+import clsx from 'clsx'
 import { supabase } from '@/lib/supabase/client'
 
 interface Workload {
@@ -10,6 +11,13 @@ interface Workload {
 export default function EmployeeWorkload() {
   const [workloads, setWorkloads] = useState<Workload[]>([])
   const [loading, setLoading] = useState(true)
+
+  const gradients = [
+    'from-electric-pink via-electric-orange to-electric-purple',
+    'from-electric-blue via-electric-aqua to-electric-purple',
+    'from-electric-lime via-brand-mint to-electric-aqua',
+    'from-brand-lavender via-electric-purple to-electric-pink'
+  ]
 
   useEffect(() => {
     const fetchWorkloads = async () => {
@@ -32,37 +40,42 @@ export default function EmployeeWorkload() {
     fetchWorkloads()
   }, [])
 
-  if (loading) return <div className="text-white/80">Loading...</div>
+  if (loading) return <div className="flex items-center gap-2 text-white/80">🐾 Crunching paws-per-groomer stats...</div>
   if (workloads.length === 0)
     return (
-      <div className="rounded-3xl border border-white/25 bg-white/10 p-6 text-white/85 backdrop-blur-lg">
-        No active jobs.
+      <div className="rounded-[2rem] border border-dashed border-white/35 bg-white/10 p-6 text-white/80 backdrop-blur-xl">
+        No active jobs—treat the team to a dance break!
       </div>
     )
 
   const max = workloads.length ? Math.max(...workloads.map((w) => w.count), 1) : 1
 
   return (
-    <ul className="space-y-3 text-white/90">
-      {workloads.map((wl) => {
+    <ul className="space-y-4 text-white">
+      {workloads.map((wl, index) => {
         const width = Math.max((wl.count / max) * 100, 12)
+        const gradient = gradients[index % gradients.length]
         return (
           <li
             key={wl.employee_name}
-            className="rounded-3xl border border-white/15 bg-white/10 p-4 shadow-inner backdrop-blur"
+            className="group relative overflow-hidden rounded-[1.75rem] border border-white/20 bg-gradient-to-r from-white/15 via-white/8 to-white/5 p-4 shadow-[0_26px_50px_-26px_rgba(120,92,255,0.45)] backdrop-blur-2xl"
           >
-            <div className="flex items-center justify-between text-sm font-semibold tracking-tight">
-              <span>{wl.employee_name}</span>
-              <span className="flex items-center gap-1 text-xs uppercase">
-                <span className="inline-flex h-2 w-2 rounded-full bg-white/80" />
-                {wl.count} {wl.count === 1 ? 'dog' : 'dogs'}
-              </span>
-            </div>
-            <div className="mt-3 h-2 rounded-full bg-white/15">
-              <div
-                className="h-full rounded-full bg-white/80"
-                style={{ width: `${width}%` }}
-              />
+            <div className="pointer-events-none absolute -left-16 top-1/2 h-40 w-40 -translate-y-1/2 rounded-full bg-white/12 blur-3xl transition duration-500 group-hover:scale-110" />
+            <div className="pointer-events-none absolute -top-16 right-0 h-44 w-44 rounded-full bg-white/12 blur-3xl" />
+            <div className="relative flex flex-col gap-3">
+              <div className="flex items-center justify-between">
+                <span className="font-display text-sm uppercase tracking-[0.35em]">{wl.employee_name}</span>
+                <span className="inline-flex items-center gap-2 rounded-full bg-white/15 px-3 py-1 text-[0.55rem] uppercase tracking-[0.35em] text-white/80">
+                  <span className="h-1.5 w-1.5 rounded-full bg-electric-lime" />
+                  {wl.count} {wl.count === 1 ? 'pet' : 'pets'}
+                </span>
+              </div>
+              <div className="h-2.5 overflow-hidden rounded-full bg-white/15">
+                <div
+                  className={clsx('h-full rounded-full bg-gradient-to-r transition-all duration-500', gradient)}
+                  style={{ width: `${width}%` }}
+                />
+              </div>
             </div>
           </li>
         )

--- a/components/dashboard/Messages.tsx
+++ b/components/dashboard/Messages.tsx
@@ -33,29 +33,34 @@ export default function Messages() {
       minute: '2-digit'
     })
 
-  if (loading) return <div className="text-white/80">Loading...</div>
+  if (loading) return <div className="flex items-center gap-2 text-white/80">📬 Fetching party gossip...</div>
   if (!messages.length)
     return (
-      <div className="rounded-3xl border border-white/25 bg-white/10 p-6 text-white/80 backdrop-blur-lg">
-        No messages yet.
+      <div className="rounded-[2rem] border border-dashed border-white/35 bg-white/10 p-6 text-white/80 backdrop-blur-xl">
+        Inbox is snoozing—send a glittery hello!
       </div>
     )
   return (
-    <ul className="space-y-3">
+    <ul className="space-y-4 text-white">
       {messages.map((msg) => (
         <li
           key={msg.id}
-          className="rounded-3xl border border-white/25 bg-white/95 p-4 text-brand-navy shadow-lg backdrop-blur"
+          className="group relative overflow-hidden rounded-[1.85rem] border border-white/20 bg-gradient-to-r from-white/20 via-white/10 to-white/5 p-5 shadow-[0_26px_50px_-28px_rgba(120,92,255,0.45)] backdrop-blur-2xl"
         >
-          <div className="flex items-center justify-between gap-3 text-xs font-semibold uppercase tracking-wide text-brand-navy/70">
-            <span>
-              {msg.sender} → {msg.recipient}
-            </span>
-            <span>{formatTime(msg.created_at)}</span>
+          <div className="pointer-events-none absolute -right-16 top-0 h-40 w-40 rounded-full bg-white/12 blur-3xl" />
+          <div className="pointer-events-none absolute -left-14 bottom-0 h-32 w-32 rounded-full bg-white/10 blur-3xl" />
+          <div className="relative flex flex-col gap-3">
+            <div className="flex flex-wrap items-center justify-between gap-3 text-[0.6rem] uppercase tracking-[0.4em] text-white/75">
+              <span className="inline-flex items-center gap-2">
+                <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-white/20 text-xs">💌</span>
+                {msg.sender} → {msg.recipient}
+              </span>
+              <span className="rounded-full bg-white/15 px-3 py-1 text-white/80">{formatTime(msg.created_at)}</span>
+            </div>
+            <p className="text-sm leading-relaxed text-white/85" title={msg.body}>
+              {msg.body}
+            </p>
           </div>
-          <p className="mt-2 max-h-14 overflow-hidden text-sm text-brand-navy/80" title={msg.body}>
-            {msg.body}
-          </p>
         </li>
       ))}
     </ul>

--- a/components/dashboard/Revenue.tsx
+++ b/components/dashboard/Revenue.tsx
@@ -42,19 +42,40 @@ export default function Revenue() {
 
   const format = (value: number | null) => (value ?? 0).toFixed(2)
 
-  if (loading) return <div className="text-white/80">Loading...</div>
+  if (loading) return <div className="flex items-center gap-2 text-white/80">💸 Counting sparkly tips...</div>
   return (
-    <div className="space-y-4 text-white">
-      <div className="rounded-3xl border border-white/20 bg-white/10 p-5 shadow-inner backdrop-blur">
-        <p className="text-xs uppercase tracking-[0.35em] text-white/70">Today</p>
-        <div className="mt-2 flex items-end gap-2">
-          <span className="text-3xl font-bold drop-shadow-sm">${format(todayRevenue)}</span>
-          <span className="text-xs text-white/70">so far</span>
+    <div className="space-y-5 text-white">
+      <div className="relative overflow-hidden rounded-[2rem] border border-white/20 bg-gradient-to-br from-electric-blue/25 via-electric-purple/25 to-electric-pink/25 p-6 shadow-[0_32px_65px_-28px_rgba(120,92,255,0.45)] backdrop-blur-2xl">
+        <div className="pointer-events-none absolute -left-16 top-1/2 h-48 w-48 -translate-y-1/2 rounded-full bg-white/20 blur-3xl" />
+        <div className="pointer-events-none absolute right-[-10rem] top-0 h-56 w-56 rounded-full bg-white/10 blur-3xl" />
+        <div className="relative flex items-start justify-between">
+          <div>
+            <p className="text-[0.6rem] uppercase tracking-[0.5em] text-white/70">Today&apos;s Glow</p>
+            <div className="mt-3 flex items-baseline gap-3">
+              <span className="font-display text-4xl uppercase tracking-[0.35em] drop-shadow-[0_10px_25px_rgba(0,0,0,0.35)]">
+                ${format(todayRevenue)}
+              </span>
+              <span className="rounded-full bg-white/20 px-3 py-1 text-[0.55rem] uppercase tracking-[0.35em] text-white/75">
+                so far
+              </span>
+            </div>
+            <p className="mt-3 text-sm text-white/75">Keep the dryers humming—today&apos;s total is shining bright.</p>
+          </div>
+          <span className="grid h-12 w-12 place-items-center rounded-3xl bg-white/15 text-lg text-white/80 shadow-inner">
+            ✨
+          </span>
         </div>
       </div>
-      <div className="rounded-3xl border border-white/20 bg-white/10 p-5 shadow-inner backdrop-blur">
-        <p className="text-xs uppercase tracking-[0.35em] text-white/70">This Week</p>
-        <div className="mt-2 text-xl font-semibold drop-shadow-sm">${format(weekRevenue)}</div>
+      <div className="relative overflow-hidden rounded-[2rem] border border-white/20 bg-gradient-to-br from-electric-pink/25 via-electric-orange/25 to-electric-purple/25 p-6 shadow-[0_32px_65px_-28px_rgba(255,102,196,0.45)] backdrop-blur-2xl">
+        <div className="pointer-events-none absolute -top-12 left-1/3 h-52 w-52 rounded-full bg-white/12 blur-3xl" />
+        <div className="pointer-events-none absolute -bottom-16 right-0 h-60 w-60 rounded-full bg-white/18 blur-3xl" />
+        <div className="relative flex flex-col gap-3">
+          <p className="text-[0.6rem] uppercase tracking-[0.5em] text-white/70">Week-To-Date</p>
+          <span className="font-display text-3xl uppercase tracking-[0.35em] drop-shadow-[0_8px_22px_rgba(0,0,0,0.35)]">
+            ${format(weekRevenue)}
+          </span>
+          <p className="text-sm text-white/75">That&apos;s a whole lot of wag-worthy sparkle for the crew.</p>
+        </div>
       </div>
     </div>
   )

--- a/components/dashboard/TodaysAppointments.tsx
+++ b/components/dashboard/TodaysAppointments.tsx
@@ -12,11 +12,19 @@ interface Appointment {
 }
 
 const statusStyles: Record<string, string> = {
-  Completed: 'bg-brand-mint/30 text-brand-navy',
-  Upcoming: 'bg-white/40 text-brand-navy',
-  Cancelled: 'bg-brand-bubble/40 text-white',
-  'In Progress': 'bg-brand-sunshine/60 text-brand-navy',
-  'Checked In': 'bg-brand-lavender/40 text-white'
+  Completed: 'bg-electric-lime/80 text-brand-navy',
+  Upcoming: 'bg-white/90 text-brand-navy',
+  Cancelled: 'bg-electric-pink/85 text-white',
+  'In Progress': 'bg-electric-orange/80 text-brand-navy',
+  'Checked In': 'bg-electric-aqua/85 text-brand-navy'
+}
+
+const petEmojis = ['🐶', '🐱', '🐕‍🦺', '🛁', '🐩', '🎉', '🦄', '🐾']
+
+const emojiForAppointment = (id: string, petName: string) => {
+  const seed = `${id}-${petName}`
+  const code = Array.from(seed).reduce((acc, char) => acc + char.charCodeAt(0), 0)
+  return petEmojis[code % petEmojis.length]
 }
 
 export default function TodaysAppointments() {
@@ -56,13 +64,13 @@ export default function TodaysAppointments() {
   }, [])
 
   if (loading) {
-    return <div className="text-white/80">Loading...</div>
+    return <div className="flex items-center gap-2 text-white/80">✨ Loading the party schedule...</div>
   }
 
   if (appointments.length === 0) {
     return (
-      <div className="rounded-3xl border border-white/30 bg-white/10 p-6 text-white/80 backdrop-blur-md">
-        No appointments today.
+      <div className="rounded-[2rem] border border-dashed border-white/40 bg-white/10 p-6 text-center text-white/75 backdrop-blur-xl">
+        No appointments today—time to plan a surprise spa party! 🥳
       </div>
     )
   }
@@ -74,42 +82,60 @@ export default function TodaysAppointments() {
   })
 
   return (
-    <div className="space-y-5">
-      <div className="flex items-center justify-between text-white">
+    <div className="space-y-6 text-white">
+      <div className="flex flex-wrap items-center justify-between gap-4">
         <div>
-          <p className="text-xs uppercase tracking-[0.35em] text-white/70">Today</p>
-          <h3 className="text-2xl font-semibold tracking-tight drop-shadow-sm">{today}</h3>
+          <p className="text-[0.6rem] uppercase tracking-[0.5em] text-white/70">Today</p>
+          <h3 className="font-display text-3xl uppercase tracking-[0.35em] drop-shadow-[0_8px_22px_rgba(0,0,0,0.35)]">{today}</h3>
         </div>
-        <span className="flex h-12 w-12 items-center justify-center rounded-full bg-white/25 text-lg font-semibold text-white shadow-inner">
-          {appointments.length}
-        </span>
+        <div className="flex items-center gap-3">
+          <span className="rounded-full bg-white/15 px-4 py-2 text-[0.65rem] font-semibold uppercase tracking-[0.4em] text-white/75">
+            {appointments.length} Slots
+          </span>
+          <span className="grid h-14 w-14 place-items-center rounded-3xl bg-gradient-to-br from-electric-pink via-electric-orange to-electric-purple text-2xl shadow-[0_24px_45px_-24px_rgba(120,92,255,0.5)]">
+            ✂️
+          </span>
+        </div>
       </div>
-      <ul className="space-y-3">
-        {appointments.map((appt) => (
-          <li
-            key={appt.id}
-            className="grid grid-cols-[auto,1fr,auto] items-center gap-4 rounded-3xl bg-white/95 px-5 py-4 text-brand-navy shadow-lg shadow-primary/10 backdrop-blur"
-          >
-            <div className="grid h-12 w-12 place-items-center rounded-full bg-brand-bubble/20 text-2xl">
-              🐶
-            </div>
-            <div>
-              <p className="text-sm font-semibold text-brand-navy">{appt.pet_name}</p>
-              <p className="text-xs text-brand-navy/70">{appt.client_name}</p>
-            </div>
-            <div className="text-right">
-              <div className="text-sm font-semibold text-brand-navy">{appt.time}</div>
-              <span
-                className={clsx(
-                  'mt-2 inline-flex items-center justify-center rounded-full px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-wide',
-                  statusStyles[appt.status] ?? 'bg-white/40 text-brand-navy'
-                )}
-              >
-                {appt.status}
-              </span>
-            </div>
-          </li>
-        ))}
+      <p className="text-sm text-white/75">
+        Roll out the confetti! We&apos;re pampering <span className="font-semibold text-white">{appointments.length}</span> party animals today.
+      </p>
+      <ul className="space-y-4">
+        {appointments.map((appt) => {
+          const emoji = emojiForAppointment(appt.id, appt.pet_name)
+          return (
+            <li
+              key={appt.id}
+              className="group relative overflow-hidden rounded-[2rem] border border-white/20 bg-gradient-to-r from-white/20 via-white/10 to-white/5 p-5 text-white shadow-[0_30px_60px_-28px_rgba(120,92,255,0.45)] backdrop-blur-2xl"
+            >
+              <div className="pointer-events-none absolute -left-20 top-1/2 h-56 w-56 -translate-y-1/2 rotate-12 rounded-full bg-white/15 blur-3xl transition duration-500 group-hover:rotate-0 group-hover:scale-110" />
+              <div className="pointer-events-none absolute right-[-3rem] top-[-3rem] h-36 w-36 rounded-full bg-white/10 blur-3xl" />
+              <div className="relative flex flex-wrap items-center gap-5">
+                <div className="grid h-14 w-14 place-items-center rounded-3xl bg-white text-2xl text-brand-navy shadow-inner">
+                  {emoji}
+                </div>
+                <div className="flex min-w-[160px] flex-1 flex-col gap-1">
+                  <p className="font-display text-lg uppercase tracking-[0.25em] drop-shadow">{appt.pet_name}</p>
+                  <p className="text-sm text-white/75">with {appt.client_name}</p>
+                </div>
+                <div className="flex flex-1 flex-col items-end gap-2 text-right sm:max-w-[160px]">
+                  <span className="rounded-full bg-white/20 px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.4em] text-white">
+                    {appt.time}
+                  </span>
+                  <span
+                    className={clsx(
+                      'inline-flex items-center gap-2 rounded-full px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.4em]',
+                      statusStyles[appt.status] ?? 'bg-white/80 text-brand-navy'
+                    )}
+                  >
+                    <span className="h-1.5 w-1.5 rounded-full bg-white/70" />
+                    {appt.status}
+                  </span>
+                </div>
+              </div>
+            </li>
+          )
+        })}
       </ul>
     </div>
   )

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -30,13 +30,22 @@ const config: Config = {
           lavender: '#7C5CFF',
           sunshine: '#FFD166',
           cream: '#F9FBFF'
+        },
+        electric: {
+          pink: '#FF3CAC',
+          purple: '#784BA0',
+          blue: '#2B86C5',
+          lime: '#B9FF38',
+          aqua: '#1BE7FF',
+          orange: '#FF8A05'
         }
       },
       fontFamily: {
         sans: ['var(--font-sans)', 'system-ui', 'sans-serif']
       },
       boxShadow: {
-        soft: '0 24px 55px -25px rgba(20, 90, 200, 0.55)'
+        soft: '0 24px 55px -25px rgba(20, 90, 200, 0.55)',
+        hyper: '0 28px 65px -20px rgba(120, 92, 255, 0.55)'
       },
       borderRadius: {
         '3xl': '1.75rem',


### PR DESCRIPTION
## Summary
- Switch the root layout to a neon cosmic backdrop with new display fonts and animated aurora layers that energise the entire experience. 
- Overhaul the global navigation, page container and widget shell into glowing glassmorphism cards with animated sparkles and gradient lighting. 
- Reimagine dashboard content with party-themed quick actions, emoji-rich appointment timelines, gradient workload meters, and celebratory revenue and inbox panels, powered by an expanded electric colour palette.

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd570d15a08324b8da2e1d3925e671