### PR TITLE
Reduce spacing on client detail page

### DIFF
--- a/app/clients/[id]/page.tsx
+++ b/app/clients/[id]/page.tsx
@@ -184,7 +184,7 @@ export default function ClientDetailPage() {
   const showSkeleton = loading && !client;
 
   return (
-    <PageContainer className="space-y-6">
+    <PageContainer variant="compact" className="space-y-5">
       <div>
         <Link
           href="/clients"
@@ -251,8 +251,8 @@ export default function ClientDetailPage() {
 
       {!showSkeleton && client && (
         <>
-          <Card className="space-y-8">
-            <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+          <Card className="space-y-6">
+            <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
               <div className="flex items-center gap-5">
                 <div className="flex h-20 w-20 items-center justify-center rounded-3xl bg-gradient-to-br from-brand-bubble to-brand-lavender text-2xl font-semibold text-primary shadow-soft">
                   {getInitials(client.full_name)}
@@ -376,7 +376,7 @@ export default function ClientDetailPage() {
             </div>
           </Card>
 
-          <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+          <div className="grid gap-5 lg:grid-cols-[2fr,1fr]">
             <Card className="space-y-6">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                 <h2 className="text-xl font-semibold text-primary-dark">Appointments</h2>

--- a/components/PageContainer.tsx
+++ b/components/PageContainer.tsx
@@ -1,9 +1,18 @@
 import { ReactNode } from 'react'
 import clsx from 'clsx'
 
-export default function PageContainer({ children, className = '' }: { children: ReactNode; className?: string }) {
+type PageContainerProps = {
+  children: ReactNode
+  className?: string
+  variant?: 'default' | 'compact'
+}
+
+export default function PageContainer({ children, className = '', variant = 'default' }: PageContainerProps) {
+  const paddingClass =
+    variant === 'compact' ? 'px-4 pb-16 pt-6 md:px-6' : 'px-4 pb-24 pt-10 md:px-8'
+
   return (
-    <div className="relative z-10 flex w-full justify-center px-4 pb-24 pt-10 md:px-8">
+    <div className={clsx('relative z-10 flex w-full justify-center', paddingClass)}>
       <div className="pointer-events-none absolute inset-0 -z-10">
         <div className="absolute left-0 top-10 h-72 w-72 rounded-full bg-white/10 blur-3xl" />
         <div className="absolute bottom-0 right-0 h-[28rem] w-[28rem] rounded-full bg-brand-bubble/10 blur-[160px]" />


### PR DESCRIPTION
## Summary
- add a compact variant to PageContainer to support tighter vertical padding
- use the compact layout on the client detail page and tune gaps to tighten the hero card and lower grid spacing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdbf7339e88324b2ad7b5d21d8aa2c