### PR TITLE
Refine glitter accents on cards

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -37,3 +37,153 @@
     @apply rounded-full px-4 py-2 text-sm font-semibold text-white/90 transition hover:bg-white/15;
   }
 }
+
+:root {
+  --glitter-pointer-x: 0.5;
+  --glitter-pointer-y: 0.5;
+  --glitter-spark: 0.35;
+  --glitter-twinkle: 0.35;
+  --glitter-shimmer: 0.35;
+  --glitter-scroll: 0;
+  --glitter-hue: 220;
+}
+
+@layer components {
+  .glitter-card {
+    position: relative;
+    overflow: hidden;
+  }
+
+  .glitter-card::before,
+  .glitter-card::after {
+    content: "";
+    position: absolute;
+    pointer-events: none;
+    border-radius: inherit;
+    mix-blend-mode: screen;
+    transition: opacity 0.4s ease, transform 0.6s ease, filter 0.4s ease,
+      background-position 0.6s ease;
+  }
+
+  .glitter-card::before {
+    inset: -14%;
+    background-image:
+      radial-gradient(circle at 12% 18%, rgba(255, 255, 255, 0.86), transparent 60%),
+      radial-gradient(circle at 18% 78%, rgba(255, 255, 255, 0.5), transparent 68%),
+      radial-gradient(circle at 88% 16%, rgba(255, 255, 255, 0.7), transparent 70%),
+      radial-gradient(circle at 84% 78%, rgba(255, 255, 255, 0.7), transparent 70%),
+      radial-gradient(circle at 50% -6%, rgba(255, 250, 245, 0.55), transparent 70%);
+    background-size: 220px 220px, 200px 200px, 260px 260px, 210px 210px, 260px 260px;
+    background-repeat: no-repeat;
+    opacity: calc(
+      0.18 + var(--glitter-spark, 0.35) * 0.4 + var(--glitter-twinkle, 0.35) * 0.25
+    );
+    transform: translate3d(
+        calc((var(--glitter-pointer-x, 0.5) - 0.5) * 18px),
+        calc((var(--glitter-pointer-y, 0.5) - 0.5) * 18px),
+        0
+      )
+      scale(1.02);
+    filter: hue-rotate(calc((var(--glitter-hue, 220) - 24) * 1deg))
+      saturate(1.35) drop-shadow(0 0 12px rgba(255, 255, 255, 0.18));
+    animation: glitter-card-dust 20s ease-in-out infinite;
+  }
+
+  .glitter-card::after {
+    inset: -4px;
+    background-image:
+      conic-gradient(from 140deg at 14% 16%, rgba(255, 255, 255, 0.8), transparent 120deg),
+      conic-gradient(from -20deg at 86% 14%, rgba(255, 255, 255, 0.78), transparent 120deg),
+      conic-gradient(from 210deg at 16% 86%, rgba(255, 255, 255, 0.82), transparent 120deg),
+      conic-gradient(from 30deg at 84% 84%, rgba(255, 255, 255, 0.76), transparent 120deg),
+      linear-gradient(
+        130deg,
+        rgba(255, 255, 255, 0) 45%,
+        rgba(255, 255, 255, 0.6) 50%,
+        rgba(255, 255, 255, 0) 55%
+      );
+    background-size: 52% 52%, 52% 52%, 52% 52%, 52% 52%, 200% 200%;
+    background-repeat: no-repeat;
+    background-position:
+      0% 0%,
+      100% 0%,
+      0% 100%,
+      100% 100%,
+      calc(50% + (var(--glitter-pointer-x, 0.5) - 0.5) * 26%)
+        calc(50% + (var(--glitter-pointer-y, 0.5) - 0.5) * 18%);
+    opacity: calc(0.1 + var(--glitter-shimmer, 0.35) * 0.45);
+    filter: hue-rotate(calc(var(--glitter-hue, 220) * 1deg));
+    mask-image: radial-gradient(
+      farthest-side,
+      transparent 60%,
+      rgba(0, 0, 0, 0.85) 80%,
+      rgba(0, 0, 0, 0.95) 100%
+    );
+    -webkit-mask-image: radial-gradient(
+      farthest-side,
+      transparent 60%,
+      rgba(0, 0, 0, 0.85) 80%,
+      rgba(0, 0, 0, 0.95) 100%
+    );
+    animation: glitter-card-edge 16s ease-in-out infinite;
+  }
+
+  .glitter-card:hover::before,
+  .glitter-card:focus-within::before {
+    opacity: calc(0.28 + var(--glitter-spark, 0.35) * 0.65);
+    filter: hue-rotate(calc(var(--glitter-hue, 220) * 1deg)) saturate(1.55)
+      drop-shadow(0 0 16px rgba(255, 255, 255, 0.28));
+    transform: translate3d(
+        calc((var(--glitter-pointer-x, 0.5) - 0.5) * 14px),
+        calc((var(--glitter-pointer-y, 0.5) - 0.5) * 14px),
+        0
+      )
+      scale(1.05);
+  }
+
+  .glitter-card:hover::after,
+  .glitter-card:focus-within::after {
+    opacity: calc(0.18 + var(--glitter-shimmer, 0.35) * 0.6);
+    background-position:
+      0% 0%,
+      100% 0%,
+      0% 100%,
+      100% 100%,
+      calc(48% + (var(--glitter-pointer-x, 0.5) - 0.5) * 40%)
+        calc(46% + (var(--glitter-pointer-y, 0.5) - 0.5) * 32%);
+  }
+}
+
+@keyframes glitter-card-dust {
+  0% {
+    background-position: 0% 0%, 80% 10%, 20% 85%, 100% 68%, 40% 6%;
+  }
+  50% {
+    background-position: 12% 8%, 68% 18%, 24% 72%, 92% 62%, 36% 10%;
+  }
+  100% {
+    background-position: 4% 14%, 96% 38%, 30% 90%, 74% 84%, 60% -2%;
+  }
+}
+
+@keyframes glitter-card-edge {
+  0%,
+  100% {
+    transform: rotate(0deg) scale(1);
+  }
+  40% {
+    transform: rotate(0.45deg) scale(1.01);
+  }
+  60% {
+    transform: rotate(-0.35deg) scale(1.005);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .glitter-card::before,
+  .glitter-card::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import AuthProvider from "@/components/AuthProvider";
 import LogoutButton from "@/components/LogoutButton";
 import { mapProfileRow, type Role, type UserProfile } from "@/lib/auth/profile";
 import { createClient } from "@/lib/supabase/server";
+import GlitterOverlay from "@/components/GlitterOverlay";
 import "./globals.css";
 
 export const metadata = {
@@ -110,6 +111,7 @@ export default async function RootLayout({
               <div className="absolute -right-24 top-24 h-[28rem] w-[28rem] rounded-full bg-brand-lavender/25 blur-[140px]" />
               <div className="absolute bottom-[-18rem] left-1/2 h-[32rem] w-[32rem] -translate-x-1/2 rounded-full bg-brand-mint/20 blur-[160px]" />
             </div>
+            <GlitterOverlay />
             <header className="sticky top-0 z-40 flex justify-center px-4 pt-6">
               <div className="glass-panel flex w-full max-w-6xl items-center gap-6 px-6 py-4">
                 <Link href="/" className="group flex items-center gap-4 text-white">

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -5,7 +5,7 @@ export default function Card({ children, className = '' }: { children: ReactNode
   return (
     <div
       className={clsx(
-        'rounded-[2rem] border border-white/30 bg-white/85 p-6 text-brand-navy shadow-soft backdrop-blur-xl',
+        'glitter-card relative overflow-hidden rounded-[2rem] border border-white/30 bg-white/85 p-6 text-brand-navy shadow-soft backdrop-blur-xl',
         className
       )}
     >

--- a/components/GlitterOverlay.tsx
+++ b/components/GlitterOverlay.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect } from "react";
+
+const BASE_SPARK = 0.35;
+
+const clamp = (value: number, min: number, max: number) =>
+  Math.min(Math.max(value, min), max);
+
+export default function GlitterOverlay() {
+  useEffect(() => {
+    const root = document.documentElement;
+
+    let animationFrame = 0;
+    let sparklePhase = Math.random() * Math.PI * 2;
+    let shimmerPhase = Math.random() * Math.PI * 2;
+    let spark = BASE_SPARK;
+    let targetSpark = BASE_SPARK;
+
+    const updatePointerPosition = (clientX: number, clientY: number) => {
+      const x = clamp(clientX / window.innerWidth, 0, 1);
+      const y = clamp(clientY / window.innerHeight, 0, 1);
+      root.style.setProperty("--glitter-pointer-x", x.toFixed(3));
+      root.style.setProperty("--glitter-pointer-y", y.toFixed(3));
+    };
+
+    const handlePointerMove = (event: PointerEvent) => {
+      updatePointerPosition(event.clientX, event.clientY);
+
+      const velocity = clamp(
+        Math.sqrt(event.movementX ** 2 + event.movementY ** 2) / 18,
+        0,
+        1
+      );
+      targetSpark = Math.max(targetSpark, BASE_SPARK + velocity * 0.4);
+    };
+
+    const handlePointerDown = () => {
+      targetSpark = BASE_SPARK + 0.5;
+    };
+
+    const settleIntensity = () => {
+      targetSpark = BASE_SPARK;
+    };
+
+    const handleScroll = () => {
+      const maxScroll =
+        document.documentElement.scrollHeight - window.innerHeight;
+      const progress = maxScroll > 0 ? window.scrollY / maxScroll : 0;
+      root.style.setProperty("--glitter-scroll", progress.toFixed(3));
+      const hue = 205 + progress * 50;
+      root.style.setProperty("--glitter-hue", hue.toFixed(1));
+      targetSpark = Math.max(targetSpark, BASE_SPARK + progress * 0.2);
+    };
+
+    const animate = () => {
+      sparklePhase += 0.025;
+      shimmerPhase += 0.018;
+
+      spark += (targetSpark - spark) * 0.08;
+      targetSpark = Math.max(BASE_SPARK, targetSpark - 0.01);
+
+      const shimmer = 0.28 + (Math.sin(shimmerPhase) + 1) * 0.18 + spark * 0.12;
+      const twinkle =
+        0.24 + (Math.sin(sparklePhase * 1.35) + 1) * 0.18 + spark * 0.18;
+
+      root.style.setProperty("--glitter-spark", spark.toFixed(3));
+      root.style.setProperty("--glitter-shimmer", shimmer.toFixed(3));
+      root.style.setProperty("--glitter-twinkle", twinkle.toFixed(3));
+
+      animationFrame = window.requestAnimationFrame(animate);
+    };
+
+    const handleResize = () => {
+      updatePointerPosition(window.innerWidth / 2, window.innerHeight / 2);
+    };
+
+    updatePointerPosition(window.innerWidth / 2, window.innerHeight / 2);
+    handleScroll();
+    animationFrame = window.requestAnimationFrame(animate);
+
+    window.addEventListener("pointermove", handlePointerMove, {
+      passive: true,
+    });
+    window.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("pointerup", settleIntensity);
+    window.addEventListener("pointerleave", settleIntensity);
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.cancelAnimationFrame(animationFrame);
+      window.removeEventListener("pointermove", handlePointerMove);
+      window.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("pointerup", settleIntensity);
+      window.removeEventListener("pointerleave", settleIntensity);
+      window.removeEventListener("scroll", handleScroll);
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- restyle card backgrounds with pseudo-element glitter accents that shimmer around the corners and edges
- drive the accent variables from a lightweight glitter controller that tracks pointer, scroll, and click input without rendering a full-screen overlay
- expose new glitter CSS variables and animations to keep sparkles localized while reacting to user movement

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d3840fc31c832499a5f24860b4ac40