### PR TITLE
Fix employee self-service pages to locate payroll data

### DIFF
--- a/app/employees/payroll/page.tsx
+++ b/app/employees/payroll/page.tsx
@@ -3,6 +3,7 @@
 
 import { useEffect, useState } from 'react';
 import { supabase } from '@/lib/supabase/client';
+import { resolveCurrentEmployee } from '@/lib/employees/current-employee';
 
 type Row = {
   id: number;
@@ -24,21 +25,9 @@ export default function EmployeePayrollPage() {
     setLoading(true);
     setErr(null);
 
-    const uid = (await supabase.auth.getUser()).data.user?.id;
-    if (!uid) {
-      setErr('No logged-in user');
-      setLoading(false);
-      return;
-    }
-
-    const { data: emp, error: empErr } = await supabase
-      .from('employees')
-      .select('id')
-      .eq('user_id', uid)
-      .single();
-
-    if (empErr || !emp) {
-      setErr(empErr?.message || 'Employee not found');
+    const { employeeId, error: employeeError } = await resolveCurrentEmployee();
+    if (!employeeId) {
+      setErr(employeeError || 'Employee not found');
       setLoading(false);
       return;
     }
@@ -55,7 +44,7 @@ export default function EmployeePayrollPage() {
         guarantee_topup_dollars,
         final_dollars
       `)
-      .eq('employee_id', emp.id)
+      .eq('employee_id', employeeId)
       .order('paid_at', { ascending: false });
 
     if (error) setErr(error.message);

--- a/lib/employees/current-employee.ts
+++ b/lib/employees/current-employee.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import type { PostgrestError } from "@supabase/supabase-js";
+
+import { supabase } from "@/lib/supabase/client";
+
+function isMissingColumnError(error: PostgrestError | null) {
+  if (!error) return false;
+  if (error.code === "42703") return true;
+  const message = error.message?.toLowerCase() ?? "";
+  return message.includes("column") && message.includes("does not exist");
+}
+
+export type CurrentEmployeeResolution = {
+  userId: string | null;
+  email: string | null;
+  employeeId: number | null;
+  method: "user_id" | "email" | null;
+  error: string | null;
+};
+
+function normaliseId(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+export async function resolveCurrentEmployee(): Promise<CurrentEmployeeResolution> {
+  const { data: authData, error: authError } = await supabase.auth.getUser();
+  if (authError) {
+    return { userId: null, email: null, employeeId: null, method: null, error: authError.message };
+  }
+
+  const user = authData.user;
+  if (!user) {
+    return { userId: null, email: null, employeeId: null, method: null, error: "No logged-in user" };
+  }
+
+  const userId = user.id ?? null;
+  const email = typeof user.email === "string" ? user.email : null;
+
+  if (userId) {
+    const { data, error } = await supabase
+      .from("employees")
+      .select("id")
+      .eq("user_id", userId)
+      .maybeSingle();
+
+    if (!error && data) {
+      const employeeId = normaliseId((data as { id: unknown }).id);
+      if (employeeId !== null) {
+        return { userId, email, employeeId, method: "user_id", error: null };
+      }
+    }
+
+    if (error && !isMissingColumnError(error as PostgrestError)) {
+      return { userId, email, employeeId: null, method: "user_id", error: error.message };
+    }
+  }
+
+  if (email) {
+    const trimmedEmail = email.trim();
+    if (trimmedEmail) {
+      const { data, error } = await supabase
+        .from("employees")
+        .select("id")
+        .ilike("email", trimmedEmail)
+        .maybeSingle();
+
+      if (!error && data) {
+        const employeeId = normaliseId((data as { id: unknown }).id);
+        if (employeeId !== null) {
+          return { userId, email, employeeId, method: "email", error: null };
+        }
+      }
+
+      if (error && !isMissingColumnError(error as PostgrestError)) {
+        return { userId, email, employeeId: null, method: "email", error: error.message };
+      }
+    }
+  }
+
+  return {
+    userId,
+    email,
+    employeeId: null,
+    method: null,
+    error: "Employee record not found for the current user",
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared helper that resolves the current employee record from the logged-in Supabase user, falling back to email matching when user_id is absent
- update the employee payroll, overview, and history self-service pages to rely on the helper so they can load data instead of erroring out

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d14345266483248a4e58535de1d07f