### PR TITLE
Fix employee workload widget query

### DIFF
--- a/components/dashboard/EmployeeWorkload.tsx
+++ b/components/dashboard/EmployeeWorkload.tsx
@@ -7,39 +7,99 @@ interface Workload {
   count: number
 }
 
+type WorkloadRow = {
+  employee_id: number | null
+  status: string | null
+  start_time: string
+  employees?:
+    | { name: string | null }[]
+    | { name: string | null }
+    | null
+}
+
+const ACTIVE_STATUS_KEYS = new Set(['checked_in', 'in_progress'])
+
 export default function EmployeeWorkload() {
   const [workloads, setWorkloads] = useState<Workload[]>([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
+    let active = true
+
     const fetchWorkloads = async () => {
+      setLoading(true)
       const now = new Date()
       const startOfDay = new Date(now)
       startOfDay.setHours(0, 0, 0, 0)
       const endOfDay = new Date(now)
       endOfDay.setHours(23, 59, 59, 999)
 
-      // Only fetch the appointments that could still be "active" today so we avoid
-      // loading the entire historical appointments table (which had started to slow
-      // the dashboard down as more records were added).
-      const { data, error } = await supabase
-        .from('appointments')
-        .select('groomer_name, status, start_time')
-        .in('status', ['Checked In', 'In Progress'])
-        .gte('start_time', startOfDay.toISOString())
-        .lte('start_time', endOfDay.toISOString())
+      try {
+        // Only fetch the appointments that could still be "active" today so we avoid
+        // loading the entire historical appointments table (which had started to slow
+        // the dashboard down as more records were added).
+        const { data, error } = await supabase
+          .from('appointments')
+          .select('employee_id, status, start_time, employees ( name )')
+          .gte('start_time', startOfDay.toISOString())
+          .lte('start_time', endOfDay.toISOString())
+          .in('status', [
+            'checked_in',
+            'in_progress',
+            'checked-in',
+            'in-progress',
+            'Checked In',
+            'In Progress',
+            'Checked-In',
+            'In-Progress',
+          ])
 
-      if (!error && data) {
-        const counts: Record<string, number> = {}
-        data.forEach((row) => {
-          const name = row.groomer_name || 'Unassigned'
-          counts[name] = (counts[name] || 0) + 1
+        if (error) throw error
+
+        const counts = new Map<string, number>()
+        const rows: WorkloadRow[] = data ?? []
+        rows.forEach((row) => {
+          const statusKey = (row.status ?? '')
+            .toString()
+            .toLowerCase()
+            .replace(/[-\s]+/g, '_')
+          if (!ACTIVE_STATUS_KEYS.has(statusKey)) return
+
+          const employeeRelation = Array.isArray(row.employees) ? row.employees[0] : row.employees
+          const nameFromRelation = employeeRelation?.name?.trim()
+          const fallbackName =
+            row.employee_id !== null && row.employee_id !== undefined
+              ? `Employee #${row.employee_id}`
+              : 'Unassigned'
+          const name = nameFromRelation && nameFromRelation.length > 0 ? nameFromRelation : fallbackName
+          counts.set(name, (counts.get(name) ?? 0) + 1)
         })
-        setWorkloads(Object.entries(counts).map(([employee_name, count]) => ({ employee_name, count })))
+
+        if (active) {
+          const sorted = Array.from(counts.entries())
+            .map(([employee_name, count]) => ({ employee_name, count }))
+            .sort((a, b) => {
+              if (b.count !== a.count) return b.count - a.count
+              return a.employee_name.localeCompare(b.employee_name)
+            })
+          setWorkloads(sorted)
+        }
+      } catch (err) {
+        console.error('Failed to load employee workload', err)
+        if (active) {
+          setWorkloads([])
+        }
+      } finally {
+        if (active) {
+          setLoading(false)
+        }
       }
-      setLoading(false)
     }
-    fetchWorkloads()
+    void fetchWorkloads()
+
+    return () => {
+      active = false
+    }
   }, [])
 
   if (loading) return <div className="text-white/80">Loading...</div>


### PR DESCRIPTION
## Summary
- update the employee workload widget to query Supabase appointments using the employees relationship
- normalise active appointment statuses, provide fallbacks for unnamed staff, and sort counts consistently
- improve robustness of the widget by handling empty/error cases and keeping loading state accurate

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd675aa00883249b9f4fe2bdb2e9ba