### PR TITLE
feat: refresh application theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -5,7 +5,7 @@
 /* Custom global styles */
 @layer base {
   body {
-    @apply relative min-h-screen;
+    @apply relative min-h-screen bg-brand-obsidian text-white/90;
     background-attachment: fixed;
   }
 
@@ -24,16 +24,20 @@
   }
 
   ::selection {
-    @apply bg-brand-bubble/70 text-white;
+    @apply bg-primary/70 text-white;
   }
 }
 
 @layer components {
   .glass-panel {
-    @apply rounded-[2.25rem] border border-white/20 bg-white/10 shadow-soft backdrop-blur-2xl;
+    @apply relative overflow-hidden rounded-[2.25rem] border border-white/10 text-white shadow-[0_35px_85px_-45px_rgba(3,8,30,0.9)] backdrop-blur-3xl;
+    background:
+      radial-gradient(circle at top left, rgba(124, 92, 255, 0.18), transparent 60%),
+      radial-gradient(circle at bottom right, rgba(49, 216, 175, 0.15), transparent 55%),
+      linear-gradient(140deg, rgba(10, 15, 32, 0.9), rgba(6, 9, 22, 0.74));
   }
 
   .nav-link {
-    @apply rounded-full px-4 py-2 text-sm font-semibold text-white/90 transition hover:bg-white/15;
+    @apply rounded-full px-4 py-2 text-sm font-semibold text-white/80 transition hover:bg-white/10 hover:text-white;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -46,14 +46,19 @@ export default async function RootLayout({ children }: { children: React.ReactNo
   return (
     <html lang="en" className="scroll-smooth">
       <body
-        className={`${nunito.variable} font-sans text-white/90 antialiased bg-gradient-to-br from-brand-blue via-primary to-brand-sky min-h-screen overflow-x-hidden`}
+        className={`${nunito.variable} bg-brand-obsidian font-sans text-white/90 antialiased min-h-screen overflow-x-hidden`}
       >
         <AuthProvider initialSession={session} initialProfile={initialProfile}>
           <div className="relative flex min-h-screen flex-col overflow-hidden">
             <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-              <div className="absolute -left-32 -top-40 h-96 w-96 rounded-full bg-brand-bubble/30 blur-[120px]" />
-              <div className="absolute -right-24 top-24 h-[28rem] w-[28rem] rounded-full bg-brand-lavender/25 blur-[140px]" />
-              <div className="absolute bottom-[-18rem] left-1/2 h-[32rem] w-[32rem] -translate-x-1/2 rounded-full bg-brand-mint/20 blur-[160px]" />
+              <div className="absolute inset-0 bg-gradient-to-br from-brand-obsidian via-brand-navy/60 to-black" />
+              <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(30,123,255,0.25),transparent_62%)]" />
+              <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom_right,rgba(255,102,196,0.22),transparent_58%)]" />
+              <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,rgba(8,36,90,0.5),transparent_65%)]" />
+              <div className="absolute -left-44 -top-40 h-[28rem] w-[28rem] rounded-full bg-primary/20 blur-[220px]" />
+              <div className="absolute right-[-20rem] top-1/3 h-[34rem] w-[34rem] rounded-full bg-brand-bubble/25 blur-[240px]" />
+              <div className="absolute bottom-[-22rem] left-1/4 h-[38rem] w-[38rem] rounded-full bg-brand-mint/22 blur-[220px]" />
+              <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(255,255,255,0.06),transparent_70%)]" />
             </div>
             <TopNav />
             <main className="relative z-10 flex-1">{children}</main>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -19,8 +19,10 @@ export default function LoginPage() {
     <Suspense fallback={null}>
       <div className="relative flex min-h-[calc(100vh-6rem)] w-full items-center justify-center px-4 pb-16 pt-12">
         <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-          <div className="absolute -left-24 top-10 h-80 w-80 rounded-full bg-white/15 blur-[140px]" />
-          <div className="absolute bottom-0 right-0 h-[28rem] w-[28rem] rounded-full bg-brand-bubble/20 blur-[200px]" />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(30,123,255,0.2),transparent_60%)]" />
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom_right,rgba(255,102,196,0.2),transparent_60%)]" />
+          <div className="absolute -left-24 top-6 h-80 w-80 rounded-full bg-primary/25 blur-[200px]" />
+          <div className="absolute bottom-[-14rem] right-[-6rem] h-[30rem] w-[30rem] rounded-full bg-brand-obsidian/70 blur-[220px]" />
         </div>
         <LoginForm />
       </div>

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -127,38 +127,38 @@ export default function SettingsPage() {
 
   return (
     <div className="space-y-8 p-6">
-      <div className="glass-panel max-w-3xl space-y-4 bg-white/90 p-6 text-brand-navy">
+      <div className="glass-panel max-w-3xl space-y-5 bg-[linear-gradient(150deg,rgba(8,12,28,0.94)_0%,rgba(8,36,90,0.78)_52%,rgba(5,6,18,0.92)_100%)] p-6 backdrop-saturate-150">
         <div>
-          <h1 className="text-3xl font-bold text-brand-navy">Settings</h1>
-          <p className="text-sm text-brand-navy/70">Manage your Scruffy Butts workspace.</p>
+          <h1 className="text-3xl font-bold text-white">Settings</h1>
+          <p className="text-sm text-white/70">Manage your Scruffy Butts workspace.</p>
         </div>
 
-        <div className="rounded-2xl bg-white/70 p-4 shadow-inner">
-          <p className="text-xs font-semibold uppercase tracking-[0.35em] text-brand-navy/60">Logged in as</p>
-          <p className="text-2xl font-bold text-brand-navy">
+        <div className="rounded-2xl border border-white/10 bg-white/5 p-4 shadow-[inset_0_1px_0_rgba(255,255,255,0.06)]">
+          <p className="text-xs font-semibold uppercase tracking-[0.35em] text-white/50">Logged in as</p>
+          <p className="text-2xl font-bold text-white">
             {displayName ?? userEmail ?? 'Team member'}
           </p>
-          <p className="text-sm text-brand-navy/70">
-            Role: <span className="font-semibold text-brand-navy">{roleLabel}</span>
+          <p className="text-sm text-white/70">
+            Role: <span className="font-semibold text-white">{roleLabel}</span>
           </p>
-          {userEmail && <p className="text-xs text-brand-navy/50">Email: {userEmail}</p>}
+          {userEmail && <p className="text-xs text-white/50">Email: {userEmail}</p>}
         </div>
 
         <button
           onClick={handleLogout}
-          className="inline-flex items-center justify-center rounded-full bg-brand-bubble px-5 py-2 text-sm font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:bg-brand-bubbleDark"
+          className="inline-flex items-center justify-center rounded-full bg-gradient-to-r from-brand-bubble to-brand-bubbleDark px-5 py-2 text-sm font-semibold text-white shadow-[0_24px_40px_-24px_rgba(255,102,196,0.85)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_24px_45px_-22px_rgba(255,61,158,0.9)]"
         >
           Log out
         </button>
       </div>
 
       <div className="grid gap-6 lg:grid-cols-2">
-        <div className="glass-panel space-y-3 bg-white/90 p-6 text-brand-navy">
-          <h2 className="text-xl font-semibold">Configuration</h2>
-          <ul className="list-disc space-y-1 pl-6 text-sm text-brand-navy/80">
+        <div className="glass-panel space-y-4 bg-[linear-gradient(150deg,rgba(8,12,28,0.92)_0%,rgba(8,36,90,0.75)_50%,rgba(5,6,18,0.9)_100%)] p-6 backdrop-saturate-150">
+          <h2 className="text-xl font-semibold text-white">Configuration</h2>
+          <ul className="list-disc space-y-1 pl-6 text-sm text-white/70">
             {configurationLinks.map((link) => (
               <li key={link.href}>
-                <Link className="text-brand-bubble hover:text-brand-bubbleDark" href={link.href}>
+                <Link className="text-brand-bubble transition-colors hover:text-brand-bubbleDark" href={link.href}>
                   {link.label}
                 </Link>
               </li>
@@ -167,33 +167,33 @@ export default function SettingsPage() {
         </div>
 
         {isOwner && (
-          <div className="glass-panel space-y-4 bg-white/90 p-6 text-brand-navy">
+          <div className="glass-panel space-y-4 bg-[linear-gradient(150deg,rgba(8,12,28,0.92)_0%,rgba(8,36,90,0.75)_50%,rgba(5,6,18,0.9)_100%)] p-6 backdrop-saturate-150">
             <div className="flex items-center justify-between">
-              <h2 className="text-xl font-semibold">Team members with elevated access</h2>
+              <h2 className="text-xl font-semibold text-white">Team members with elevated access</h2>
               <button
                 onClick={() => void loadTeam()}
                 disabled={loading}
-                className="text-sm font-semibold text-brand-bubble transition hover:text-brand-bubbleDark disabled:cursor-not-allowed disabled:opacity-60"
+                className="text-sm font-semibold text-brand-bubble transition-colors hover:text-brand-bubbleDark disabled:cursor-not-allowed disabled:opacity-60"
               >
                 {loading ? 'Refreshing…' : 'Refresh'}
               </button>
             </div>
-            {err && <p className="text-sm font-medium text-red-600">{err}</p>}
+            {err && <p className="text-sm font-medium text-red-200">{err}</p>}
             {!err && team.length === 0 && (
-              <p className="text-sm text-brand-navy/70">
+              <p className="text-sm text-white/70">
                 No other teammates currently have elevated access.
               </p>
             )}
-            <ul className="space-y-3 text-sm">
+            <ul className="space-y-3 text-sm text-white">
               {team.map((member) => (
                 <li
                   key={member.id ?? member.email ?? Math.random()}
-                  className="rounded-xl border border-brand-navy/10 bg-white/70 p-3 shadow-sm"
+                  className="rounded-xl border border-white/10 bg-white/5 p-3 shadow-[0_18px_38px_-28px_rgba(5,10,35,0.75)]"
                 >
-                  <p className="font-semibold text-brand-navy">
+                  <p className="font-semibold text-white">
                     {member.name ?? member.email ?? `Team member #${member.id ?? '—'}`}
                   </p>
-                  <p className="text-xs text-brand-navy/60">
+                  <p className="text-xs text-white/60">
                     {member.email ?? '—'} • {member.role ?? 'Team member'}
                   </p>
                 </li>

--- a/components/LoginBanner.tsx
+++ b/components/LoginBanner.tsx
@@ -27,7 +27,7 @@ export default function LoginBanner() {
   return (
     <form
       onSubmit={onSubmit}
-      className="glass-panel mb-6 flex flex-wrap items-center gap-3 bg-white/95 p-4 text-sm text-brand-navy"
+      className="glass-panel mb-6 flex flex-wrap items-center gap-3 bg-[linear-gradient(150deg,rgba(8,12,28,0.92)_0%,rgba(8,36,90,0.75)_48%,rgba(5,6,18,0.9)_100%)] p-4 text-sm text-white/80 backdrop-saturate-150"
     >
       <input
         type="email"
@@ -35,6 +35,7 @@ export default function LoginBanner() {
         placeholder="Email"
         value={email}
         onChange={(e) => setEmail(e.target.value)}
+        className="min-w-[160px] flex-1 rounded-2xl border-white/10 bg-white/10 px-4 py-2 text-sm text-white placeholder:text-white/55 shadow-[0_16px_40px_-28px_rgba(8,36,90,0.8)] focus:border-brand-bubble focus:ring-brand-bubble/40"
       />
       <input
         type="password"
@@ -42,15 +43,20 @@ export default function LoginBanner() {
         placeholder="Password"
         value={password}
         onChange={(e) => setPassword(e.target.value)}
+        className="min-w-[140px] flex-1 rounded-2xl border-white/10 bg-white/10 px-4 py-2 text-sm text-white placeholder:text-white/55 shadow-[0_16px_40px_-28px_rgba(8,36,90,0.8)] focus:border-brand-bubble focus:ring-brand-bubble/40"
       />
       <button
         type="submit"
         disabled={loading}
-        className="rounded-full bg-brand-bubble px-4 py-2 font-semibold text-white shadow-lg transition hover:-translate-y-0.5 hover:bg-brand-bubbleDark disabled:cursor-not-allowed disabled:opacity-60"
+        className="rounded-full bg-gradient-to-r from-brand-bubble to-brand-bubbleDark px-4 py-2 font-semibold text-white shadow-[0_22px_40px_-24px_rgba(255,102,196,0.85)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_22px_45px_-22px_rgba(255,61,158,0.9)] disabled:cursor-not-allowed disabled:opacity-60"
       >
         {loading ? 'Logging in...' : 'Login'}
       </button>
-      {err && <span className="ml-2 font-medium text-red-600">{err}</span>}
+      {err && (
+        <span className="ml-2 rounded-full border border-red-500/30 bg-red-500/15 px-3 py-1 font-medium text-red-100">
+          {err}
+        </span>
+      )}
     </form>
   );
 }

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -169,29 +169,29 @@ export default function LoginForm() {
   return (
     <form
       onSubmit={onSubmit}
-      className="glass-panel w-full max-w-md space-y-5 bg-white/95 p-10 text-brand-navy"
+      className="glass-panel w-full max-w-md space-y-6 bg-[linear-gradient(155deg,rgba(8,12,28,0.95)_0%,rgba(8,36,90,0.78)_52%,rgba(5,6,18,0.92)_100%)] p-10 backdrop-saturate-150"
     >
-      <div className="space-y-1">
-        <p className="text-xs font-semibold uppercase tracking-[0.35em] text-brand-navy/60">
+      <div className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.35em] text-white/50">
           Welcome back
         </p>
-        <h1 className="text-3xl font-black tracking-tight text-brand-navy">
-          Scruffy squad <span className="ml-1">🐶</span>
+        <h1 className="text-3xl font-black tracking-tight text-white">
+          Scruffy squad <span className="ml-1 text-brand-bubble">🐶</span>
         </h1>
-        <p className="text-sm text-brand-navy/70">Sign in to keep the tails wagging.</p>
+        <p className="text-sm text-white/70">Sign in to keep the tails wagging.</p>
       </div>
 
       {err && (
-        <div className="rounded-2xl border border-red-300/60 bg-red-100/60 px-3 py-2 text-sm text-red-700">
+        <div className="rounded-2xl border border-red-500/40 bg-red-500/15 px-3 py-2 text-sm text-red-100 shadow-inner">
           {err}
         </div>
       )}
 
       <div className="space-y-4">
         <div className="space-y-1">
-          <label className="block text-sm font-semibold text-brand-navy">Email</label>
+          <label className="block text-sm font-semibold text-white">Email</label>
           <input
-            className="w-full"
+            className="w-full border-white/10 bg-white/10 text-white placeholder:text-white/60 shadow-[0_22px_45px_-30px_rgba(8,36,90,0.8)] focus:border-brand-bubble focus:ring-brand-bubble/40"
             type="email"
             required
             value={email}
@@ -201,9 +201,9 @@ export default function LoginForm() {
         </div>
 
         <div className="space-y-1">
-          <label className="block text-sm font-semibold text-brand-navy">Password</label>
+          <label className="block text-sm font-semibold text-white">Password</label>
           <input
-            className="w-full"
+            className="w-full border-white/10 bg-white/10 text-white placeholder:text-white/60 shadow-[0_22px_45px_-30px_rgba(8,36,90,0.8)] focus:border-brand-bubble focus:ring-brand-bubble/40"
             type="password"
             required
             value={password}
@@ -216,12 +216,12 @@ export default function LoginForm() {
       <button
         type="submit"
         disabled={loading}
-        className="w-full rounded-full bg-brand-bubble px-5 py-3 text-base font-semibold text-white shadow-lg transition-all duration-200 hover:-translate-y-0.5 hover:bg-brand-bubbleDark disabled:cursor-not-allowed disabled:opacity-60"
+        className="w-full rounded-full bg-gradient-to-r from-brand-bubble to-brand-bubbleDark px-5 py-3 text-base font-semibold text-white shadow-[0_28px_45px_-25px_rgba(255,102,196,0.85)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_28px_50px_-23px_rgba(255,61,158,0.9)] disabled:cursor-not-allowed disabled:opacity-60"
       >
         {loading ? 'Signing in…' : 'Sign in'}
       </button>
 
-      <div className="flex justify-between text-sm text-brand-navy/70">
+      <div className="flex justify-between text-sm text-white/60">
         <a className="font-semibold text-brand-bubble transition-colors hover:text-brand-bubbleDark" href="/signup">
           Create account
         </a>

--- a/components/PageContainer.tsx
+++ b/components/PageContainer.tsx
@@ -14,8 +14,11 @@ export default function PageContainer({ children, className = '', variant = 'def
   return (
     <div className={clsx('relative z-10 flex w-full justify-center', paddingClass)}>
       <div className="pointer-events-none absolute inset-0 -z-10">
-        <div className="absolute left-0 top-10 h-72 w-72 rounded-full bg-white/10 blur-3xl" />
-        <div className="absolute bottom-0 right-0 h-[28rem] w-[28rem] rounded-full bg-brand-bubble/10 blur-[160px]" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(30,123,255,0.18),transparent_60%)]" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom_right,rgba(255,102,196,0.16),transparent_62%)]" />
+        <div className="absolute -left-32 top-4 h-80 w-80 rounded-full bg-primary/25 blur-[200px]" />
+        <div className="absolute right-[-18rem] bottom-[-12rem] h-[32rem] w-[32rem] rounded-full bg-brand-obsidian/80 blur-[240px]" />
+        <div className="absolute left-1/2 top-1/3 h-[26rem] w-[26rem] -translate-x-1/2 rounded-full bg-brand-mint/20 blur-[200px]" />
       </div>
       <div className={clsx('w-full max-w-6xl space-y-6', className)}>{children}</div>
     </div>

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -29,14 +29,21 @@ export default function TopNav() {
 
   return (
     <header className="sticky top-0 z-40 flex justify-center px-4 pt-6">
-      <div className="glass-panel flex w-full max-w-6xl items-center justify-between px-6 py-4">
-        <Link href="/" className="group flex items-center gap-4 text-white">
-          <span className="grid h-12 w-12 place-items-center rounded-full bg-white/90 text-2xl shadow-inner ring-4 ring-white/40 transition-transform duration-300 group-hover:-rotate-12">
+      <div
+        className="glass-panel flex w-full max-w-6xl items-center justify-between overflow-hidden px-6 py-4 ring-1 ring-white/10 bg-[linear-gradient(135deg,rgba(5,6,18,0.92)_0%,rgba(8,36,90,0.66)_45%,rgba(5,6,18,0.88)_100%)]"
+      >
+        <div className="pointer-events-none absolute inset-0 -z-10">
+          <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/25 to-transparent" />
+          <div className="absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-white/10 to-transparent" />
+          <div className="absolute left-1/2 top-1/2 h-48 w-48 -translate-x-1/2 -translate-y-1/2 rounded-full bg-white/5 blur-[160px]" />
+        </div>
+        <Link href="/" className="group relative flex items-center gap-4 text-white">
+          <span className="grid h-12 w-12 place-items-center rounded-[1.4rem] border border-white/15 bg-[radial-gradient(circle_at_top_left,rgba(124,92,255,0.35),rgba(5,6,18,0.92))] text-2xl text-brand-bubble shadow-[inset_0_1px_6px_rgba(255,255,255,0.12)] transition-all duration-300 group-hover:-rotate-12 group-hover:scale-105">
             🐾
           </span>
           <div className="flex flex-col leading-tight">
-            <span className="text-xs font-semibold uppercase tracking-[0.4em] text-white/70">Scruffy</span>
-            <span className="text-2xl font-black text-white transition-colors duration-300 group-hover:text-brand-cream">
+            <span className="text-xs font-semibold uppercase tracking-[0.4em] text-white/60">Scruffy</span>
+            <span className="text-2xl font-black text-white transition-colors duration-300 group-hover:text-brand-bubble">
               Butts
             </span>
           </div>
@@ -49,10 +56,10 @@ export default function TopNav() {
                 key={link.href}
                 href={link.href}
                 className={clsx(
-                  "nav-link",
+                  "nav-link backdrop-blur-sm transition-all duration-200",
                   isActive
-                    ? "bg-white/25 text-white shadow-sm"
-                    : "text-white/80 hover:text-white"
+                    ? "bg-white/12 text-white shadow-[0_12px_32px_-18px_rgba(30,123,255,0.85)] ring-1 ring-white/15"
+                    : "text-white/70 hover:bg-white/5 hover:text-white"
                 )}
               >
                 {link.label}
@@ -61,16 +68,16 @@ export default function TopNav() {
           })}
         </nav>
         <div className="flex items-center gap-3">
-          <div className="hidden text-right text-xs leading-tight text-white/80 sm:flex sm:flex-col sm:items-end">
+          <div className="hidden text-right text-xs leading-tight text-white/70 sm:flex sm:flex-col sm:items-end">
             {displayName && (
               <span className="font-semibold text-white">{displayName}</span>
             )}
-            {role && <span className="uppercase tracking-[0.22em] text-[11px] text-white/60">{role}</span>}
+            {role && <span className="uppercase tracking-[0.22em] text-[11px] text-white/50">{role}</span>}
           </div>
           <button
             type="button"
             onClick={handleSignOut}
-            className="rounded-full bg-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.25em] text-white transition hover:bg-white/30"
+            className="rounded-full bg-gradient-to-r from-brand-bubble to-brand-bubbleDark px-4 py-2 text-xs font-semibold uppercase tracking-[0.25em] text-white shadow-[0_22px_36px_-22px_rgba(255,102,196,0.85)] transition-all duration-200 hover:-translate-y-0.5 hover:shadow-[0_22px_40px_-20px_rgba(255,102,196,0.9)] disabled:cursor-not-allowed disabled:opacity-60"
             disabled={loading}
           >
             Log out

--- a/components/Widget.tsx
+++ b/components/Widget.tsx
@@ -11,10 +11,10 @@ interface WidgetProps {
 }
 
 const backgroundMap: Record<Required<WidgetProps>['color'], string> = {
-  blue: 'bg-gradient-to-br from-[#1D4DFF] via-[#2E8CFF] to-[#55C3FF]',
-  pink: 'bg-gradient-to-br from-brand-bubble to-brand-bubbleDark',
-  purple: 'bg-gradient-to-br from-brand-lavender via-[#5B7DFF] to-primary',
-  green: 'bg-gradient-to-br from-brand-mint via-[#3CE0B7] to-[#43F0C5]'
+  blue: 'bg-[linear-gradient(135deg,rgba(5,7,18,0.95)_0%,rgba(29,77,255,0.85)_45%,rgba(99,196,255,0.9)_100%)]',
+  pink: 'bg-[linear-gradient(135deg,rgba(5,7,18,0.95)_0%,rgba(255,102,196,0.9)_52%,rgba(255,61,158,0.88)_100%)]',
+  purple: 'bg-[linear-gradient(135deg,rgba(5,7,18,0.95)_0%,rgba(124,92,255,0.85)_48%,rgba(30,123,255,0.85)_100%)]',
+  green: 'bg-[linear-gradient(135deg,rgba(5,7,18,0.95)_0%,rgba(49,216,175,0.85)_45%,rgba(67,240,197,0.85)_100%)]'
 }
 
 export default function Widget({
@@ -30,13 +30,14 @@ export default function Widget({
   return (
     <div
       className={clsx(
-        'relative overflow-hidden rounded-3xl border border-white/25 text-white shadow-soft backdrop-blur-xl',
+        'relative overflow-hidden rounded-3xl border border-white/10 text-white shadow-[0_40px_90px_-45px_rgba(5,10,45,0.9)] backdrop-blur-xl',
         gradient,
         className
       )}
     >
-      <div className="pointer-events-none absolute -right-16 -top-24 h-56 w-56 rounded-full bg-white/25 blur-[120px]" />
-      <div className="pointer-events-none absolute bottom-[-30%] left-[-20%] h-72 w-72 rounded-full bg-white/10 blur-[160px]" />
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/25 to-transparent" />
+      <div className="pointer-events-none absolute -right-24 -top-28 h-64 w-64 rounded-full bg-white/12 blur-[150px]" />
+      <div className="pointer-events-none absolute bottom-[-35%] left-[-20%] h-80 w-80 rounded-full bg-brand-obsidian/70 blur-[220px]" />
       {!hideHeader && (
         <div className="relative flex items-center justify-between px-5 pt-5">
           <h2 className="text-base font-semibold tracking-tight drop-shadow-md">{title}</h2>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -24,6 +24,8 @@ const config: Config = {
           sky: '#5CC2FF',
           blue: '#1A6BFF',
           navy: '#08245A',
+          obsidian: '#05060F',
+          charcoal: '#111322',
           bubble: '#FF66C4',
           bubbleDark: '#FF3D9E',
           mint: '#31D8AF',
@@ -36,7 +38,7 @@ const config: Config = {
         sans: ['var(--font-sans)', 'system-ui', 'sans-serif']
       },
       boxShadow: {
-        soft: '0 24px 55px -25px rgba(20, 90, 200, 0.55)'
+        soft: '0 32px 90px -40px rgba(5, 10, 45, 0.75)'
       },
       borderRadius: {
         '3xl': '1.75rem',


### PR DESCRIPTION
## Summary
- introduce a noir-inspired palette by extending brand colors and updating global glass treatments
- restyle the layout chrome, navigation, and widgets with deeper gradients and accent glows
- refresh authentication and settings views to match the new theme while keeping brand accents

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cdef2378c8832485b7360cdccb8717