### PR TITLE
Improve client creation form layout

### DIFF
--- a/app/clients/new/page.tsx
+++ b/app/clients/new/page.tsx
@@ -173,15 +173,11 @@ export default function NewClientPage() {
   };
 
   return (
-    <PageContainer className="max-w-5xl space-y-10">
-      <Card className="space-y-8">
+    <PageContainer className="max-w-5xl space-y-8">
+      <Card>
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="space-y-2">
-            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-brand-navy/50">Create client</p>
-            <h1 className="text-3xl font-bold text-brand-navy">Add new client</h1>
-            <p className="text-sm text-brand-navy/70">
-              Record owner details and their dogs so you can start scheduling appointments right away.
-            </p>
+            <h1 className="text-3xl font-bold text-brand-navy">New Client</h1>
           </div>
           <Link
             href="/clients"
@@ -190,316 +186,316 @@ export default function NewClientPage() {
             Cancel
           </Link>
         </div>
+      </Card>
 
+      <form onSubmit={handleSubmit} className="space-y-8">
         {error && (
           <div className="rounded-2xl border border-red-300/60 bg-red-100/70 px-4 py-3 text-sm text-red-700">{error}</div>
         )}
 
-        <form onSubmit={handleSubmit} className="space-y-10">
-          <section className="space-y-6">
-            <div className="space-y-1">
-              <h2 className="text-lg font-semibold text-brand-navy">Owner information</h2>
-              <p className="text-sm text-brand-navy/60">Tell us about the person who owns the pets.</p>
+        <Card className="space-y-6">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold text-brand-navy">Owner information</h2>
+            <p className="text-sm text-brand-navy/60">Tell us about the person who owns the pets.</p>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <label className={labelClass} htmlFor="firstName">
+                First name
+              </label>
+              <input
+                id="firstName"
+                name="firstName"
+                type="text"
+                required
+                className={textInputClass}
+                value={firstName}
+                onChange={(event) => {
+                  setFirstName(event.target.value);
+                  resetError();
+                }}
+                autoComplete="given-name"
+              />
             </div>
-            <div className="grid gap-4 md:grid-cols-2">
-              <div className="space-y-2">
-                <label className={labelClass} htmlFor="firstName">
-                  First name
-                </label>
-                <input
-                  id="firstName"
-                  name="firstName"
-                  type="text"
-                  required
-                  className={textInputClass}
-                  value={firstName}
-                  onChange={(event) => {
-                    setFirstName(event.target.value);
-                    resetError();
-                  }}
-                  autoComplete="given-name"
-                />
-              </div>
-              <div className="space-y-2">
-                <label className={labelClass} htmlFor="lastName">
-                  Last name
-                </label>
-                <input
-                  id="lastName"
-                  name="lastName"
-                  type="text"
-                  required
-                  className={textInputClass}
-                  value={lastName}
-                  onChange={(event) => {
-                    setLastName(event.target.value);
-                    resetError();
-                  }}
-                  autoComplete="family-name"
-                />
-              </div>
-              <div className="space-y-2">
-                <label className={labelClass} htmlFor="phone">
-                  Phone number <span className="font-normal text-brand-navy/60">(10 digits)</span>
-                </label>
-                <input
-                  id="phone"
-                  name="phone"
-                  type="tel"
-                  inputMode="tel"
-                  className={textInputClass}
-                  value={phone}
-                  onChange={(event) => {
-                    setPhone(event.target.value);
-                    resetError();
-                  }}
-                  placeholder="(555) 123-4567"
-                  autoComplete="tel"
-                />
-              </div>
-              <div className="space-y-2">
-                <label className={labelClass} htmlFor="email">
-                  Email <span className="font-normal text-brand-navy/60">(optional)</span>
-                </label>
-                <input
-                  id="email"
-                  name="email"
-                  type="email"
-                  className={textInputClass}
-                  value={email}
-                  onChange={(event) => {
-                    setEmail(event.target.value);
-                    resetError();
-                  }}
-                  placeholder="jane@example.com"
-                  autoComplete="email"
-                />
-              </div>
-              <div className="space-y-2 md:col-span-2">
-                <label className={labelClass} htmlFor="address">
-                  Address <span className="font-normal text-brand-navy/60">(optional)</span>
-                </label>
-                <input
-                  id="address"
-                  name="address"
-                  type="text"
-                  className={textInputClass}
-                  value={address}
-                  onChange={(event) => {
-                    setAddress(event.target.value);
-                    resetError();
-                  }}
-                  placeholder="1234 Bubble Lane, Springfield"
-                  autoComplete="street-address"
-                />
-              </div>
-              <div className="space-y-2 md:col-span-2">
-                <label className={labelClass} htmlFor="hearAboutUs">
-                  How did they hear about you? <span className="font-normal text-brand-navy/60">(optional)</span>
-                </label>
-                <select
-                  id="hearAboutUs"
-                  name="hearAboutUs"
-                  className={textInputClass}
-                  value={hearAboutUs}
-                  onChange={(event) => {
-                    setHearAboutUs(event.target.value);
-                    resetError();
-                  }}
-                >
-                  {hearAboutUsOptions.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
+            <div className="space-y-2">
+              <label className={labelClass} htmlFor="lastName">
+                Last name
+              </label>
+              <input
+                id="lastName"
+                name="lastName"
+                type="text"
+                required
+                className={textInputClass}
+                value={lastName}
+                onChange={(event) => {
+                  setLastName(event.target.value);
+                  resetError();
+                }}
+                autoComplete="family-name"
+              />
             </div>
-          </section>
-
-          <section className="space-y-6">
-            <div className="space-y-1">
-              <h2 className="text-lg font-semibold text-brand-navy">Dog information</h2>
-              <p className="text-sm text-brand-navy/60">Add each dog the client will bring in. Leave blank to skip.</p>
+            <div className="space-y-2">
+              <label className={labelClass} htmlFor="phone">
+                Phone number <span className="font-normal text-brand-navy/60">(10 digits)</span>
+              </label>
+              <input
+                id="phone"
+                name="phone"
+                type="tel"
+                inputMode="tel"
+                className={textInputClass}
+                value={phone}
+                onChange={(event) => {
+                  setPhone(event.target.value);
+                  resetError();
+                }}
+                placeholder="(555) 123-4567"
+                autoComplete="tel"
+              />
             </div>
+            <div className="space-y-2">
+              <label className={labelClass} htmlFor="email">
+                Email <span className="font-normal text-brand-navy/60">(optional)</span>
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                className={textInputClass}
+                value={email}
+                onChange={(event) => {
+                  setEmail(event.target.value);
+                  resetError();
+                }}
+                placeholder="jane@example.com"
+                autoComplete="email"
+              />
+            </div>
+            <div className="space-y-2 md:col-span-2">
+              <label className={labelClass} htmlFor="address">
+                Address <span className="font-normal text-brand-navy/60">(optional)</span>
+              </label>
+              <input
+                id="address"
+                name="address"
+                type="text"
+                className={textInputClass}
+                value={address}
+                onChange={(event) => {
+                  setAddress(event.target.value);
+                  resetError();
+                }}
+                placeholder="1234 Bubble Lane, Springfield"
+                autoComplete="street-address"
+              />
+            </div>
+            <div className="space-y-2 md:col-span-2">
+              <label className={labelClass} htmlFor="hearAboutUs">
+                How did they hear about you? <span className="font-normal text-brand-navy/60">(optional)</span>
+              </label>
+              <select
+                id="hearAboutUs"
+                name="hearAboutUs"
+                className={textInputClass}
+                value={hearAboutUs}
+                onChange={(event) => {
+                  setHearAboutUs(event.target.value);
+                  resetError();
+                }}
+              >
+                {hearAboutUsOptions.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+        </Card>
 
-            <div className="space-y-6">
-              {dogs.map((dog, index) => (
-                <div
-                  key={index}
-                  className="space-y-5 rounded-2xl border border-brand-bubble/40 bg-white/75 p-5 shadow-sm"
-                >
-                  <div className="grid gap-4 md:grid-cols-2">
-                    <div className="space-y-2">
-                      <label className={labelClass} htmlFor={`dog-name-${index}`}>
-                        Name
-                      </label>
-                      <input
-                        id={`dog-name-${index}`}
-                        type="text"
-                        className={textInputClass}
-                        value={dog.name}
-                        onChange={(event) => updateDog(index, { name: event.target.value })}
-                        placeholder="Charlie"
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <label className={labelClass} htmlFor={`dog-breed-${index}`}>
-                        Breed
-                      </label>
-                      <input
-                        id={`dog-breed-${index}`}
-                        type="text"
-                        className={textInputClass}
-                        value={dog.breed}
-                        onChange={(event) => updateDog(index, { breed: event.target.value })}
-                        placeholder="Golden Retriever"
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <span className={labelClass}>Gender</span>
-                      <div className="flex items-center gap-6 rounded-xl border border-white/50 bg-white/70 px-4 py-3">
-                        <label className="flex items-center gap-2 text-sm text-brand-navy">
-                          <input
-                            type="radio"
-                            name={`dog-gender-${index}`}
-                            value="male"
-                            checked={dog.gender === 'male'}
-                            onChange={() => updateDog(index, { gender: 'male' })}
-                            className="h-4 w-4 border-brand-bubble text-primary focus:ring-brand-bubble"
-                          />
-                          Male
-                        </label>
-                        <label className="flex items-center gap-2 text-sm text-brand-navy">
-                          <input
-                            type="radio"
-                            name={`dog-gender-${index}`}
-                            value="female"
-                            checked={dog.gender === 'female'}
-                            onChange={() => updateDog(index, { gender: 'female' })}
-                            className="h-4 w-4 border-brand-bubble text-primary focus:ring-brand-bubble"
-                          />
-                          Female
-                        </label>
-                      </div>
-                    </div>
-                    <div className="space-y-2">
-                      <label className={labelClass} htmlFor={`dog-age-${index}`}>
-                        Age
-                      </label>
-                      <input
-                        id={`dog-age-${index}`}
-                        type="text"
-                        className={textInputClass}
-                        value={dog.age}
-                        onChange={(event) => updateDog(index, { age: event.target.value })}
-                        placeholder="2 years"
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <label className={labelClass} htmlFor={`dog-weight-${index}`}>
-                        Weight
-                      </label>
-                      <input
-                        id={`dog-weight-${index}`}
-                        type="text"
-                        className={textInputClass}
-                        value={dog.weight}
-                        onChange={(event) => updateDog(index, { weight: event.target.value })}
-                        placeholder="45 lbs"
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <label className={labelClass} htmlFor={`dog-hair-${index}`}>
-                        Coat / hair type
-                      </label>
-                      <input
-                        id={`dog-hair-${index}`}
-                        type="text"
-                        className={textInputClass}
-                        value={dog.hairType}
-                        onChange={(event) => updateDog(index, { hairType: event.target.value })}
-                        placeholder="Short double coat"
-                      />
-                    </div>
-                  </div>
+        <Card className="space-y-6">
+          <div className="space-y-1">
+            <h2 className="text-lg font-semibold text-brand-navy">Dog information</h2>
+            <p className="text-sm text-brand-navy/60">Add each dog the client will bring in. Leave blank to skip.</p>
+          </div>
 
-                  <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                    <label className="flex items-center gap-2 text-sm font-semibold text-brand-navy">
-                      <input
-                        type="checkbox"
-                        checked={dog.neutered}
-                        onChange={(event) => updateDog(index, { neutered: event.target.checked })}
-                        className="h-4 w-4 rounded border-brand-bubble text-primary focus:ring-brand-bubble"
-                      />
-                      Neutered / spayed
-                    </label>
-                    <div className="space-y-2 md:w-1/2">
-                      <label className={labelClass} htmlFor={`dog-photo-${index}`}>
-                        Photo <span className="font-normal text-brand-navy/60">(optional)</span>
-                      </label>
-                      <input
-                        id={`dog-photo-${index}`}
-                        type="file"
-                        accept="image/*"
-                        capture="environment"
-                        onChange={(event) => handleDogPhotoChange(index, event)}
-                        className="block w-full text-sm text-brand-navy file:mr-4 file:rounded-full file:border-0 file:bg-brand-bubble file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white hover:file:bg-primary"
-                      />
-                    </div>
-                  </div>
-
+          <div className="space-y-6">
+            {dogs.map((dog, index) => (
+              <div
+                key={index}
+                className="space-y-5 rounded-2xl border border-brand-bubble/40 bg-white/75 p-5 shadow-sm"
+              >
+                <div className="grid gap-4 md:grid-cols-2">
                   <div className="space-y-2">
-                    <label className={labelClass} htmlFor={`dog-medical-${index}`}>
-                      Medical notes / allergies <span className="font-normal text-brand-navy/60">(optional)</span>
+                    <label className={labelClass} htmlFor={`dog-name-${index}`}>
+                      Name
                     </label>
-                    <textarea
-                      id={`dog-medical-${index}`}
-                      className={textAreaClass}
-                      value={dog.medical}
-                      onChange={(event) => updateDog(index, { medical: event.target.value })}
-                      placeholder="Allergies, meds, behavioral notes"
+                    <input
+                      id={`dog-name-${index}`}
+                      type="text"
+                      className={textInputClass}
+                      value={dog.name}
+                      onChange={(event) => updateDog(index, { name: event.target.value })}
+                      placeholder="Charlie"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className={labelClass} htmlFor={`dog-breed-${index}`}>
+                      Breed
+                    </label>
+                    <input
+                      id={`dog-breed-${index}`}
+                      type="text"
+                      className={textInputClass}
+                      value={dog.breed}
+                      onChange={(event) => updateDog(index, { breed: event.target.value })}
+                      placeholder="Golden Retriever"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <span className={labelClass}>Gender</span>
+                    <div className="flex items-center gap-6 rounded-xl border border-white/50 bg-white/70 px-4 py-3">
+                      <label className="flex items-center gap-2 text-sm text-brand-navy">
+                        <input
+                          type="radio"
+                          name={`dog-gender-${index}`}
+                          value="male"
+                          checked={dog.gender === 'male'}
+                          onChange={() => updateDog(index, { gender: 'male' })}
+                          className="h-4 w-4 border-brand-bubble text-primary focus:ring-brand-bubble"
+                        />
+                        Male
+                      </label>
+                      <label className="flex items-center gap-2 text-sm text-brand-navy">
+                        <input
+                          type="radio"
+                          name={`dog-gender-${index}`}
+                          value="female"
+                          checked={dog.gender === 'female'}
+                          onChange={() => updateDog(index, { gender: 'female' })}
+                          className="h-4 w-4 border-brand-bubble text-primary focus:ring-brand-bubble"
+                        />
+                        Female
+                      </label>
+                    </div>
+                  </div>
+                  <div className="space-y-2">
+                    <label className={labelClass} htmlFor={`dog-age-${index}`}>
+                      Age
+                    </label>
+                    <input
+                      id={`dog-age-${index}`}
+                      type="text"
+                      className={textInputClass}
+                      value={dog.age}
+                      onChange={(event) => updateDog(index, { age: event.target.value })}
+                      placeholder="2 years"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className={labelClass} htmlFor={`dog-weight-${index}`}>
+                      Weight
+                    </label>
+                    <input
+                      id={`dog-weight-${index}`}
+                      type="text"
+                      className={textInputClass}
+                      value={dog.weight}
+                      onChange={(event) => updateDog(index, { weight: event.target.value })}
+                      placeholder="45 lbs"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label className={labelClass} htmlFor={`dog-hair-${index}`}>
+                      Coat / hair type
+                    </label>
+                    <input
+                      id={`dog-hair-${index}`}
+                      type="text"
+                      className={textInputClass}
+                      value={dog.hairType}
+                      onChange={(event) => updateDog(index, { hairType: event.target.value })}
+                      placeholder="Short double coat"
                     />
                   </div>
                 </div>
-              ))}
-            </div>
 
-            <button
-              type="button"
-              onClick={addDog}
-              className="inline-flex items-center justify-center gap-2 rounded-xl border border-dashed border-brand-bubble/60 bg-brand-bubble/10 px-4 py-2 text-sm font-semibold text-brand-bubble transition hover:bg-brand-bubble/15 focus:outline-none focus:ring-2 focus:ring-brand-bubble/40"
-            >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-                fill="currentColor"
-                className="h-4 w-4"
-                aria-hidden="true"
-              >
-                <path d="M10 3a.75.75 0 0 1 .75.75V9.25h5.5a.75.75 0 0 1 0 1.5h-5.5v5.5a.75.75 0 0 1-1.5 0v-5.5H3.25a.75.75 0 0 1 0-1.5h5.5V3.75A.75.75 0 0 1 10 3Z" />
-              </svg>
-              Add another dog
-            </button>
-          </section>
+                <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                  <label className="flex items-center gap-2 text-sm font-semibold text-brand-navy">
+                    <input
+                      type="checkbox"
+                      checked={dog.neutered}
+                      onChange={(event) => updateDog(index, { neutered: event.target.checked })}
+                      className="h-4 w-4 rounded border-brand-bubble text-primary focus:ring-brand-bubble"
+                    />
+                    Neutered / spayed
+                  </label>
+                  <div className="space-y-2 md:w-1/2">
+                    <label className={labelClass} htmlFor={`dog-photo-${index}`}>
+                      Photo <span className="font-normal text-brand-navy/60">(optional)</span>
+                    </label>
+                    <input
+                      id={`dog-photo-${index}`}
+                      type="file"
+                      accept="image/*"
+                      capture="environment"
+                      onChange={(event) => handleDogPhotoChange(index, event)}
+                      className="block w-full text-sm text-brand-navy file:mr-4 file:rounded-full file:border-0 file:bg-brand-bubble file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white hover:file:bg-primary"
+                    />
+                  </div>
+                </div>
 
-          <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
-            <Link
-              href="/clients"
-              className="inline-flex items-center justify-center rounded-xl border border-white/40 bg-white/80 px-4 py-2 text-sm font-semibold text-brand-navy shadow-sm transition hover:bg-white focus:outline-none focus:ring-2 focus:ring-brand-bubble/40"
-            >
-              Back to clients
-            </Link>
-            <button
-              type="submit"
-              disabled={saving}
-              className="inline-flex items-center justify-center rounded-xl bg-primary px-6 py-3 text-sm font-semibold text-white shadow-soft transition hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-brand-bubble/40 disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {saving ? 'Saving…' : 'Create client'}
-            </button>
+                <div className="space-y-2">
+                  <label className={labelClass} htmlFor={`dog-medical-${index}`}>
+                    Medical notes / allergies <span className="font-normal text-brand-navy/60">(optional)</span>
+                  </label>
+                  <textarea
+                    id={`dog-medical-${index}`}
+                    className={textAreaClass}
+                    value={dog.medical}
+                    onChange={(event) => updateDog(index, { medical: event.target.value })}
+                    placeholder="Allergies, meds, behavioral notes"
+                  />
+                </div>
+              </div>
+            ))}
           </div>
-        </form>
-      </Card>
+
+          <button
+            type="button"
+            onClick={addDog}
+            className="inline-flex items-center justify-center gap-2 rounded-xl border border-dashed border-brand-bubble/60 bg-brand-bubble/10 px-4 py-2 text-sm font-semibold text-brand-bubble transition hover:bg-brand-bubble/15 focus:outline-none focus:ring-2 focus:ring-brand-bubble/40"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              className="h-4 w-4"
+              aria-hidden="true"
+            >
+              <path d="M10 3a.75.75 0 0 1 .75.75V9.25h5.5a.75.75 0 0 1 0 1.5h-5.5v5.5a.75.75 0 0 1-1.5 0v-5.5H3.25a.75.75 0 0 1 0-1.5h5.5V3.75A.75.75 0 0 1 10 3Z" />
+            </svg>
+            Add another dog
+          </button>
+        </Card>
+
+        <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+          <Link
+            href="/clients"
+            className="inline-flex items-center justify-center rounded-xl border border-white/40 bg-white/80 px-4 py-2 text-sm font-semibold text-brand-navy shadow-sm transition hover:bg-white focus:outline-none focus:ring-2 focus:ring-brand-bubble/40"
+          >
+            Back to clients
+          </Link>
+          <button
+            type="submit"
+            disabled={saving}
+            className="inline-flex items-center justify-center rounded-xl bg-primary px-6 py-3 text-sm font-semibold text-white shadow-soft transition hover:bg-primary-dark focus:outline-none focus:ring-2 focus:ring-brand-bubble/40 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {saving ? 'Saving…' : 'Create client'}
+          </button>
+        </div>
+      </form>
     </PageContainer>
   );
 }

--- a/app/clients/page.tsx
+++ b/app/clients/page.tsx
@@ -64,7 +64,7 @@ export default function ClientsPage() {
             >
               <path d="M10 3a.75.75 0 0 1 .75.75V9.25h5.5a.75.75 0 0 1 0 1.5h-5.5v5.5a.75.75 0 0 1-1.5 0v-5.5H3.25a.75.75 0 0 1 0-1.5h5.5V3.75A.75.75 0 0 1 10 3Z" />
             </svg>
-            Add new client
+            New Client
           </Link>
           <form
             onSubmit={(event) => {


### PR DESCRIPTION
## Summary
- rename client listing call-to-action button to "New Client"
- simplify the new client page header by removing the uppercase label and intro copy
- retitle the new client page heading to "New Client"
- wrap owner and dog information sections in their own cards for clearer structure

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d36cb3a2a483249db4093c3678f2b0