### PR TITLE
Clarify required dog details on new client form

### DIFF
--- a/app/clients/new/page.tsx
+++ b/app/clients/new/page.tsx
@@ -48,6 +48,19 @@ const hearAboutUsOptions = [
   { value: 'Other', label: 'Other' },
 ];
 
+const hairTypeOptions = [
+  { value: '', label: 'Select coat type' },
+  { value: 'Smooth', label: 'Smooth' },
+  { value: 'Short', label: 'Short' },
+  { value: 'Medium', label: 'Medium' },
+  { value: 'Long', label: 'Long' },
+  { value: 'Wire', label: 'Wire' },
+  { value: 'Curly', label: 'Curly' },
+  { value: 'Double', label: 'Double' },
+  { value: 'Hairless', label: 'Hairless' },
+  { value: 'Other', label: 'Other' },
+];
+
 function hasDogData(dog: DogForm) {
   return (
     dog.name.trim() !== '' ||
@@ -68,7 +81,6 @@ export default function NewClientPage() {
   const [lastName, setLastName] = useState('');
   const [phone, setPhone] = useState('');
   const [email, setEmail] = useState('');
-  const [address, setAddress] = useState('');
   const [hearAboutUs, setHearAboutUs] = useState('');
   const [dogs, setDogs] = useState<DogForm[]>([{ ...emptyDog }]);
   const [saving, setSaving] = useState(false);
@@ -111,6 +123,14 @@ export default function NewClientPage() {
         throw new Error('Please enter a valid 10 digit phone number.');
       }
 
+      const dogsToSave = dogs.filter((dog) => hasDogData(dog));
+
+      for (const dog of dogsToSave) {
+        if (!dog.age.trim() || !dog.weight.trim() || !dog.hairType.trim()) {
+          throw new Error('Please provide age, weight, and coat type for each dog you add.');
+        }
+      }
+
       const { data: client, error: clientError } = await supabase
         .from('clients')
         .insert({
@@ -119,7 +139,6 @@ export default function NewClientPage() {
           last_name: trimmedLast,
           phone: digits,
           email: email.trim() || null,
-          address: address.trim() || null,
           hear_about_us: hearAboutUs || null,
         })
         .select('id')
@@ -129,9 +148,7 @@ export default function NewClientPage() {
         throw new Error(clientError?.message ?? 'Failed to create client.');
       }
 
-      for (const dog of dogs) {
-        if (!hasDogData(dog)) continue;
-
+      for (const dog of dogsToSave) {
         let photoUrl: string | null = null;
 
         if (dog.photo) {
@@ -173,7 +190,7 @@ export default function NewClientPage() {
   };
 
   return (
-    <PageContainer className="max-w-5xl space-y-8">
+    <PageContainer className="max-w-5xl space-y-6 lg:space-y-5">
       <Card>
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div className="space-y-2">
@@ -188,250 +205,244 @@ export default function NewClientPage() {
         </div>
       </Card>
 
-      <form onSubmit={handleSubmit} className="space-y-8">
+      <form onSubmit={handleSubmit} className="space-y-6">
         {error && (
           <div className="rounded-2xl border border-red-300/60 bg-red-100/70 px-4 py-3 text-sm text-red-700">{error}</div>
         )}
 
-        <Card className="space-y-6">
-          <div className="space-y-1">
-            <h2 className="text-lg font-semibold text-brand-navy">Owner information</h2>
-            <p className="text-sm text-brand-navy/60">Tell us about the person who owns the pets.</p>
-          </div>
-          <div className="grid gap-4 md:grid-cols-2">
-            <div className="space-y-2">
-              <label className={labelClass} htmlFor="firstName">
-                First name
-              </label>
-              <input
-                id="firstName"
-                name="firstName"
-                type="text"
-                required
-                className={textInputClass}
-                value={firstName}
-                onChange={(event) => {
-                  setFirstName(event.target.value);
-                  resetError();
-                }}
-                autoComplete="given-name"
-              />
+        <div className="grid gap-6 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+          <Card className="space-y-5 p-5 lg:space-y-4">
+            <div className="space-y-1">
+              <h2 className="text-lg font-semibold text-brand-navy">Owner information</h2>
+              <p className="text-sm text-brand-navy/60">Tell us about the person who owns the pets.</p>
             </div>
-            <div className="space-y-2">
-              <label className={labelClass} htmlFor="lastName">
-                Last name
-              </label>
-              <input
-                id="lastName"
-                name="lastName"
-                type="text"
-                required
-                className={textInputClass}
-                value={lastName}
-                onChange={(event) => {
-                  setLastName(event.target.value);
-                  resetError();
-                }}
-                autoComplete="family-name"
-              />
+            <div className="grid gap-3 md:grid-cols-2">
+              <div className="space-y-1.5">
+                <label className={labelClass} htmlFor="firstName">
+                  First name
+                </label>
+                <input
+                  id="firstName"
+                  name="firstName"
+                  type="text"
+                  required
+                  className={textInputClass}
+                  value={firstName}
+                  onChange={(event) => {
+                    setFirstName(event.target.value);
+                    resetError();
+                  }}
+                  autoComplete="given-name"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label className={labelClass} htmlFor="lastName">
+                  Last name
+                </label>
+                <input
+                  id="lastName"
+                  name="lastName"
+                  type="text"
+                  required
+                  className={textInputClass}
+                  value={lastName}
+                  onChange={(event) => {
+                    setLastName(event.target.value);
+                    resetError();
+                  }}
+                  autoComplete="family-name"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label className={labelClass} htmlFor="phone">
+                  Phone number <span className="font-normal text-brand-navy/60">(10 digits)</span>
+                </label>
+                <input
+                  id="phone"
+                  name="phone"
+                  type="tel"
+                  inputMode="tel"
+                  className={textInputClass}
+                  value={phone}
+                  onChange={(event) => {
+                    setPhone(event.target.value);
+                    resetError();
+                  }}
+                  placeholder="(555) 123-4567"
+                  autoComplete="tel"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label className={labelClass} htmlFor="email">
+                  Email <span className="font-normal text-brand-navy/60">(optional)</span>
+                </label>
+                <input
+                  id="email"
+                  name="email"
+                  type="email"
+                  className={textInputClass}
+                  value={email}
+                  onChange={(event) => {
+                    setEmail(event.target.value);
+                    resetError();
+                  }}
+                  placeholder="jane@example.com"
+                  autoComplete="email"
+                />
+              </div>
+              <div className="space-y-1.5 md:col-span-2">
+                <label className={labelClass} htmlFor="hearAboutUs">
+                  How did they hear about you? <span className="font-normal text-brand-navy/60">(optional)</span>
+                </label>
+                <select
+                  id="hearAboutUs"
+                  name="hearAboutUs"
+                  className={textInputClass}
+                  value={hearAboutUs}
+                  onChange={(event) => {
+                    setHearAboutUs(event.target.value);
+                    resetError();
+                  }}
+                >
+                  {hearAboutUsOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
             </div>
-            <div className="space-y-2">
-              <label className={labelClass} htmlFor="phone">
-                Phone number <span className="font-normal text-brand-navy/60">(10 digits)</span>
-              </label>
-              <input
-                id="phone"
-                name="phone"
-                type="tel"
-                inputMode="tel"
-                className={textInputClass}
-                value={phone}
-                onChange={(event) => {
-                  setPhone(event.target.value);
-                  resetError();
-                }}
-                placeholder="(555) 123-4567"
-                autoComplete="tel"
-              />
-            </div>
-            <div className="space-y-2">
-              <label className={labelClass} htmlFor="email">
-                Email <span className="font-normal text-brand-navy/60">(optional)</span>
-              </label>
-              <input
-                id="email"
-                name="email"
-                type="email"
-                className={textInputClass}
-                value={email}
-                onChange={(event) => {
-                  setEmail(event.target.value);
-                  resetError();
-                }}
-                placeholder="jane@example.com"
-                autoComplete="email"
-              />
-            </div>
-            <div className="space-y-2 md:col-span-2">
-              <label className={labelClass} htmlFor="address">
-                Address <span className="font-normal text-brand-navy/60">(optional)</span>
-              </label>
-              <input
-                id="address"
-                name="address"
-                type="text"
-                className={textInputClass}
-                value={address}
-                onChange={(event) => {
-                  setAddress(event.target.value);
-                  resetError();
-                }}
-                placeholder="1234 Bubble Lane, Springfield"
-                autoComplete="street-address"
-              />
-            </div>
-            <div className="space-y-2 md:col-span-2">
-              <label className={labelClass} htmlFor="hearAboutUs">
-                How did they hear about you? <span className="font-normal text-brand-navy/60">(optional)</span>
-              </label>
-              <select
-                id="hearAboutUs"
-                name="hearAboutUs"
-                className={textInputClass}
-                value={hearAboutUs}
-                onChange={(event) => {
-                  setHearAboutUs(event.target.value);
-                  resetError();
-                }}
-              >
-                {hearAboutUsOptions.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-          </div>
-        </Card>
+          </Card>
 
-        <Card className="space-y-6">
-          <div className="space-y-1">
-            <h2 className="text-lg font-semibold text-brand-navy">Dog information</h2>
-            <p className="text-sm text-brand-navy/60">Add each dog the client will bring in. Leave blank to skip.</p>
-          </div>
+          <Card className="flex flex-col gap-5 p-5">
+            <div className="space-y-1">
+              <h2 className="text-lg font-semibold text-brand-navy">Dog information</h2>
+              <p className="text-sm text-brand-navy/60">
+                Add each dog the client will bring in. Leave blank to skip. Age, weight, and coat type are required for each dog
+                you add.
+              </p>
+            </div>
 
-          <div className="space-y-6">
-            {dogs.map((dog, index) => (
-              <div
-                key={index}
-                className="space-y-5 rounded-2xl border border-brand-bubble/40 bg-white/75 p-5 shadow-sm"
-              >
-                <div className="grid gap-4 md:grid-cols-2">
-                  <div className="space-y-2">
-                    <label className={labelClass} htmlFor={`dog-name-${index}`}>
-                      Name
-                    </label>
-                    <input
-                      id={`dog-name-${index}`}
-                      type="text"
-                      className={textInputClass}
-                      value={dog.name}
-                      onChange={(event) => updateDog(index, { name: event.target.value })}
-                      placeholder="Charlie"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <label className={labelClass} htmlFor={`dog-breed-${index}`}>
-                      Breed
-                    </label>
-                    <input
-                      id={`dog-breed-${index}`}
-                      type="text"
-                      className={textInputClass}
-                      value={dog.breed}
-                      onChange={(event) => updateDog(index, { breed: event.target.value })}
-                      placeholder="Golden Retriever"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <span className={labelClass}>Gender</span>
-                    <div className="flex items-center gap-6 rounded-xl border border-white/50 bg-white/70 px-4 py-3">
-                      <label className="flex items-center gap-2 text-sm text-brand-navy">
-                        <input
-                          type="radio"
-                          name={`dog-gender-${index}`}
-                          value="male"
-                          checked={dog.gender === 'male'}
-                          onChange={() => updateDog(index, { gender: 'male' })}
-                          className="h-4 w-4 border-brand-bubble text-primary focus:ring-brand-bubble"
-                        />
-                        Male
+            <div className="space-y-4">
+              {dogs.map((dog, index) => (
+                <div
+                  key={index}
+                  className="space-y-4 rounded-2xl border border-brand-bubble/40 bg-white/75 p-4 shadow-sm lg:p-5"
+                >
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <div className="space-y-1.5">
+                      <label className={labelClass} htmlFor={`dog-name-${index}`}>
+                        Name
                       </label>
-                      <label className="flex items-center gap-2 text-sm text-brand-navy">
-                        <input
-                          type="radio"
-                          name={`dog-gender-${index}`}
-                          value="female"
-                          checked={dog.gender === 'female'}
-                          onChange={() => updateDog(index, { gender: 'female' })}
-                          className="h-4 w-4 border-brand-bubble text-primary focus:ring-brand-bubble"
-                        />
-                        Female
+                      <input
+                        id={`dog-name-${index}`}
+                        type="text"
+                        className={textInputClass}
+                        value={dog.name}
+                        onChange={(event) => updateDog(index, { name: event.target.value })}
+                        placeholder="Charlie"
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <label className={labelClass} htmlFor={`dog-breed-${index}`}>
+                        Breed
                       </label>
+                      <input
+                        id={`dog-breed-${index}`}
+                        type="text"
+                        className={textInputClass}
+                        value={dog.breed}
+                        onChange={(event) => updateDog(index, { breed: event.target.value })}
+                        placeholder="Golden Retriever"
+                      />
                     </div>
                   </div>
-                  <div className="space-y-2">
-                    <label className={labelClass} htmlFor={`dog-age-${index}`}>
-                      Age
-                    </label>
-                    <input
-                      id={`dog-age-${index}`}
-                      type="text"
-                      className={textInputClass}
-                      value={dog.age}
-                      onChange={(event) => updateDog(index, { age: event.target.value })}
-                      placeholder="2 years"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <label className={labelClass} htmlFor={`dog-weight-${index}`}>
-                      Weight
-                    </label>
-                    <input
-                      id={`dog-weight-${index}`}
-                      type="text"
-                      className={textInputClass}
-                      value={dog.weight}
-                      onChange={(event) => updateDog(index, { weight: event.target.value })}
-                      placeholder="45 lbs"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <label className={labelClass} htmlFor={`dog-hair-${index}`}>
-                      Coat / hair type
-                    </label>
-                    <input
-                      id={`dog-hair-${index}`}
-                      type="text"
-                      className={textInputClass}
-                      value={dog.hairType}
-                      onChange={(event) => updateDog(index, { hairType: event.target.value })}
-                      placeholder="Short double coat"
-                    />
-                  </div>
-                </div>
 
-                <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-                  <label className="flex items-center gap-2 text-sm font-semibold text-brand-navy">
-                    <input
-                      type="checkbox"
-                      checked={dog.neutered}
-                      onChange={(event) => updateDog(index, { neutered: event.target.checked })}
-                      className="h-4 w-4 rounded border-brand-bubble text-primary focus:ring-brand-bubble"
-                    />
-                    Neutered / spayed
-                  </label>
-                  <div className="space-y-2 md:w-1/2">
+                  <div className="flex flex-wrap items-center gap-4 rounded-xl border border-white/50 bg-white/70 px-3 py-2">
+                    <span className="text-sm font-semibold text-brand-navy">Gender:</span>
+                    <label className="flex items-center gap-2 text-sm text-brand-navy">
+                      <input
+                        type="radio"
+                        name={`dog-gender-${index}`}
+                        value="male"
+                        checked={dog.gender === 'male'}
+                        onChange={() => updateDog(index, { gender: 'male' })}
+                        className="h-4 w-4 border-brand-bubble text-primary focus:ring-brand-bubble"
+                      />
+                      Male
+                    </label>
+                    <label className="flex items-center gap-2 text-sm text-brand-navy">
+                      <input
+                        type="radio"
+                        name={`dog-gender-${index}`}
+                        value="female"
+                        checked={dog.gender === 'female'}
+                        onChange={() => updateDog(index, { gender: 'female' })}
+                        className="h-4 w-4 border-brand-bubble text-primary focus:ring-brand-bubble"
+                      />
+                      Female
+                    </label>
+                    <label className="flex items-center gap-2 text-sm text-brand-navy">
+                      <input
+                        type="checkbox"
+                        checked={dog.neutered}
+                        onChange={(event) => updateDog(index, { neutered: event.target.checked })}
+                        className="h-4 w-4 rounded border-brand-bubble text-primary focus:ring-brand-bubble"
+                      />
+                      Spayed / neutered
+                    </label>
+                  </div>
+
+                  <div className="grid gap-3 md:grid-cols-3">
+                    <div className="space-y-1.5">
+                      <label className={labelClass} htmlFor={`dog-age-${index}`}>
+                        Age
+                      </label>
+                      <input
+                        id={`dog-age-${index}`}
+                        type="text"
+                        className={textInputClass}
+                        value={dog.age}
+                        onChange={(event) => updateDog(index, { age: event.target.value })}
+                        placeholder="2 years"
+                        required={hasDogData(dog)}
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <label className={labelClass} htmlFor={`dog-weight-${index}`}>
+                        Weight
+                      </label>
+                      <input
+                        id={`dog-weight-${index}`}
+                        type="text"
+                        className={textInputClass}
+                        value={dog.weight}
+                        onChange={(event) => updateDog(index, { weight: event.target.value })}
+                        placeholder="45 lbs"
+                        required={hasDogData(dog)}
+                      />
+                    </div>
+                    <div className="space-y-1.5">
+                      <label className={labelClass} htmlFor={`dog-hair-${index}`}>
+                        Coat / hair type
+                      </label>
+                      <select
+                        id={`dog-hair-${index}`}
+                        className={textInputClass}
+                        value={dog.hairType}
+                        onChange={(event) => updateDog(index, { hairType: event.target.value })}
+                        required={hasDogData(dog)}
+                      >
+                        {hairTypeOptions.map((option) => (
+                          <option key={option.value} value={option.value}>
+                            {option.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+
+                  <div className="space-y-1.5">
                     <label className={labelClass} htmlFor={`dog-photo-${index}`}>
                       Photo <span className="font-normal text-brand-navy/60">(optional)</span>
                     </label>
@@ -444,41 +455,41 @@ export default function NewClientPage() {
                       className="block w-full text-sm text-brand-navy file:mr-4 file:rounded-full file:border-0 file:bg-brand-bubble file:px-4 file:py-2 file:text-sm file:font-semibold file:text-white hover:file:bg-primary"
                     />
                   </div>
-                </div>
 
-                <div className="space-y-2">
-                  <label className={labelClass} htmlFor={`dog-medical-${index}`}>
-                    Medical notes / allergies <span className="font-normal text-brand-navy/60">(optional)</span>
-                  </label>
-                  <textarea
-                    id={`dog-medical-${index}`}
-                    className={textAreaClass}
-                    value={dog.medical}
-                    onChange={(event) => updateDog(index, { medical: event.target.value })}
-                    placeholder="Allergies, meds, behavioral notes"
-                  />
+                  <div className="space-y-1.5">
+                    <label className={labelClass} htmlFor={`dog-medical-${index}`}>
+                      Medical notes / allergies <span className="font-normal text-brand-navy/60">(optional)</span>
+                    </label>
+                    <textarea
+                      id={`dog-medical-${index}`}
+                      className={textAreaClass}
+                      value={dog.medical}
+                      onChange={(event) => updateDog(index, { medical: event.target.value })}
+                      placeholder="Allergies, meds, behavioral notes"
+                    />
+                  </div>
                 </div>
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
 
-          <button
-            type="button"
-            onClick={addDog}
-            className="inline-flex items-center justify-center gap-2 rounded-xl border border-dashed border-brand-bubble/60 bg-brand-bubble/10 px-4 py-2 text-sm font-semibold text-brand-bubble transition hover:bg-brand-bubble/15 focus:outline-none focus:ring-2 focus:ring-brand-bubble/40"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-              className="h-4 w-4"
-              aria-hidden="true"
+            <button
+              type="button"
+              onClick={addDog}
+              className="inline-flex items-center justify-center gap-2 self-start rounded-lg border border-dashed border-brand-bubble/60 bg-brand-bubble/10 px-3 py-2 text-sm font-semibold text-brand-bubble transition hover:bg-brand-bubble/15 focus:outline-none focus:ring-2 focus:ring-brand-bubble/40"
             >
-              <path d="M10 3a.75.75 0 0 1 .75.75V9.25h5.5a.75.75 0 0 1 0 1.5h-5.5v5.5a.75.75 0 0 1-1.5 0v-5.5H3.25a.75.75 0 0 1 0-1.5h5.5V3.75A.75.75 0 0 1 10 3Z" />
-            </svg>
-            Add another dog
-          </button>
-        </Card>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                className="h-4 w-4"
+                aria-hidden="true"
+              >
+                <path d="M10 3a.75.75 0 0 1 .75.75V9.25h5.5a.75.75 0 0 1 0 1.5h-5.5v5.5a.75.75 0 0 1-1.5 0v-5.5H3.25a.75.75 0 0 1 0-1.5h5.5V3.75A.75.75 0 0 1 10 3Z" />
+              </svg>
+              Add another dog
+            </button>
+          </Card>
+        </div>
 
         <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
           <Link


### PR DESCRIPTION
## Summary
- remove the owner address input so the client section feels lighter
- require age, weight, and coat details for any dog that gets added, using a dropdown list for coat type
- place the spayed/neutered checkbox with the gender radios and update the helper copy accordingly

## Testing
- npm run lint
- CI=1 npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d382152bd883249412e2d495ef1dd8