### PR TITLE
Separate compensation and permissions cards for staff management

### DIFF
--- a/app/employees/[id]/settings/page.tsx
+++ b/app/employees/[id]/settings/page.tsx
@@ -80,6 +80,7 @@ export default function EmployeeSettingsPage() {
   const [editing, setEditing] = useState({
     profile: false,
     comp: false,
+    perms: false,
     prefs: false,
     notes: false,
   });
@@ -87,6 +88,7 @@ export default function EmployeeSettingsPage() {
   const [saving, setSaving] = useState({
     profile: false,
     comp: false,
+    perms: false,
     prefs: false,
     notes: false,
   });
@@ -111,8 +113,8 @@ export default function EmployeeSettingsPage() {
     pushToast("Profile updated", "success");
   };
 
-  const handleCompensationSave = async () => {
-    setSaving((s) => ({ ...s, comp: true }));
+  const persistCompensation = async (section: "comp" | "perms") => {
+    setSaving((s) => ({ ...s, [section]: true }));
     const result = await saveCompensationAction(employee.id, {
       pay_type: compensation.pay_type,
       commission_rate: Number(compensation.commission_rate) || 0,
@@ -120,13 +122,23 @@ export default function EmployeeSettingsPage() {
       salary_rate: Number(compensation.salary_rate) || 0,
       app_permissions: compensation.app_permissions,
     });
-    setSaving((s) => ({ ...s, comp: false }));
+    setSaving((s) => ({ ...s, [section]: false }));
     if (!result.success) {
-      pushToast(result.error ?? "Failed to save compensation", "error");
+      const errorMessage =
+        section === "comp" ? "Failed to save compensation" : "Failed to save permissions";
+      pushToast(result.error ?? errorMessage, "error");
       return;
     }
-    setEditing((e) => ({ ...e, comp: false }));
-    pushToast("Compensation updated", "success");
+    setEditing((e) => ({ ...e, [section]: false }));
+    pushToast(section === "comp" ? "Compensation updated" : "Permissions updated", "success");
+  };
+
+  const handleCompensationSave = () => {
+    void persistCompensation("comp");
+  };
+
+  const handlePermissionsSave = () => {
+    void persistCompensation("perms");
   };
 
   const handlePreferencesSave = async () => {
@@ -206,8 +218,8 @@ export default function EmployeeSettingsPage() {
       {/* Compensation */}
       <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
         <SectionHeader
-          title="Compensation & Permissions"
-          subtitle="Control pay structures and access for this employee."
+          title="Compensation"
+          subtitle="Control pay structures for this employee."
           isEditing={editing.comp}
           isSaving={saving.comp}
           onEdit={() => beginEdit("comp")}
@@ -240,29 +252,38 @@ export default function EmployeeSettingsPage() {
             disabled={!editing.comp || saving.comp}
           />
         </div>
-        <div className="mt-6">
-          <div className="text-xs font-semibold uppercase tracking-wide text-slate-500">App permissions</div>
-          <div className="mt-3 grid gap-3 md:grid-cols-2">
-            {PERMISSION_OPTIONS.map((option) => (
-              <label key={option.key} className="flex items-center gap-2 text-sm text-slate-600">
-                <input
-                  type="checkbox"
-                  checked={!!compensation.app_permissions[option.key]}
-                  onChange={(e) =>
-                    setCompensation((prev) => ({
-                      ...prev,
-                      app_permissions: {
-                        ...prev.app_permissions,
-                        [option.key]: e.target.checked,
-                      },
-                    }))
-                  }
-                  disabled={!editing.comp || saving.comp}
-                />
-                {option.label}
-              </label>
-            ))}
-          </div>
+      </section>
+
+      {/* App permissions */}
+      <section className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+        <SectionHeader
+          title="App Permissions"
+          subtitle="Choose which parts of Scruffy Butts this employee can manage."
+          isEditing={editing.perms}
+          isSaving={saving.perms}
+          onEdit={() => beginEdit("perms")}
+          onSave={handlePermissionsSave}
+        />
+        <div className="mt-4 grid gap-3 md:grid-cols-2">
+          {PERMISSION_OPTIONS.map((option) => (
+            <label key={option.key} className="flex items-center gap-2 text-sm text-slate-600">
+              <input
+                type="checkbox"
+                checked={!!compensation.app_permissions[option.key]}
+                onChange={(e) =>
+                  setCompensation((prev) => ({
+                    ...prev,
+                    app_permissions: {
+                      ...prev.app_permissions,
+                      [option.key]: e.target.checked,
+                    },
+                  }))
+                }
+                disabled={!editing.perms || saving.perms}
+              />
+              {option.label}
+            </label>
+          ))}
         </div>
       </section>
 

--- a/app/employees/new/page.tsx
+++ b/app/employees/new/page.tsx
@@ -482,82 +482,87 @@ export default function NewEmployeePage() {
             ) : null}
           </section>
 
-          <section className="space-y-6">
+          <section className="space-y-4">
             <div className="space-y-1">
-              <h2 className="text-xl font-semibold text-brand-navy">Compensation & access</h2>
+              <h2 className="text-xl font-semibold text-brand-navy">Compensation</h2>
+              <p className="text-sm text-brand-navy/70">Set how this employee is paid and rewarded.</p>
+            </div>
+            <div className="rounded-2xl border border-white/50 bg-white/80 p-4 shadow-inner">
+              <div className="grid gap-4 md:grid-cols-2">
+                <div className="space-y-1">
+                  <label className={labelClass} htmlFor="employee-pay-type">
+                    Pay type
+                  </label>
+                  <select
+                    id="employee-pay-type"
+                    className={inputClass}
+                    value={form.payType}
+                    onChange={(event) => setForm((prev) => ({ ...prev, payType: event.target.value as PayType }))}
+                  >
+                    {PAY_TYPE_OPTIONS.map((option) => (
+                      <option key={option} value={option}>
+                        {option.charAt(0).toUpperCase() + option.slice(1)}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="space-y-1">
+                  <label className={labelClass} htmlFor="employee-commission">
+                    Commission %
+                  </label>
+                  <input
+                    id="employee-commission"
+                    className={inputClass}
+                    type="number"
+                    min={0}
+                    max={100}
+                    step="0.1"
+                    value={form.commissionPercent}
+                    onChange={(event) => setForm((prev) => ({ ...prev, commissionPercent: event.target.value }))}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className={labelClass} htmlFor="employee-hourly">
+                    Hourly rate
+                  </label>
+                  <input
+                    id="employee-hourly"
+                    className={inputClass}
+                    type="number"
+                    min={0}
+                    step="0.01"
+                    value={form.hourlyRate}
+                    onChange={(event) => setForm((prev) => ({ ...prev, hourlyRate: event.target.value }))}
+                  />
+                </div>
+                <div className="space-y-1">
+                  <label className={labelClass} htmlFor="employee-salary">
+                    Salary rate
+                  </label>
+                  <input
+                    id="employee-salary"
+                    className={inputClass}
+                    type="number"
+                    min={0}
+                    step="0.01"
+                    value={form.salaryRate}
+                    onChange={(event) => setForm((prev) => ({ ...prev, salaryRate: event.target.value }))}
+                  />
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="space-y-4">
+            <div className="space-y-1">
+              <h2 className="text-xl font-semibold text-brand-navy">App permissions</h2>
               <p className="text-sm text-brand-navy/70">
-                Configure how this employee is paid and the tools they can manage inside Scruffy Butts.
-              </p>
-            </div>
-            <div className="grid gap-4 md:grid-cols-2">
-              <div className="space-y-1">
-                <label className={labelClass} htmlFor="employee-pay-type">
-                  Pay type
-                </label>
-                <select
-                  id="employee-pay-type"
-                  className={inputClass}
-                  value={form.payType}
-                  onChange={(event) => setForm((prev) => ({ ...prev, payType: event.target.value as PayType }))}
-                >
-                  {PAY_TYPE_OPTIONS.map((option) => (
-                    <option key={option} value={option}>
-                      {option.charAt(0).toUpperCase() + option.slice(1)}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <div className="space-y-1">
-                <label className={labelClass} htmlFor="employee-commission">
-                  Commission %
-                </label>
-                <input
-                  id="employee-commission"
-                  className={inputClass}
-                  type="number"
-                  min={0}
-                  max={100}
-                  step="0.1"
-                  value={form.commissionPercent}
-                  onChange={(event) => setForm((prev) => ({ ...prev, commissionPercent: event.target.value }))}
-                />
-              </div>
-              <div className="space-y-1">
-                <label className={labelClass} htmlFor="employee-hourly">
-                  Hourly rate
-                </label>
-                <input
-                  id="employee-hourly"
-                  className={inputClass}
-                  type="number"
-                  min={0}
-                  step="0.01"
-                  value={form.hourlyRate}
-                  onChange={(event) => setForm((prev) => ({ ...prev, hourlyRate: event.target.value }))}
-                />
-              </div>
-              <div className="space-y-1">
-                <label className={labelClass} htmlFor="employee-salary">
-                  Salary rate
-                </label>
-                <input
-                  id="employee-salary"
-                  className={inputClass}
-                  type="number"
-                  min={0}
-                  step="0.01"
-                  value={form.salaryRate}
-                  onChange={(event) => setForm((prev) => ({ ...prev, salaryRate: event.target.value }))}
-                />
-              </div>
-            </div>
-            <div className="rounded-2xl border border-brand-bubble/30 bg-brand-bubble/10 p-4">
-              <h3 className="text-sm font-semibold text-brand-navy">App permissions</h3>
-              <p className="mt-1 text-xs text-brand-navy/70">
                 Choose which areas of the workspace this team member can access. Role templates above will pre-select the
                 common access, and you can fine-tune anything here or later in their settings.
               </p>
-              <div className="mt-4 grid gap-3 md:grid-cols-2">
+            </div>
+            <div className="rounded-2xl border border-brand-bubble/30 bg-brand-bubble/10 p-4">
+              <div className="grid gap-3 md:grid-cols-2">
                 {PERMISSION_OPTIONS.map((option) => (
                   <label key={option.key} className="flex items-start gap-2 text-sm text-brand-navy">
                     <input


### PR DESCRIPTION
## Summary
- split the new staff form compensation and permissions areas into individual cards for clearer separation
- add dedicated cards for compensation and app permissions on the employee settings page with independent edit/save flows

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1b140599c8324b6736afc061e30f2