### PR TITLE
Support guarantee payout options in compensation forms

### DIFF
--- a/app/api/staff/route.ts
+++ b/app/api/staff/route.ts
@@ -4,6 +4,17 @@ import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { z } from "zod";
 
 import { getSupabaseAdmin } from "@/lib/supabase/server";
+import {
+  clonePlan,
+  defaultCompensationPlan,
+  derivePayType,
+  getCommissionRate,
+  getHourlyRate,
+  getSalaryRate,
+  normaliseCompensationPlan,
+  planHasConfiguration,
+  toStoredPlan,
+} from "@/lib/compensationPlan";
 
 const PERMISSION_KEYS = [
   "can_view_reports",
@@ -103,16 +114,68 @@ const goalsSchema = z
     };
   });
 
+const compensationPlanSchema = z
+  .union([
+    z
+      .object({
+        commission: z
+          .object({
+            enabled: z.boolean().optional(),
+            rate: optionalNumber,
+          })
+          .optional(),
+        hourly: z
+          .object({
+            enabled: z.boolean().optional(),
+            rate: optionalNumber,
+          })
+          .optional(),
+        salary: z
+          .object({
+            enabled: z.boolean().optional(),
+            rate: optionalNumber,
+          })
+          .optional(),
+        guarantee: z
+          .object({
+            enabled: z.boolean().optional(),
+            weekly_amount: optionalNumber,
+            commission_rate: optionalNumber,
+            payout_mode: z.enum(["higher", "stacked"]).optional(),
+          })
+          .optional(),
+        overrides: z
+          .array(
+            z.object({
+              subordinate_id: z.number().int().positive(),
+              percentage: optionalNumber,
+            }),
+          )
+          .optional(),
+      })
+      .strict(),
+    z.null(),
+    z.undefined(),
+  ])
+  .transform((value) => {
+    if (!value) {
+      return clonePlan(defaultCompensationPlan);
+    }
+    const normalised = normaliseCompensationPlan(value);
+    return toStoredPlan(normalised);
+  });
+
 const staffSchema = z.object({
   name: z.string().trim().min(1, "Name is required"),
   role: z.string().trim().min(1, "Role is required"),
   email: optionalEmail,
   phone: optionalPhone,
   status: optionalText,
-  pay_type: z.enum(["hourly", "commission", "salary", "hybrid"]).default("hourly"),
+  pay_type: z.enum(["hourly", "commission", "salary", "hybrid", "guarantee", "custom"]).default("hourly"),
   commission_rate: optionalNumber,
   hourly_rate: optionalNumber,
   salary_rate: optionalNumber,
+  compensation_plan: compensationPlanSchema.optional(),
   app_permissions: permissionsSchema,
   avatar_url: optionalText,
   address_street: optionalText,
@@ -169,9 +232,15 @@ export async function POST(req: Request) {
 
   const data = parsed.data;
 
-  const commissionRate = data.commission_rate ?? 0;
-  const hourlyRate = data.hourly_rate ?? 0;
-  const salaryRate = data.salary_rate ?? 0;
+  const compensationPlan = data.compensation_plan
+    ? toStoredPlan(data.compensation_plan)
+    : clonePlan(defaultCompensationPlan);
+  const planConfigured = planHasConfiguration(compensationPlan);
+
+  const commissionRate = planConfigured ? getCommissionRate(compensationPlan) : data.commission_rate ?? 0;
+  const hourlyRate = planConfigured ? getHourlyRate(compensationPlan) : data.hourly_rate ?? 0;
+  const salaryRate = planConfigured ? getSalaryRate(compensationPlan) : data.salary_rate ?? 0;
+  const finalPayType = planConfigured ? derivePayType(compensationPlan) : data.pay_type ?? "hourly";
 
   if (commissionRate < 0 || commissionRate > 1) {
     return NextResponse.json(
@@ -219,10 +288,11 @@ export async function POST(req: Request) {
     address_zip: data.address_zip,
     emergency_contact_name: data.emergency_contact_name,
     emergency_contact_phone: data.emergency_contact_phone,
-    pay_type: data.pay_type,
+    pay_type: finalPayType,
     commission_rate: commissionRate,
     hourly_rate: hourlyRate,
     salary_rate: salaryRate,
+    compensation_plan: compensationPlan,
     app_permissions: data.app_permissions,
     manager_notes: data.manager_notes,
   };

--- a/app/employees/[id]/EmployeeDetailClient.tsx
+++ b/app/employees/[id]/EmployeeDetailClient.tsx
@@ -36,6 +36,7 @@ export type StaffRecord = {
   commission_rate?: number | null;
   hourly_rate?: number | null;
   salary_rate?: number | null;
+  compensation_plan?: Record<string, unknown> | null;
   app_permissions?: Record<string, unknown> | null;
   preferred_breeds?: string[] | null;
   not_accepted_breeds?: string[] | null;

--- a/app/employees/[id]/settings/actions.ts
+++ b/app/employees/[id]/settings/actions.ts
@@ -3,6 +3,8 @@
 import { revalidatePath } from "next/cache";
 
 import { createClient } from "@/lib/supabase/server";
+import type { CompensationPlan } from "@/lib/compensationPlan";
+import { toStoredPlan } from "@/lib/compensationPlan";
 
 export async function saveProfileAction(
   staffId: number,
@@ -53,6 +55,7 @@ export async function saveCompensationAction(
     commission_rate: number;
     hourly_rate: number;
     salary_rate: number;
+    compensation_plan: CompensationPlan;
     app_permissions: Record<string, boolean>;
   }
 ) {
@@ -62,6 +65,7 @@ export async function saveCompensationAction(
     commission_rate: Number.isFinite(input.commission_rate) ? input.commission_rate : 0,
     hourly_rate: Number.isFinite(input.hourly_rate) ? input.hourly_rate : 0,
     salary_rate: Number.isFinite(input.salary_rate) ? input.salary_rate : 0,
+    compensation_plan: toStoredPlan(input.compensation_plan),
     app_permissions: input.app_permissions,
   };
   const { error } = await supabase.from("employees").update(payload).eq("id", staffId);

--- a/app/employees/[id]/settings/page.tsx
+++ b/app/employees/[id]/settings/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import clsx from "clsx";
+import { ReactNode, useEffect, useMemo, useState } from "react";
 import { useEmployeeDetail } from "../EmployeeDetailClient";
 import {
   saveCompensationAction,
@@ -8,6 +9,21 @@ import {
   savePreferencesAction,
   saveProfileAction,
 } from "./actions";
+import {
+  CompensationPlan,
+  CompensationPlanDraft,
+  draftFromPlan,
+  derivePayType,
+  getCommissionRate,
+  getHourlyRate,
+  getSalaryRate,
+  parseDraft,
+  planFromRecord,
+  planHasConfiguration,
+  planSummaryLines,
+  toStoredPlan,
+} from "@/lib/compensationPlan";
+import { supabase } from "@/lib/supabase/client";
 
 type PermissionKey =
   | "can_view_reports"
@@ -59,13 +75,38 @@ export default function EmployeeSettingsPage() {
     emergency_contact_phone: employee.emergency_contact_phone ?? "",
   });
 
-  const [compensation, setCompensation] = useState({
-    pay_type: employee.pay_type ?? "hourly",
-    commission_rate: employee.commission_rate ?? 0,
-    hourly_rate: employee.hourly_rate ?? 0,
-    salary_rate: employee.salary_rate ?? 0,
-    app_permissions: permissionState,
-  });
+  const {
+    compensation_plan: employeeCompensationPlan,
+    commission_rate: employeeCommissionRate,
+    hourly_rate: employeeHourlyRate,
+    salary_rate: employeeSalaryRate,
+    pay_type: employeePayType,
+  } = employee;
+
+  const initialPlan = useMemo(
+    () =>
+      toStoredPlan(
+        planFromRecord({
+          compensation_plan: employeeCompensationPlan,
+          commission_rate: employeeCommissionRate,
+          hourly_rate: employeeHourlyRate,
+          salary_rate: employeeSalaryRate,
+          pay_type: employeePayType,
+        }),
+      ),
+    [
+      employeeCompensationPlan,
+      employeeCommissionRate,
+      employeeHourlyRate,
+      employeeSalaryRate,
+      employeePayType,
+    ],
+  );
+
+  const [currentPlan, setCurrentPlan] = useState<CompensationPlan>(initialPlan);
+  const [compensationDraft, setCompensationDraft] = useState<CompensationPlanDraft>(() => draftFromPlan(initialPlan));
+  const [appPermissions, setAppPermissions] = useState(permissionState);
+  const [staffOptions, setStaffOptions] = useState<{ id: number; name: string | null }[]>([]);
 
   const [preferences, setPreferences] = useState({
     preferred_breeds: [...(employee.preferred_breeds ?? [])],
@@ -93,10 +134,65 @@ export default function EmployeeSettingsPage() {
     notes: false,
   });
 
+  const staffNameMap = useMemo(() => {
+    const map = new Map<number, string>();
+    for (const option of staffOptions) {
+      map.set(option.id, option.name ?? `Staff #${option.id}`);
+    }
+    return map;
+  }, [staffOptions]);
+
+  const compensationPreview = useMemo(() => {
+    const { plan } = parseDraft(compensationDraft);
+    return {
+      summary: planSummaryLines(plan, { staffNameMap }),
+      hasConfiguration: planHasConfiguration(plan),
+    };
+  }, [compensationDraft, staffNameMap]);
+
+  useEffect(() => {
+    setAppPermissions(permissionState);
+  }, [permissionState]);
+
+  useEffect(() => {
+    if (!editing.comp) {
+      setCurrentPlan(initialPlan);
+      setCompensationDraft(draftFromPlan(initialPlan));
+    }
+  }, [initialPlan, editing.comp]);
+
+  useEffect(() => {
+    let active = true;
+    const loadStaffOptions = async () => {
+      const { data, error } = await supabase
+        .from("employees")
+        .select("id,name")
+        .order("name", { ascending: true });
+      if (!active) return;
+      if (error) {
+        console.error("Failed to load staff list", error);
+        setStaffOptions([]);
+        return;
+      }
+      const rows = (data as { id: number; name: string | null }[]) ?? [];
+      setStaffOptions(rows.filter((row) => row.id !== employee.id));
+    };
+    void loadStaffOptions();
+    return () => {
+      active = false;
+    };
+  }, [employee.id]);
+
   const beginEdit = (key: keyof typeof editing) => {
     if (!viewerCanEditStaff) {
       pushToast("You don't have permission to edit staff settings", "error");
       return;
+    }
+    if (key === "comp") {
+      setCompensationDraft(draftFromPlan(currentPlan));
+    }
+    if (key === "perms") {
+      setAppPermissions(permissionState);
     }
     setEditing((e) => ({ ...e, [key]: true }));
   };
@@ -113,32 +209,48 @@ export default function EmployeeSettingsPage() {
     pushToast("Profile updated", "success");
   };
 
-  const persistCompensation = async (section: "comp" | "perms") => {
+  const savePlanAndPermissions = async (
+    plan: CompensationPlan,
+    permissions: Record<string, boolean>,
+    section: "comp" | "perms",
+  ) => {
     setSaving((s) => ({ ...s, [section]: true }));
+    const storedPlan = toStoredPlan(plan);
     const result = await saveCompensationAction(employee.id, {
-      pay_type: compensation.pay_type,
-      commission_rate: Number(compensation.commission_rate) || 0,
-      hourly_rate: Number(compensation.hourly_rate) || 0,
-      salary_rate: Number(compensation.salary_rate) || 0,
-      app_permissions: compensation.app_permissions,
+      pay_type: derivePayType(storedPlan),
+      commission_rate: getCommissionRate(storedPlan),
+      hourly_rate: getHourlyRate(storedPlan),
+      salary_rate: getSalaryRate(storedPlan),
+      compensation_plan: storedPlan,
+      app_permissions: permissions,
     });
     setSaving((s) => ({ ...s, [section]: false }));
     if (!result.success) {
       const errorMessage =
         section === "comp" ? "Failed to save compensation" : "Failed to save permissions";
       pushToast(result.error ?? errorMessage, "error");
-      return;
+      return false;
     }
     setEditing((e) => ({ ...e, [section]: false }));
     pushToast(section === "comp" ? "Compensation updated" : "Permissions updated", "success");
+    return true;
   };
 
-  const handleCompensationSave = () => {
-    void persistCompensation("comp");
+  const handleCompensationSave = async () => {
+    const draftResult = parseDraft(compensationDraft);
+    if (draftResult.errors.length > 0) {
+      pushToast(draftResult.errors.join(" "), "error");
+      return;
+    }
+    const success = await savePlanAndPermissions(draftResult.plan, appPermissions, "comp");
+    if (success) {
+      setCurrentPlan(draftResult.plan);
+      setCompensationDraft(draftFromPlan(draftResult.plan));
+    }
   };
 
-  const handlePermissionsSave = () => {
-    void persistCompensation("perms");
+  const handlePermissionsSave = async () => {
+    await savePlanAndPermissions(currentPlan, appPermissions, "perms");
   };
 
   const handlePreferencesSave = async () => {
@@ -223,21 +335,20 @@ export default function EmployeeSettingsPage() {
           isEditing={editing.perms}
           isSaving={saving.perms}
           onEdit={() => beginEdit("perms")}
-          onSave={handlePermissionsSave}
+          onSave={() => {
+            void handlePermissionsSave();
+          }}
         />
         <div className="mt-4 grid gap-3 md:grid-cols-2">
           {PERMISSION_OPTIONS.map((option) => (
             <label key={option.key} className="flex items-center gap-2 text-sm text-slate-600">
               <input
                 type="checkbox"
-                checked={!!compensation.app_permissions[option.key]}
+                checked={!!appPermissions[option.key]}
                 onChange={(e) =>
-                  setCompensation((prev) => ({
+                  setAppPermissions((prev) => ({
                     ...prev,
-                    app_permissions: {
-                      ...prev.app_permissions,
-                      [option.key]: e.target.checked,
-                    },
+                    [option.key]: e.target.checked,
                   }))
                 }
                 disabled={!editing.perms || saving.perms}
@@ -256,34 +367,343 @@ export default function EmployeeSettingsPage() {
           isEditing={editing.comp}
           isSaving={saving.comp}
           onEdit={() => beginEdit("comp")}
-          onSave={handleCompensationSave}
+          onSave={() => {
+            void handleCompensationSave();
+          }}
         />
-        <div className="mt-4 grid gap-4 md:grid-cols-2">
-          <SelectField
-            label="Pay type"
-            value={compensation.pay_type}
-            options={["hourly", "commission", "salary", "hybrid"]}
-            onChange={(v) => setCompensation((p) => ({ ...p, pay_type: v }))}
+        <div className="mt-4 space-y-4">
+          <CompensationCard
+            title="Commission on personal grooms"
+            description="Pay a percentage of every dog this employee personally grooms."
+            enabled={compensationDraft.commission.enabled}
+            onToggle={(next) =>
+              setCompensationDraft((prev) => {
+                const nextGuarantee =
+                  !next && prev.guarantee.payoutMode === "higher"
+                    ? { ...prev.guarantee, payoutMode: "stacked" as const }
+                    : prev.guarantee;
+                return {
+                  ...prev,
+                  commission: {
+                    ...prev.commission,
+                    enabled: next,
+                  },
+                  guarantee: nextGuarantee,
+                };
+              })
+            }
             disabled={!editing.comp || saving.comp}
-          />
-          <NumberField
-            label="Commission %"
-            value={Number(compensation.commission_rate ?? 0) * 100}
-            onChange={(v) => setCompensation((p) => ({ ...p, commission_rate: v / 100 }))}
+          >
+            {compensationDraft.commission.enabled && (
+              <div className="grid gap-3 md:grid-cols-2">
+                <FieldGroup label="Commission %">
+                  <input
+                    type="number"
+                    min={0}
+                    max={100}
+                    step="0.1"
+                    value={compensationDraft.commission.rate}
+                    onChange={(event) =>
+                      setCompensationDraft((prev) => ({
+                        ...prev,
+                        commission: { ...prev.commission, rate: event.target.value },
+                      }))
+                    }
+                    disabled={!editing.comp || saving.comp}
+                    className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-700 disabled:bg-slate-100"
+                  />
+                </FieldGroup>
+              </div>
+            )}
+          </CompensationCard>
+
+          <CompensationCard
+            title="Hourly pay"
+            description="Guarantee an hourly base rate alongside other earnings."
+            enabled={compensationDraft.hourly.enabled}
+            onToggle={(next) =>
+              setCompensationDraft((prev) => ({
+                ...prev,
+                hourly: {
+                  ...prev.hourly,
+                  enabled: next,
+                },
+              }))
+            }
             disabled={!editing.comp || saving.comp}
-          />
-          <NumberField
-            label="Hourly rate"
-            value={Number(compensation.hourly_rate ?? 0)}
-            onChange={(v) => setCompensation((p) => ({ ...p, hourly_rate: v }))}
+          >
+            {compensationDraft.hourly.enabled && (
+              <div className="grid gap-3 md:grid-cols-2">
+                <FieldGroup label="Hourly rate ($)">
+                  <input
+                    type="number"
+                    min={0}
+                    step="0.01"
+                    value={compensationDraft.hourly.rate}
+                    onChange={(event) =>
+                      setCompensationDraft((prev) => ({
+                        ...prev,
+                        hourly: { ...prev.hourly, rate: event.target.value },
+                      }))
+                    }
+                    disabled={!editing.comp || saving.comp}
+                    className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-700 disabled:bg-slate-100"
+                  />
+                </FieldGroup>
+              </div>
+            )}
+          </CompensationCard>
+
+          <CompensationCard
+            title="Salary"
+            description="Track an annual salary amount for reporting."
+            enabled={compensationDraft.salary.enabled}
+            onToggle={(next) =>
+              setCompensationDraft((prev) => ({
+                ...prev,
+                salary: {
+                  ...prev.salary,
+                  enabled: next,
+                },
+              }))
+            }
             disabled={!editing.comp || saving.comp}
-          />
-          <NumberField
-            label="Salary rate"
-            value={Number(compensation.salary_rate ?? 0)}
-            onChange={(v) => setCompensation((p) => ({ ...p, salary_rate: v }))}
+          >
+            {compensationDraft.salary.enabled && (
+              <div className="grid gap-3 md:grid-cols-2">
+                <FieldGroup label="Salary (annual $)">
+                  <input
+                    type="number"
+                    min={0}
+                    step="0.01"
+                    value={compensationDraft.salary.rate}
+                    onChange={(event) =>
+                      setCompensationDraft((prev) => ({
+                        ...prev,
+                        salary: { ...prev.salary, rate: event.target.value },
+                      }))
+                    }
+                    disabled={!editing.comp || saving.comp}
+                    className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-700 disabled:bg-slate-100"
+                  />
+                </FieldGroup>
+              </div>
+            )}
+          </CompensationCard>
+
+          <CompensationCard
+            title="Weekly guarantee vs. commission"
+            description="Guarantee pay per week and choose whether it&rsquo;s paid alongside their commission or whichever amount is higher."
+            enabled={compensationDraft.guarantee.enabled}
+            onToggle={(next) =>
+              setCompensationDraft((prev) => ({
+                ...prev,
+                guarantee: {
+                  ...prev.guarantee,
+                  enabled: next,
+                },
+              }))
+            }
             disabled={!editing.comp || saving.comp}
-          />
+          >
+            {compensationDraft.guarantee.enabled && (
+              <div className="grid gap-3 md:grid-cols-2">
+                <FieldGroup label="Weekly guarantee ($)">
+                  <input
+                    type="number"
+                    min={0}
+                    step="0.01"
+                    value={compensationDraft.guarantee.weeklyAmount}
+                    onChange={(event) =>
+                      setCompensationDraft((prev) => ({
+                        ...prev,
+                        guarantee: { ...prev.guarantee, weeklyAmount: event.target.value },
+                      }))
+                    }
+                    disabled={!editing.comp || saving.comp}
+                    className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-700 disabled:bg-slate-100"
+                  />
+                </FieldGroup>
+                <FieldGroup label="How should the guarantee pay out?">
+                  <div className="space-y-2 rounded-lg border border-slate-200 bg-slate-50/60 p-3">
+                    <label className="flex items-start gap-2 text-sm text-slate-600">
+                      <input
+                        type="radio"
+                        name="guarantee-mode"
+                        value="stacked"
+                        checked={compensationDraft.guarantee.payoutMode === "stacked"}
+                        onChange={() =>
+                          setCompensationDraft((prev) => ({
+                            ...prev,
+                        guarantee: { ...prev.guarantee, payoutMode: "stacked" as const },
+                          }))
+                        }
+                        disabled={!editing.comp || saving.comp}
+                        className="mt-1 h-4 w-4 border-slate-300 text-brand-blue focus:ring-brand-blue/40 disabled:border-slate-200 disabled:text-slate-300"
+                      />
+                      <span>
+                        <span className="font-semibold text-slate-700">Pay the weekly guarantee and their commission</span>
+                        <span className="block text-xs text-slate-500">
+                          They receive both the guaranteed amount and whatever commission they earn.
+                        </span>
+                      </span>
+                    </label>
+                    <label
+                      className={clsx(
+                        "flex items-start gap-2 text-sm text-slate-600",
+                        (!compensationDraft.commission.enabled || !editing.comp || saving.comp) && "opacity-60",
+                      )}
+                    >
+                      <input
+                        type="radio"
+                        name="guarantee-mode"
+                        value="higher"
+                        checked={compensationDraft.guarantee.payoutMode === "higher"}
+                        onChange={() =>
+                          setCompensationDraft((prev) => ({
+                            ...prev,
+                        guarantee: { ...prev.guarantee, payoutMode: "higher" as const },
+                          }))
+                        }
+                        disabled={!compensationDraft.commission.enabled || !editing.comp || saving.comp}
+                        className="mt-1 h-4 w-4 border-slate-300 text-brand-blue focus:ring-brand-blue/40 disabled:border-slate-200 disabled:text-slate-300"
+                      />
+                      <span>
+                        <span className="font-semibold text-slate-700">Pay whichever amount is higher</span>
+                        <span className="block text-xs text-slate-500">
+                          Compare their commission earnings to the guarantee and pay the larger amount.
+                        </span>
+                      </span>
+                    </label>
+                  </div>
+                  {!compensationDraft.commission.enabled && (
+                    <p className="text-xs text-slate-500">
+                      Enable a commission rate above to compare against the guarantee.
+                    </p>
+                  )}
+                </FieldGroup>
+              </div>
+            )}
+          </CompensationCard>
+
+          <CompensationCard
+            title="Team overrides"
+            description="Pay them an extra share of the appointments completed by groomers they manage. This amount comes out of the business share so the groomers below them keep their full commission."
+            enabled={compensationDraft.overridesEnabled}
+            onToggle={(next) =>
+              setCompensationDraft((prev) => ({
+                ...prev,
+                overridesEnabled: next,
+                overrides:
+                  next && prev.overrides.length === 0
+                    ? [{ subordinateId: null, percentage: "" }]
+                    : prev.overrides,
+              }))
+            }
+            disabled={!editing.comp || saving.comp}
+          >
+            {compensationDraft.overridesEnabled && (
+              <div className="space-y-3">
+                {staffOptions.length === 0 && (
+                  <p className="text-xs text-slate-500">
+                    Add more staff members to assign override relationships.
+                  </p>
+                )}
+                {compensationDraft.overrides.map((entry, index) => (
+                  <div key={`override-${index}`} className="grid gap-3 md:grid-cols-2">
+                    <FieldGroup label="Team member">
+                      <select
+                        value={entry.subordinateId ?? ""}
+                        onChange={(event) => {
+                          const value = event.target.value;
+                          setCompensationDraft((prev) => {
+                            const next = [...prev.overrides];
+                            next[index] = {
+                              ...next[index],
+                              subordinateId: value ? Number(value) : null,
+                            };
+                            return { ...prev, overrides: next };
+                          });
+                        }}
+                        disabled={!editing.comp || saving.comp}
+                        className="rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-700 disabled:bg-slate-100"
+                      >
+                        <option value="">Select a groomer</option>
+                        {staffOptions.map((option) => (
+                          <option key={option.id} value={option.id}>
+                            {option.name ?? `Staff #${option.id}`}
+                          </option>
+                        ))}
+                      </select>
+                    </FieldGroup>
+                    <FieldGroup label="Override % of appointment revenue">
+                      <div className="flex items-center gap-2">
+                        <input
+                          type="number"
+                          min={0}
+                          max={100}
+                          step="0.1"
+                          value={entry.percentage}
+                          onChange={(event) =>
+                            setCompensationDraft((prev) => {
+                              const next = [...prev.overrides];
+                              next[index] = {
+                                ...next[index],
+                                percentage: event.target.value,
+                              };
+                              return { ...prev, overrides: next };
+                            })
+                          }
+                          disabled={!editing.comp || saving.comp}
+                          className="flex-1 rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-700 disabled:bg-slate-100"
+                        />
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setCompensationDraft((prev) => ({
+                              ...prev,
+                              overrides: prev.overrides.filter((_, idx) => idx !== index),
+                            }))
+                          }
+                          disabled={!editing.comp || saving.comp}
+                          className="rounded-lg border border-slate-300 px-3 py-2 text-xs font-semibold text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          Remove
+                        </button>
+                      </div>
+                    </FieldGroup>
+                  </div>
+                ))}
+                <button
+                  type="button"
+                  onClick={() =>
+                    setCompensationDraft((prev) => ({
+                      ...prev,
+                      overrides: [...prev.overrides, { subordinateId: null, percentage: "" }],
+                    }))
+                  }
+                  disabled={!editing.comp || saving.comp || staffOptions.length === 0}
+                  className="inline-flex items-center justify-center rounded-lg border border-slate-300 px-3 py-2 text-xs font-semibold text-slate-600 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  Add override
+                </button>
+              </div>
+            )}
+          </CompensationCard>
+          {compensationPreview.hasConfiguration && (
+            <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
+              <h4 className="text-sm font-semibold text-slate-700">Pay summary</h4>
+              {compensationPreview.summary.length > 0 ? (
+                <ul className="mt-2 list-inside list-disc space-y-1 text-sm text-slate-600">
+                  {compensationPreview.summary.map((line, index) => (
+                    <li key={`pay-summary-${index}`}>{line}</li>
+                  ))}
+                </ul>
+              ) : (
+                <p className="mt-2 text-sm text-slate-500">Enter rates above to preview how they’ll be paid.</p>
+              )}
+            </div>
+          )}
         </div>
       </section>
 
@@ -356,6 +776,50 @@ export default function EmployeeSettingsPage() {
           placeholder="Add private notes for this staff member"
         />
       </section>
+    </div>
+  );
+}
+
+type CompensationCardProps = {
+  title: string;
+  description: string;
+  enabled: boolean;
+  onToggle: (enabled: boolean) => void;
+  disabled?: boolean;
+  children?: ReactNode;
+};
+
+function CompensationCard({ title, description, enabled, onToggle, disabled, children }: CompensationCardProps) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h3 className="text-sm font-semibold text-slate-700">{title}</h3>
+          <p className="text-xs text-slate-500">{description}</p>
+        </div>
+        <label className="flex items-center gap-2 text-xs text-slate-600">
+          <input
+            type="checkbox"
+            checked={enabled}
+            onChange={(event) => onToggle(event.target.checked)}
+            disabled={disabled}
+            className="h-4 w-4 rounded border-slate-300 text-brand-blue focus:ring-brand-blue/40 disabled:cursor-not-allowed"
+          />
+          <span>Enable</span>
+        </label>
+      </div>
+      {children && <div className="mt-3 space-y-3 text-sm text-slate-600">{children}</div>}
+    </div>
+  );
+}
+
+type FieldGroupProps = { label: string; children: ReactNode };
+
+function FieldGroup({ label, children }: FieldGroupProps) {
+  return (
+    <div className="flex flex-col gap-1 text-sm text-slate-600">
+      <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">{label}</span>
+      {children}
     </div>
   );
 }

--- a/app/employees/new/page.tsx
+++ b/app/employees/new/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 export const runtime = "nodejs";
 
-import { FormEvent, useMemo, useState } from "react";
+import { FormEvent, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 
@@ -9,14 +9,21 @@ import clsx from "clsx";
 import Card from "@/components/Card";
 import PageContainer from "@/components/PageContainer";
 import { useAuth } from "@/components/AuthProvider";
+import {
+  CompensationPlanDraft,
+  defaultCompensationPlan,
+  draftFromPlan,
+  parseDraft,
+  planHasConfiguration,
+  planSummaryLines,
+} from "@/lib/compensationPlan";
+import { supabase } from "@/lib/supabase/client";
 
 type PermissionKey =
   | "can_view_reports"
   | "can_edit_schedule"
   | "can_manage_discounts"
   | "can_manage_staff";
-
-type PayType = "hourly" | "commission" | "salary" | "hybrid";
 
 const inputClass =
   "h-11 w-full rounded-xl border border-white/50 bg-white/95 px-4 text-base text-brand-navy placeholder:text-brand-navy/50 shadow-inner transition focus:border-brand-bubble focus:outline-none focus:ring-2 focus:ring-brand-bubble/30";
@@ -25,7 +32,6 @@ const textareaClass =
 const labelClass = "text-sm font-semibold text-brand-navy";
 
 const STATUS_OPTIONS = ["Active", "Inactive", "On leave"] as const;
-const PAY_TYPE_OPTIONS: PayType[] = ["hourly", "commission", "salary", "hybrid"];
 const PERMISSION_OPTIONS: { key: PermissionKey; label: string; helper: string }[] = [
   {
     key: "can_edit_schedule",
@@ -110,10 +116,6 @@ type FormState = {
   emergencyContactPhone: string;
   role: string;
   status: (typeof STATUS_OPTIONS)[number];
-  payType: PayType;
-  commissionPercent: string;
-  hourlyRate: string;
-  salaryRate: string;
 };
 
 const defaultPermissions: Record<PermissionKey, boolean> = {
@@ -139,21 +141,37 @@ export default function NewEmployeePage() {
     emergencyContactPhone: "",
     role: "",
     status: "Active",
-    payType: "hourly",
-    commissionPercent: "0",
-    hourlyRate: "",
-    salaryRate: "",
   });
   const [selectedRoleId, setSelectedRoleId] = useState<string | null>(null);
   const [customRoleDraft, setCustomRoleDraft] = useState("");
   const [permissionState, setPermissionState] = useState<Record<PermissionKey, boolean>>({
     ...defaultPermissions,
   });
+  const [compensationDraft, setCompensationDraft] = useState<CompensationPlanDraft>(() =>
+    draftFromPlan(defaultCompensationPlan),
+  );
+  const [staffOptions, setStaffOptions] = useState<{ id: number; name: string | null }[]>([]);
   const [notes, setNotes] = useState("");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const canManageEmployees = useMemo(() => permissions.canManageEmployees, [permissions.canManageEmployees]);
+
+  const staffNameMap = useMemo(() => {
+    const map = new Map<number, string>();
+    for (const option of staffOptions) {
+      map.set(option.id, option.name ?? `Staff #${option.id}`);
+    }
+    return map;
+  }, [staffOptions]);
+
+  const compensationPreview = useMemo(() => {
+    const { plan } = parseDraft(compensationDraft);
+    return {
+      summary: planSummaryLines(plan, { staffNameMap }),
+      hasConfiguration: planHasConfiguration(plan),
+    };
+  }, [compensationDraft, staffNameMap]);
 
   const applyPermissionPreset = (keys: PermissionKey[]) => {
     setPermissionState({
@@ -163,6 +181,27 @@ export default function NewEmployeePage() {
       can_manage_staff: keys.includes("can_manage_staff"),
     });
   };
+
+  useEffect(() => {
+    let active = true;
+    const loadStaffOptions = async () => {
+      const { data, error: staffError } = await supabase
+        .from("employees")
+        .select("id,name")
+        .order("name", { ascending: true });
+      if (!active) return;
+      if (staffError) {
+        console.error("Failed to load staff list", staffError);
+        setStaffOptions([]);
+        return;
+      }
+      setStaffOptions((data as { id: number; name: string | null }[]) ?? []);
+    };
+    void loadStaffOptions();
+    return () => {
+      active = false;
+    };
+  }, []);
 
   const handleRoleTemplateSelect = (template: RoleTemplate) => {
     setSelectedRoleId(template.id);
@@ -193,27 +232,9 @@ export default function NewEmployeePage() {
       return;
     }
 
-    const commissionValue = form.commissionPercent.trim() === ""
-      ? null
-      : Number(form.commissionPercent.replace(/,/g, ".")) / 100;
-    if (commissionValue !== null && !Number.isFinite(commissionValue)) {
-      setError("Commission percentage must be a valid number");
-      return;
-    }
-    if (commissionValue !== null && (commissionValue < 0 || commissionValue > 1)) {
-      setError("Commission percentage must be between 0% and 100%");
-      return;
-    }
-
-    const hourlyValue = form.hourlyRate.trim() === "" ? null : Number(form.hourlyRate);
-    if (hourlyValue !== null && (!Number.isFinite(hourlyValue) || hourlyValue < 0)) {
-      setError("Hourly rate must be zero or greater");
-      return;
-    }
-
-    const salaryValue = form.salaryRate.trim() === "" ? null : Number(form.salaryRate);
-    if (salaryValue !== null && (!Number.isFinite(salaryValue) || salaryValue < 0)) {
-      setError("Salary rate must be zero or greater");
+    const draftResult = parseDraft(compensationDraft);
+    if (draftResult.errors.length > 0) {
+      setError(draftResult.errors.join(" "));
       return;
     }
 
@@ -236,10 +257,11 @@ export default function NewEmployeePage() {
           emergency_contact_name: form.emergencyContactName.trim() || null,
           emergency_contact_phone: form.emergencyContactPhone.trim() || null,
           status: form.status,
-          pay_type: form.payType,
-          commission_rate: commissionValue,
-          hourly_rate: hourlyValue,
-          salary_rate: salaryValue,
+          pay_type: draftResult.payType,
+          commission_rate: draftResult.commissionRate,
+          hourly_rate: draftResult.hourlyRate,
+          salary_rate: draftResult.salaryRate,
+          compensation_plan: draftResult.plan,
           app_permissions: permissionState,
           manager_notes: notes.trim() ? notes.trim() : null,
         }),
@@ -618,71 +640,421 @@ export default function NewEmployeePage() {
           <section className="space-y-4">
             <div className="space-y-1">
               <h2 className="text-xl font-semibold text-brand-navy">Compensation</h2>
-              <p className="text-sm text-brand-navy/70">Set how this employee is paid and rewarded.</p>
+              <p className="text-sm text-brand-navy/70">
+                Combine hourly pay, commission, guarantees, and team overrides to match how this team member earns.
+              </p>
             </div>
-            <div className="rounded-2xl border border-white/50 bg-white/80 p-4 shadow-inner">
-              <div className="grid gap-4 md:grid-cols-2">
-                <div className="space-y-1">
-                  <label className={labelClass} htmlFor="employee-pay-type">
-                    Pay type
+
+            <div className="space-y-4">
+              <div className="rounded-2xl border border-white/50 bg-white/80 p-4 shadow-inner">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <h3 className="text-base font-semibold text-brand-navy">Commission on personal grooms</h3>
+                    <p className="text-sm text-brand-navy/70">
+                      Pay a percentage of every dog this staff member personally grooms.
+                    </p>
+                  </div>
+                  <label className="flex items-center gap-2 text-sm text-brand-navy">
+                    <input
+                      type="checkbox"
+                      checked={compensationDraft.commission.enabled}
+                      onChange={(event) => {
+                        const enabled = event.target.checked;
+                        setCompensationDraft((prev) => {
+                          const nextGuarantee =
+                            !enabled && prev.guarantee.payoutMode === "higher"
+                              ? { ...prev.guarantee, payoutMode: "stacked" as const }
+                              : prev.guarantee;
+                          return {
+                            ...prev,
+                            commission: {
+                              ...prev.commission,
+                              enabled,
+                            },
+                            guarantee: nextGuarantee,
+                          };
+                        });
+                      }}
+                      className="h-4 w-4 rounded border-brand-bubble/50 text-brand-bubble focus:ring-brand-bubble/50"
+                    />
+                    <span>Enable</span>
                   </label>
-                  <select
-                    id="employee-pay-type"
-                    className={inputClass}
-                    value={form.payType}
-                    onChange={(event) => setForm((prev) => ({ ...prev, payType: event.target.value as PayType }))}
-                  >
-                    {PAY_TYPE_OPTIONS.map((option) => (
-                      <option key={option} value={option}>
-                        {option.charAt(0).toUpperCase() + option.slice(1)}
-                      </option>
-                    ))}
-                  </select>
                 </div>
-                <div className="space-y-1">
-                  <label className={labelClass} htmlFor="employee-commission">
-                    Commission %
-                  </label>
-                  <input
-                    id="employee-commission"
-                    className={inputClass}
-                    type="number"
-                    min={0}
-                    max={100}
-                    step="0.1"
-                    value={form.commissionPercent}
-                    onChange={(event) => setForm((prev) => ({ ...prev, commissionPercent: event.target.value }))}
-                  />
-                </div>
-                <div className="space-y-1">
-                  <label className={labelClass} htmlFor="employee-hourly">
-                    Hourly rate
-                  </label>
-                  <input
-                    id="employee-hourly"
-                    className={inputClass}
-                    type="number"
-                    min={0}
-                    step="0.01"
-                    value={form.hourlyRate}
-                    onChange={(event) => setForm((prev) => ({ ...prev, hourlyRate: event.target.value }))}
-                  />
-                </div>
-                <div className="space-y-1">
-                  <label className={labelClass} htmlFor="employee-salary">
-                    Salary rate
-                  </label>
-                  <input
-                    id="employee-salary"
-                    className={inputClass}
-                    type="number"
-                    min={0}
-                    step="0.01"
-                    value={form.salaryRate}
-                    onChange={(event) => setForm((prev) => ({ ...prev, salaryRate: event.target.value }))}
-                  />
-                </div>
+                {compensationDraft.commission.enabled && (
+                  <div className="mt-4 grid gap-4 md:grid-cols-2">
+                    <div className="space-y-1">
+                      <label className={labelClass} htmlFor="comp-commission-rate">
+                        Commission %
+                      </label>
+                      <input
+                        id="comp-commission-rate"
+                        className={inputClass}
+                        type="number"
+                        min={0}
+                        max={100}
+                        step="0.1"
+                        value={compensationDraft.commission.rate}
+                        onChange={(event) =>
+                          setCompensationDraft((prev) => ({
+                            ...prev,
+                            commission: { ...prev.commission, rate: event.target.value },
+                          }))
+                        }
+                      />
+                    </div>
+                  </div>
+                )}
               </div>
+
+              <div className="rounded-2xl border border-white/50 bg-white/80 p-4 shadow-inner">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <h3 className="text-base font-semibold text-brand-navy">Hourly pay</h3>
+                    <p className="text-sm text-brand-navy/70">
+                      Guarantee an hourly base rate in addition to any other earnings.
+                    </p>
+                  </div>
+                  <label className="flex items-center gap-2 text-sm text-brand-navy">
+                    <input
+                      type="checkbox"
+                      checked={compensationDraft.hourly.enabled}
+                      onChange={(event) =>
+                        setCompensationDraft((prev) => ({
+                          ...prev,
+                          hourly: {
+                            ...prev.hourly,
+                            enabled: event.target.checked,
+                          },
+                        }))
+                      }
+                      className="h-4 w-4 rounded border-brand-bubble/50 text-brand-bubble focus:ring-brand-bubble/50"
+                    />
+                    <span>Enable</span>
+                  </label>
+                </div>
+                {compensationDraft.hourly.enabled && (
+                  <div className="mt-4 grid gap-4 md:grid-cols-2">
+                    <div className="space-y-1">
+                      <label className={labelClass} htmlFor="comp-hourly-rate">
+                        Hourly rate ($)
+                      </label>
+                      <input
+                        id="comp-hourly-rate"
+                        className={inputClass}
+                        type="number"
+                        min={0}
+                        step="0.01"
+                        value={compensationDraft.hourly.rate}
+                        onChange={(event) =>
+                          setCompensationDraft((prev) => ({
+                            ...prev,
+                            hourly: { ...prev.hourly, rate: event.target.value },
+                          }))
+                        }
+                      />
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className="rounded-2xl border border-white/50 bg-white/80 p-4 shadow-inner">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <h3 className="text-base font-semibold text-brand-navy">Salary</h3>
+                    <p className="text-sm text-brand-navy/70">
+                      Track an annual salary amount for reporting and payroll exports.
+                    </p>
+                  </div>
+                  <label className="flex items-center gap-2 text-sm text-brand-navy">
+                    <input
+                      type="checkbox"
+                      checked={compensationDraft.salary.enabled}
+                      onChange={(event) =>
+                        setCompensationDraft((prev) => ({
+                          ...prev,
+                          salary: {
+                            ...prev.salary,
+                            enabled: event.target.checked,
+                          },
+                        }))
+                      }
+                      className="h-4 w-4 rounded border-brand-bubble/50 text-brand-bubble focus:ring-brand-bubble/50"
+                    />
+                    <span>Enable</span>
+                  </label>
+                </div>
+                {compensationDraft.salary.enabled && (
+                  <div className="mt-4 grid gap-4 md:grid-cols-2">
+                    <div className="space-y-1">
+                      <label className={labelClass} htmlFor="comp-salary-rate">
+                        Salary (annual $)
+                      </label>
+                      <input
+                        id="comp-salary-rate"
+                        className={inputClass}
+                        type="number"
+                        min={0}
+                        step="0.01"
+                        value={compensationDraft.salary.rate}
+                        onChange={(event) =>
+                          setCompensationDraft((prev) => ({
+                            ...prev,
+                            salary: { ...prev.salary, rate: event.target.value },
+                          }))
+                        }
+                      />
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className="rounded-2xl border border-white/50 bg-white/80 p-4 shadow-inner">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <h3 className="text-base font-semibold text-brand-navy">Weekly guarantee vs. commission</h3>
+                    <p className="text-sm text-brand-navy/70">
+                      Guarantee pay per week and choose whether it&rsquo;s paid alongside their commission or whichever amount is
+                      higher.
+                    </p>
+                  </div>
+                  <label className="flex items-center gap-2 text-sm text-brand-navy">
+                    <input
+                      type="checkbox"
+                      checked={compensationDraft.guarantee.enabled}
+                      onChange={(event) =>
+                        setCompensationDraft((prev) => ({
+                          ...prev,
+                          guarantee: {
+                            ...prev.guarantee,
+                            enabled: event.target.checked,
+                          },
+                        }))
+                      }
+                      className="h-4 w-4 rounded border-brand-bubble/50 text-brand-bubble focus:ring-brand-bubble/50"
+                    />
+                    <span>Enable</span>
+                  </label>
+                </div>
+                {compensationDraft.guarantee.enabled && (
+                  <div className="mt-4 grid gap-4 md:grid-cols-2">
+                    <div className="space-y-1">
+                      <label className={labelClass} htmlFor="comp-guarantee-amount">
+                        Weekly guarantee ($)
+                      </label>
+                      <input
+                        id="comp-guarantee-amount"
+                        className={inputClass}
+                        type="number"
+                        min={0}
+                        step="0.01"
+                        value={compensationDraft.guarantee.weeklyAmount}
+                        onChange={(event) =>
+                          setCompensationDraft((prev) => ({
+                            ...prev,
+                            guarantee: { ...prev.guarantee, weeklyAmount: event.target.value },
+                          }))
+                        }
+                      />
+                    </div>
+                    <div className="space-y-2 md:col-span-2">
+                      <span className={labelClass}>How should the guarantee pay out?</span>
+                      <div className="space-y-2 rounded-xl border border-brand-bubble/30 bg-white/60 p-3">
+                        <label className="flex items-start gap-2 text-sm text-brand-navy">
+                          <input
+                            type="radio"
+                            name="guarantee-mode"
+                            value="stacked"
+                            checked={compensationDraft.guarantee.payoutMode === "stacked"}
+                            onChange={() =>
+                              setCompensationDraft((prev) => ({
+                                ...prev,
+                                guarantee: { ...prev.guarantee, payoutMode: "stacked" as const },
+                              }))
+                            }
+                            className="mt-1 h-4 w-4 border-brand-bubble/50 text-brand-bubble focus:ring-brand-bubble/50"
+                          />
+                          <span>
+                            <span className="font-semibold">Pay the weekly guarantee and their commission</span>
+                            <span className="block text-xs text-brand-navy/70">
+                              They receive both the guaranteed amount and whatever commission they earn.
+                            </span>
+                          </span>
+                        </label>
+                        <label
+                          className={clsx(
+                            "flex items-start gap-2 text-sm text-brand-navy",
+                            !compensationDraft.commission.enabled && "opacity-60",
+                          )}
+                        >
+                          <input
+                            type="radio"
+                            name="guarantee-mode"
+                            value="higher"
+                            checked={compensationDraft.guarantee.payoutMode === "higher"}
+                            onChange={() =>
+                              setCompensationDraft((prev) => ({
+                                ...prev,
+                                guarantee: { ...prev.guarantee, payoutMode: "higher" as const },
+                              }))
+                            }
+                            disabled={!compensationDraft.commission.enabled}
+                            className="mt-1 h-4 w-4 border-brand-bubble/50 text-brand-bubble focus:ring-brand-bubble/50 disabled:border-brand-bubble/30 disabled:text-brand-bubble/30"
+                          />
+                          <span>
+                            <span className="font-semibold">Pay whichever amount is higher</span>
+                            <span className="block text-xs text-brand-navy/70">
+                              Compare their commission earnings to the guarantee and pay the larger amount.
+                            </span>
+                          </span>
+                        </label>
+                      </div>
+                      {!compensationDraft.commission.enabled && (
+                        <p className="text-xs text-brand-navy/70">
+                          Enable a commission rate above to compare against the guarantee.
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className="rounded-2xl border border-white/50 bg-white/80 p-4 shadow-inner">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <h3 className="text-base font-semibold text-brand-navy">Team overrides</h3>
+                    <p className="text-sm text-brand-navy/70">
+                      Pay them an extra share of the appointments completed by groomers they manage. This amount comes out of
+                      the business share—the groomers below them keep their full commission.
+                    </p>
+                  </div>
+                  <label className="flex items-center gap-2 text-sm text-brand-navy">
+                    <input
+                      type="checkbox"
+                      checked={compensationDraft.overridesEnabled}
+                      onChange={(event) =>
+                        setCompensationDraft((prev) => ({
+                          ...prev,
+                          overridesEnabled: event.target.checked,
+                          overrides:
+                            event.target.checked && prev.overrides.length === 0
+                              ? [{ subordinateId: null, percentage: "" }]
+                              : prev.overrides,
+                        }))
+                      }
+                      className="h-4 w-4 rounded border-brand-bubble/50 text-brand-bubble focus:ring-brand-bubble/50"
+                    />
+                    <span>Enable</span>
+                  </label>
+                </div>
+                {compensationDraft.overridesEnabled && (
+                  <div className="mt-4 space-y-4">
+                    {staffOptions.length === 0 && (
+                      <p className="text-sm text-brand-navy/70">
+                        Add additional staff members first to set up override relationships.
+                      </p>
+                    )}
+                    {compensationDraft.overrides.map((entry, index) => (
+                      <div key={`override-${index}`} className="grid gap-3 md:grid-cols-2">
+                        <div className="space-y-1">
+                          <label className={labelClass} htmlFor={`override-groomer-${index}`}>
+                            Team member
+                          </label>
+                          <select
+                            id={`override-groomer-${index}`}
+                            className={inputClass}
+                            value={entry.subordinateId ?? ""}
+                            onChange={(event) => {
+                              const value = event.target.value;
+                              setCompensationDraft((prev) => {
+                                const next = [...prev.overrides];
+                                next[index] = {
+                                  ...next[index],
+                                  subordinateId: value ? Number(value) : null,
+                                };
+                                return { ...prev, overrides: next };
+                              });
+                            }}
+                          >
+                            <option value="">Select a groomer</option>
+                            {staffOptions.map((option) => (
+                              <option key={option.id} value={option.id}>
+                                {option.name ?? `Staff #${option.id}`}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div className="space-y-1">
+                          <label className={labelClass} htmlFor={`override-percent-${index}`}>
+                            Override % of appointment revenue
+                          </label>
+                          <div className="flex items-center gap-2">
+                            <input
+                              id={`override-percent-${index}`}
+                              className={inputClass}
+                              type="number"
+                              min={0}
+                              max={100}
+                              step="0.1"
+                              value={entry.percentage}
+                              onChange={(event) =>
+                                setCompensationDraft((prev) => {
+                                  const next = [...prev.overrides];
+                                  next[index] = {
+                                    ...next[index],
+                                    percentage: event.target.value,
+                                  };
+                                  return { ...prev, overrides: next };
+                                })
+                              }
+                            />
+                            <button
+                              type="button"
+                              onClick={() =>
+                                setCompensationDraft((prev) => ({
+                                  ...prev,
+                                  overrides: prev.overrides.filter((_, idx) => idx !== index),
+                                }))
+                              }
+                              className="rounded-xl border border-red-200 px-3 py-2 text-xs font-semibold text-red-600 transition hover:bg-red-50"
+                            >
+                              Remove
+                            </button>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                    <button
+                      type="button"
+                      onClick={() =>
+                        setCompensationDraft((prev) => ({
+                          ...prev,
+                          overrides: [...prev.overrides, { subordinateId: null, percentage: "" }],
+                        }))
+                      }
+                      disabled={staffOptions.length === 0}
+                      className="inline-flex items-center justify-center rounded-full border border-brand-bubble/40 px-4 py-2 text-sm font-semibold text-brand-navy transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      Add override
+                    </button>
+                  </div>
+                )}
+              </div>
+              {compensationPreview.hasConfiguration && (
+                <div className="rounded-2xl border border-white/50 bg-white/70 p-4 shadow-inner">
+                  <h4 className="text-sm font-semibold text-brand-navy">Pay summary</h4>
+                  {compensationPreview.summary.length > 0 ? (
+                    <ul className="mt-2 list-inside list-disc space-y-1 text-sm text-brand-navy">
+                      {compensationPreview.summary.map((line, index) => (
+                        <li key={`pay-summary-${index}`}>{line}</li>
+                      ))}
+                    </ul>
+                  ) : (
+                    <p className="mt-2 text-sm text-brand-navy/70">
+                      Enter rates above to preview how they’ll be paid.
+                    </p>
+                  )}
+                </div>
+              )}
             </div>
           </section>
 

--- a/lib/compensationPlan.ts
+++ b/lib/compensationPlan.ts
@@ -1,0 +1,592 @@
+type MaybeNumber = number | null | undefined | string;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export type PayType = "hourly" | "commission" | "salary" | "hybrid" | "guarantee" | "custom";
+
+export type CompensationComponent = {
+  enabled: boolean;
+  rate: number | null;
+};
+
+export type GuaranteePayoutMode = "higher" | "stacked";
+
+export type CompensationGuarantee = {
+  enabled: boolean;
+  weekly_amount: number | null;
+  commission_rate: number | null;
+  payout_mode: GuaranteePayoutMode;
+};
+
+export type CompensationOverride = {
+  subordinate_id: number;
+  percentage: number;
+};
+
+export type CompensationPlan = {
+  commission: CompensationComponent;
+  hourly: CompensationComponent;
+  salary: CompensationComponent;
+  guarantee: CompensationGuarantee;
+  overrides: CompensationOverride[];
+};
+
+export const defaultCompensationPlan: CompensationPlan = {
+  commission: { enabled: false, rate: null },
+  hourly: { enabled: false, rate: null },
+  salary: { enabled: false, rate: null },
+  guarantee: { enabled: false, weekly_amount: null, commission_rate: null, payout_mode: "higher" },
+  overrides: [],
+};
+
+function ensureNumber(value: MaybeNumber): number | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : null;
+  }
+  return null;
+}
+
+function ensureBoolean(value: unknown, fallback: boolean) {
+  if (typeof value === "boolean") return value;
+  return fallback;
+}
+
+function ensureComponent(value: unknown, fallbackRate: number | null = null): CompensationComponent {
+  if (!isPlainObject(value)) {
+    return { enabled: false, rate: fallbackRate };
+  }
+  const enabled = ensureBoolean((value as any).enabled, false);
+  const rate = ensureNumber((value as any).rate);
+  return { enabled, rate };
+}
+
+function ensureGuarantee(value: unknown): CompensationGuarantee {
+  if (!isPlainObject(value)) {
+    return { enabled: false, weekly_amount: null, commission_rate: null, payout_mode: "higher" };
+  }
+  const enabled = ensureBoolean((value as any).enabled, false);
+  const weekly = ensureNumber((value as any).weekly_amount);
+  const commissionRate = ensureNumber((value as any).commission_rate);
+  const payoutModeRaw = typeof (value as any).payout_mode === "string" ? (value as any).payout_mode : null;
+  const payoutMode: GuaranteePayoutMode = payoutModeRaw === "stacked" ? "stacked" : "higher";
+  return {
+    enabled,
+    weekly_amount: weekly,
+    commission_rate: commissionRate,
+    payout_mode: payoutMode,
+  };
+}
+
+function ensureOverrides(value: unknown): CompensationOverride[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => {
+      if (!isPlainObject(item)) return null;
+      const subordinateId = ensureNumber((item as any).subordinate_id);
+      const percentage = ensureNumber((item as any).percentage);
+      if (!Number.isFinite(subordinateId) || subordinateId === null) return null;
+      if (typeof subordinateId !== "number") return null;
+      if (!Number.isFinite(percentage ?? null)) return null;
+      const pct = percentage as number;
+      return {
+        subordinate_id: subordinateId,
+        percentage: pct,
+      };
+    })
+    .filter((entry): entry is CompensationOverride => !!entry);
+}
+
+export function normaliseCompensationPlan(raw: unknown): CompensationPlan {
+  if (!isPlainObject(raw)) {
+    return { ...defaultCompensationPlan };
+  }
+  const commission = ensureComponent((raw as any).commission);
+  const hourly = ensureComponent((raw as any).hourly);
+  const salary = ensureComponent((raw as any).salary);
+  const guarantee = ensureGuarantee((raw as any).guarantee);
+  const overrides = ensureOverrides((raw as any).overrides);
+  return {
+    commission,
+    hourly,
+    salary,
+    guarantee,
+    overrides,
+  };
+}
+
+function hasStoredPlan(raw: unknown): boolean {
+  if (!isPlainObject(raw)) return false;
+  return Object.keys(raw as Record<string, unknown>).length > 0;
+}
+
+export function planFromRecord(record: {
+  compensation_plan?: unknown;
+  commission_rate?: MaybeNumber;
+  hourly_rate?: MaybeNumber;
+  salary_rate?: MaybeNumber;
+  pay_type?: string | null;
+}): CompensationPlan {
+  const normalised = normaliseCompensationPlan(record.compensation_plan);
+  if (hasStoredPlan(record.compensation_plan)) {
+    return normalised;
+  }
+  const commissionRate = ensureNumber(record.commission_rate);
+  const hourlyRate = ensureNumber(record.hourly_rate);
+  const salaryRate = ensureNumber(record.salary_rate);
+  const payType = typeof record.pay_type === "string" ? record.pay_type : null;
+  return {
+    commission: {
+      enabled: !!commissionRate && commissionRate > 0,
+      rate: commissionRate && commissionRate > 0 ? commissionRate : commissionRate ?? null,
+    },
+    hourly: {
+      enabled: !!hourlyRate && hourlyRate > 0,
+      rate: hourlyRate ?? null,
+    },
+    salary: {
+      enabled: !!salaryRate && salaryRate > 0,
+      rate: salaryRate ?? null,
+    },
+    guarantee: {
+      enabled: payType === "guarantee",
+      weekly_amount: null,
+      commission_rate: commissionRate ?? null,
+      payout_mode: "higher",
+    },
+    overrides: [],
+  };
+}
+
+function clampPercentage(value: number | null): number | null {
+  if (value === null || !Number.isFinite(value)) return null;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+function clampNonNegative(value: number | null): number | null {
+  if (value === null || !Number.isFinite(value)) return null;
+  if (value < 0) return 0;
+  return value;
+}
+
+export function cleanOverrides(overrides: CompensationOverride[]): CompensationOverride[] {
+  const map = new Map<number, number>();
+  for (const entry of overrides) {
+    const subordinateId = entry.subordinate_id;
+    if (!Number.isFinite(subordinateId) || subordinateId <= 0) continue;
+    const percentage = clampPercentage(entry.percentage ?? null);
+    if (percentage === null) continue;
+    map.set(subordinateId, percentage);
+  }
+  return Array.from(map.entries()).map(([subordinate_id, percentage]) => ({ subordinate_id, percentage }));
+}
+
+export function toStoredPlan(plan: CompensationPlan): CompensationPlan {
+  const commissionRate = clampPercentage(plan.commission.rate ?? null);
+  const hourlyRate = clampNonNegative(plan.hourly.rate ?? null);
+  const salaryRate = clampNonNegative(plan.salary.rate ?? null);
+  const weekly = clampNonNegative(plan.guarantee.weekly_amount ?? null);
+  const guaranteeRate = clampPercentage(plan.guarantee.commission_rate ?? null);
+  return {
+    commission: {
+      enabled: plan.commission.enabled && commissionRate !== null,
+      rate: plan.commission.enabled && commissionRate !== null ? commissionRate : null,
+    },
+    hourly: {
+      enabled: plan.hourly.enabled && hourlyRate !== null,
+      rate: plan.hourly.enabled && hourlyRate !== null ? hourlyRate : null,
+    },
+    salary: {
+      enabled: plan.salary.enabled && salaryRate !== null,
+      rate: plan.salary.enabled && salaryRate !== null ? salaryRate : null,
+    },
+    guarantee: {
+      enabled: plan.guarantee.enabled && weekly !== null,
+      weekly_amount: plan.guarantee.enabled && weekly !== null ? weekly : null,
+      commission_rate: plan.guarantee.enabled && guaranteeRate !== null ? guaranteeRate : null,
+      payout_mode: plan.guarantee.payout_mode === "stacked" ? "stacked" : "higher",
+    },
+    overrides: cleanOverrides(plan.overrides ?? []),
+  };
+}
+
+export function derivePayType(plan: CompensationPlan): PayType {
+  const active: string[] = [];
+  if (plan.commission.enabled) active.push("commission");
+  if (plan.hourly.enabled) active.push("hourly");
+  if (plan.salary.enabled) active.push("salary");
+  if (plan.guarantee.enabled) active.push("guarantee");
+  if (active.length === 0) return "hourly";
+  if (active.length === 1) {
+    const key = active[0];
+    if (key === "guarantee") return "guarantee";
+    if (key === "hourly") return "hourly";
+    if (key === "salary") return "salary";
+    return "commission";
+  }
+  return "custom";
+}
+
+export function clonePlan(plan: CompensationPlan): CompensationPlan {
+  return {
+    commission: { ...plan.commission },
+    hourly: { ...plan.hourly },
+    salary: { ...plan.salary },
+    guarantee: { ...plan.guarantee },
+    overrides: [...(plan.overrides ?? [])],
+  };
+}
+
+export function planHasConfiguration(plan: CompensationPlan): boolean {
+  return (
+    !!plan &&
+    (plan.commission.enabled ||
+      plan.hourly.enabled ||
+      plan.salary.enabled ||
+      plan.guarantee.enabled ||
+      (Array.isArray(plan.overrides) && plan.overrides.length > 0))
+  );
+}
+
+export function getCommissionRate(plan: CompensationPlan): number {
+  if (plan.commission.enabled && Number.isFinite(plan.commission.rate)) {
+    return plan.commission.rate ?? 0;
+  }
+  if (plan.guarantee.enabled && Number.isFinite(plan.guarantee.commission_rate)) {
+    return plan.guarantee.commission_rate ?? 0;
+  }
+  return 0;
+}
+
+export function getHourlyRate(plan: CompensationPlan): number {
+  if (plan.hourly.enabled && Number.isFinite(plan.hourly.rate)) {
+    return plan.hourly.rate ?? 0;
+  }
+  return 0;
+}
+
+export function getSalaryRate(plan: CompensationPlan): number {
+  if (plan.salary.enabled && Number.isFinite(plan.salary.rate)) {
+    return plan.salary.rate ?? 0;
+  }
+  return 0;
+}
+
+type SummaryOptions = {
+  staffNameMap?: Map<number, string>;
+  locale?: string;
+  currency?: string;
+};
+
+function formatPercentDisplay(value: number, locale: string): string {
+  return new Intl.NumberFormat(locale, {
+    style: "percent",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function formatCurrencyDisplay(value: number, locale: string, currency: string): string {
+  return new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+export function planSummaryLines(plan: CompensationPlan, options: SummaryOptions = {}): string[] {
+  const { staffNameMap, locale = "en-US", currency = "USD" } = options;
+  const lines: string[] = [];
+
+  if (plan.commission.enabled && Number.isFinite(plan.commission.rate) && (plan.commission.rate ?? 0) > 0) {
+    lines.push(`${formatPercentDisplay(plan.commission.rate as number, locale)} commission on their own grooms.`);
+  }
+
+  if (plan.hourly.enabled && Number.isFinite(plan.hourly.rate) && (plan.hourly.rate ?? 0) > 0) {
+    lines.push(
+      `${formatCurrencyDisplay(plan.hourly.rate as number, locale, currency)} per hour base pay.`,
+    );
+  }
+
+  if (plan.salary.enabled && Number.isFinite(plan.salary.rate) && (plan.salary.rate ?? 0) > 0) {
+    lines.push(
+      `${formatCurrencyDisplay(plan.salary.rate as number, locale, currency)} salary per year.`,
+    );
+  }
+
+  if (plan.guarantee.enabled && Number.isFinite(plan.guarantee.weekly_amount) && (plan.guarantee.weekly_amount ?? 0) > 0) {
+    const payoutMode = plan.guarantee.payout_mode === "stacked" ? "stacked" : "higher";
+    const formattedAmount = formatCurrencyDisplay(plan.guarantee.weekly_amount as number, locale, currency);
+    if (payoutMode === "stacked") {
+      const hasCommission = plan.commission.enabled && Number.isFinite(plan.commission.rate) && (plan.commission.rate ?? 0) > 0;
+      if (hasCommission) {
+        lines.push(`${formattedAmount} per week guaranteed in addition to their commission earnings.`);
+      } else {
+        lines.push(`${formattedAmount} per week guaranteed.`);
+      }
+    } else {
+      const guaranteeRate = Number.isFinite(plan.guarantee.commission_rate)
+        ? (plan.guarantee.commission_rate as number)
+        : Number.isFinite(plan.commission.rate)
+        ? (plan.commission.rate as number)
+        : null;
+      const commissionText = guaranteeRate
+        ? `${formatPercentDisplay(guaranteeRate, locale)} commission`
+        : "their commission";
+      lines.push(`${formattedAmount} per week guaranteed or ${commissionText}—whichever pays more.`);
+    }
+  }
+
+  let hasLead = lines.length > 0;
+  for (const entry of plan.overrides ?? []) {
+    if (!Number.isFinite(entry?.percentage) || (entry?.percentage ?? 0) <= 0) continue;
+    const staffName = staffNameMap?.get(entry.subordinate_id) ?? `Staff #${entry.subordinate_id}`;
+    const prefix = hasLead ? "Plus " : "";
+    lines.push(
+      `${prefix}${formatPercentDisplay(entry.percentage as number, locale)} of all grooms ${staffName} completes.`,
+    );
+    hasLead = true;
+  }
+
+  return lines;
+}
+
+export type CompensationPlanDraft = {
+  commission: { enabled: boolean; rate: string };
+  hourly: { enabled: boolean; rate: string };
+  salary: { enabled: boolean; rate: string };
+  guarantee: { enabled: boolean; weeklyAmount: string; commissionRate: string; payoutMode: GuaranteePayoutMode };
+  overridesEnabled: boolean;
+  overrides: { subordinateId: number | null; percentage: string }[];
+};
+
+function formatPercent(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return "";
+  return Number((value * 100).toFixed(2)).toString();
+}
+
+function formatNumber(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return "";
+  return Number(value.toFixed(2)).toString();
+}
+
+function normalisePayoutMode(value: string): GuaranteePayoutMode {
+  return value === "stacked" ? "stacked" : "higher";
+}
+
+export function draftFromPlan(plan: CompensationPlan): CompensationPlanDraft {
+  return {
+    commission: {
+      enabled: plan.commission.enabled,
+      rate: plan.commission.enabled ? formatPercent(plan.commission.rate ?? null) : "",
+    },
+    hourly: {
+      enabled: plan.hourly.enabled,
+      rate: plan.hourly.enabled ? formatNumber(plan.hourly.rate ?? null) : "",
+    },
+    salary: {
+      enabled: plan.salary.enabled,
+      rate: plan.salary.enabled ? formatNumber(plan.salary.rate ?? null) : "",
+    },
+    guarantee: {
+      enabled: plan.guarantee.enabled,
+      weeklyAmount: plan.guarantee.enabled ? formatNumber(plan.guarantee.weekly_amount ?? null) : "",
+      commissionRate: plan.guarantee.enabled ? formatPercent(plan.guarantee.commission_rate ?? null) : "",
+      payoutMode: plan.guarantee.payout_mode === "stacked" ? "stacked" : "higher",
+    },
+    overridesEnabled: (plan.overrides ?? []).length > 0,
+    overrides: (plan.overrides ?? []).map((entry) => ({
+      subordinateId: entry.subordinate_id,
+      percentage: formatPercent(entry.percentage ?? null),
+    })),
+  };
+}
+
+type ParseFieldResult = { value: number | null; provided: boolean; valid: boolean };
+
+function parsePercentField(
+  input: string,
+  label: string,
+  errors: string[],
+  { optional = false }: { optional?: boolean } = {}
+): ParseFieldResult {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    if (optional) return { value: null, provided: false, valid: true };
+    errors.push(`${label} is required.`);
+    return { value: null, provided: false, valid: false };
+  }
+  const cleaned = trimmed.replace(/[%\s]/g, "");
+  const normalised = Number(cleaned.replace(/,/g, "."));
+  if (!Number.isFinite(normalised)) {
+    errors.push(`${label} must be a valid number.`);
+    return { value: null, provided: true, valid: false };
+  }
+  if (normalised < 0 || normalised > 100) {
+    errors.push(`${label} must be between 0 and 100.`);
+    return { value: null, provided: true, valid: false };
+  }
+  return { value: normalised / 100, provided: true, valid: true };
+}
+
+function parseCurrencyField(
+  input: string,
+  label: string,
+  errors: string[],
+  { optional = false }: { optional?: boolean } = {}
+): ParseFieldResult {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    if (optional) return { value: null, provided: false, valid: true };
+    errors.push(`${label} is required.`);
+    return { value: null, provided: false, valid: false };
+  }
+  const cleaned = trimmed.replace(/[$,\s]/g, "");
+  const normalised = Number(cleaned);
+  if (!Number.isFinite(normalised)) {
+    errors.push(`${label} must be a valid number.`);
+    return { value: null, provided: true, valid: false };
+  }
+  if (normalised < 0) {
+    errors.push(`${label} cannot be negative.`);
+    return { value: null, provided: true, valid: false };
+  }
+  return { value: normalised, provided: true, valid: true };
+}
+
+export type DraftParseResult = {
+  plan: CompensationPlan;
+  commissionRate: number;
+  hourlyRate: number;
+  salaryRate: number;
+  payType: PayType;
+  errors: string[];
+};
+
+export function parseDraft(draft: CompensationPlanDraft): DraftParseResult {
+  const errors: string[] = [];
+
+  const commissionResult = draft.commission.enabled
+    ? parsePercentField(draft.commission.rate, "Commission %", errors)
+    : { value: null, provided: false, valid: true };
+
+  const hourlyResult = draft.hourly.enabled
+    ? parseCurrencyField(draft.hourly.rate, "Hourly rate", errors)
+    : { value: null, provided: false, valid: true };
+
+  const salaryResult = draft.salary.enabled
+    ? parseCurrencyField(draft.salary.rate, "Salary rate", errors)
+    : { value: null, provided: false, valid: true };
+
+  const guaranteeWeekly = draft.guarantee.enabled
+    ? parseCurrencyField(draft.guarantee.weeklyAmount, "Weekly guarantee", errors)
+    : { value: null, provided: false, valid: true };
+
+  const guaranteeCommission = draft.guarantee.enabled
+    ? parsePercentField(draft.guarantee.commissionRate, "Guarantee commission %", errors, { optional: true })
+    : { value: null, provided: false, valid: true };
+
+  const payoutMode = normalisePayoutMode(draft.guarantee.payoutMode);
+
+  let overrides: CompensationOverride[] = [];
+  if (draft.overridesEnabled) {
+    overrides = draft.overrides
+      .map((entry, index) => {
+        const hasSubordinate = entry.subordinateId != null;
+        const hasPercent = entry.percentage.trim() !== "";
+        if (!hasSubordinate && !hasPercent) {
+          return null;
+        }
+        if (!hasSubordinate || !hasPercent) {
+          errors.push(`Override row ${index + 1} must include a groomer and percentage.`);
+          return null;
+        }
+        const percentResult = parsePercentField(entry.percentage, `Override % (row ${index + 1})`, errors);
+        if (!percentResult.valid || percentResult.value === null) {
+          return null;
+        }
+        return {
+          subordinate_id: entry.subordinateId!,
+          percentage: percentResult.value,
+        } as CompensationOverride;
+      })
+      .filter((entry): entry is CompensationOverride => !!entry);
+  }
+
+  const plan: CompensationPlan = {
+    commission: {
+      enabled: draft.commission.enabled && commissionResult.value !== null,
+      rate: commissionResult.value,
+    },
+    hourly: {
+      enabled: draft.hourly.enabled && hourlyResult.value !== null,
+      rate: hourlyResult.value,
+    },
+    salary: {
+      enabled: draft.salary.enabled && salaryResult.value !== null,
+      rate: salaryResult.value,
+    },
+    guarantee: {
+      enabled: draft.guarantee.enabled && guaranteeWeekly.value !== null,
+      weekly_amount: guaranteeWeekly.value,
+      commission_rate: null,
+      payout_mode: payoutMode,
+    },
+    overrides,
+  };
+
+  if (plan.guarantee.enabled) {
+    if (plan.guarantee.payout_mode === "higher") {
+      if (guaranteeCommission.valid && guaranteeCommission.value !== null) {
+        plan.guarantee.commission_rate = guaranteeCommission.value;
+      } else if (plan.commission.enabled && plan.commission.rate !== null) {
+        plan.guarantee.commission_rate = plan.commission.rate;
+      } else if (!guaranteeCommission.valid) {
+        // error already recorded
+      } else {
+        errors.push("Enable a commission rate to compare against the weekly guarantee.");
+      }
+    } else {
+      plan.guarantee.commission_rate = null;
+    }
+  }
+
+  const primaryEnabled =
+    plan.commission.enabled || plan.hourly.enabled || plan.salary.enabled || plan.guarantee.enabled;
+  if (!primaryEnabled) {
+    errors.push("Enable at least one primary compensation option (commission, hourly, salary, or guarantee).");
+  }
+
+  const storedPlan = toStoredPlan(plan);
+  const payType = derivePayType(storedPlan);
+  const commissionRate = getCommissionRate(storedPlan);
+  const hourlyRate = getHourlyRate(storedPlan);
+  const salaryRate = getSalaryRate(storedPlan);
+
+  return {
+    plan: storedPlan,
+    commissionRate,
+    hourlyRate,
+    salaryRate,
+    payType,
+    errors,
+  };
+}
+
+export function mergeDraftWithPlan(
+  draft: CompensationPlanDraft,
+  plan: CompensationPlan
+): CompensationPlanDraft {
+  const next = draftFromPlan(plan);
+  return {
+    ...draft,
+    ...next,
+  };
+}

--- a/supabase/migrations/20240705_add_compensation_plan.sql
+++ b/supabase/migrations/20240705_add_compensation_plan.sql
@@ -1,0 +1,2 @@
+alter table public.employees
+  add column if not exists compensation_plan jsonb default '{}'::jsonb;


### PR DESCRIPTION
## Summary
- extend the compensation plan model with a weekly guarantee payout mode and update normalization, validation, and summaries
- refresh the new employee and settings compensation forms to choose between stacking the guarantee with commission or paying whichever amount is higher
- allow the staff API schema to persist the new payout mode for weekly guarantees

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d1bfd72b5883248687d6d652a10d59