### PR TITLE
Refactor dashboard pages to render on the server

### DIFF
--- a/app/clients/page.tsx
+++ b/app/clients/page.tsx
@@ -1,10 +1,8 @@
-'use client';
+import Link from 'next/link';
 
 import Card from '@/components/Card';
 import PageContainer from '@/components/PageContainer';
-import { supabase } from '@/lib/supabase/client';
-import Link from 'next/link';
-import { useEffect, useState } from 'react';
+import { createClient } from '@/lib/supabase/server';
 
 type Client = {
   id: number;
@@ -15,37 +13,34 @@ type Client = {
   created_at: string;
 };
 
+export const dynamic = 'force-dynamic';
 
-export default function ClientsPage() {
-  const [rows, setRows] = useState<Client[]>([]);
-  const [q, setQ] = useState('');
-  const [err, setErr] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  async function load() {
-    setLoading(true);
-    setErr(null);
+type ClientsPageProps = {
+  searchParams?: Record<string, string | string[] | undefined>;
+};
 
-    let query = supabase
-      .from('clients_with_pets')
-      .select('id, full_name, email, phone, pet_names, created_at')
-      .order('created_at', { ascending: false })
-      .limit(200);
+export default async function ClientsPage({ searchParams }: ClientsPageProps) {
+  const supabase = createClient();
+  const rawQuery = searchParams?.q;
+  const query = Array.isArray(rawQuery) ? rawQuery[0] ?? '' : rawQuery ?? '';
+  const trimmedQuery = query.trim();
 
-    if (q.trim()) {
-      const pat = `%${q.trim()}%`;
-      query = query.or(
-        `full_name.ilike.${pat},email.ilike.${pat},phone.ilike.${pat},pet_names.ilike.${pat}`
-      );
-    }
+  let request = supabase
+    .from('clients_with_pets')
+    .select('id, full_name, email, phone, pet_names, created_at')
+    .order('created_at', { ascending: false })
+    .limit(200);
 
-    const { data, error } = await query;
-    if (error) setErr(error.message); else setRows(data ?? []);
-    setLoading(false);
+  if (trimmedQuery) {
+    const pattern = `%${trimmedQuery}%`;
+    request = request.or(
+      `full_name.ilike.${pattern},email.ilike.${pattern},phone.ilike.${pattern},pet_names.ilike.${pattern}`
+    );
   }
 
-  // We only need the initial fetch when the page mounts.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => { load(); }, []);
+  const { data, error } = await request;
+  const rows = (data ?? []) as Client[];
+  const err = error?.message ?? null;
 
   return (
     <PageContainer className="space-y-8">
@@ -66,18 +61,12 @@ export default function ClientsPage() {
             </svg>
             New Client
           </Link>
-          <form
-            onSubmit={(event) => {
-              event.preventDefault();
-              load();
-            }}
-            className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end"
-          >
+          <form method="get" className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
             <div className="relative w-full sm:w-72">
               <input
                 placeholder="Search name, email, phone, or pet"
-                value={q}
-                onChange={(e) => setQ(e.target.value)}
+                name="q"
+                defaultValue={query}
                 className="h-12 w-full rounded-xl border border-white/50 bg-white/90 px-4 pr-12 text-base text-brand-navy shadow-inner transition focus:border-brand-bubble focus:outline-none focus:ring-2 focus:ring-brand-bubble/30"
               />
               <div className="pointer-events-none absolute inset-y-0 right-4 flex items-center text-brand-navy/40">
@@ -106,77 +95,61 @@ export default function ClientsPage() {
           </div>
         )}
 
-        <div className="space-y-4">
-          {loading ? (
-            Array.from({ length: 3 }).map((_, index) => (
-              <div
-                key={index}
-                className="relative overflow-hidden rounded-2xl border border-white/40 bg-white/70 p-5"
-              >
-                <div className="h-5 w-1/3 animate-pulse rounded-full bg-brand-bubble/20" />
-                <div className="mt-3 h-4 w-1/2 animate-pulse rounded-full bg-brand-bubble/10" />
+        {!err && (
+          <div className="space-y-4">
+            {rows.length === 0 ? (
+              <div className="rounded-2xl border border-dashed border-brand-bubble/40 bg-white/70 px-6 py-12 text-center text-sm text-brand-navy/70">
+                No clients found.
               </div>
-            ))
-          ) : rows.length === 0 ? (
-            <div className="rounded-2xl border border-dashed border-brand-bubble/40 bg-white/70 px-6 py-12 text-center text-sm text-brand-navy/70">
-              No clients found.
-            </div>
-          ) : (
-            rows.map((r) => {
-              const petLabel = r.pet_names?.trim() ? r.pet_names : 'No pets on file';
-              return (
-                <Link
-                  key={r.id}
-                  href={`/clients/${r.id}`}
-                  className="group relative block overflow-hidden rounded-2xl border border-brand-bubble/40 bg-gradient-to-r from-white/95 via-white/90 to-brand-bubble/10 px-5 py-4 shadow-soft transition duration-200 hover:-translate-y-0.5 hover:shadow-xl"
-                >
-                  <span className="pointer-events-none absolute inset-y-3 left-3 w-1 rounded-full bg-gradient-to-b from-brand-bubble via-brand-bubble/80 to-brand-lavender opacity-80 transition-all duration-200 group-hover:inset-y-2 group-hover:w-1.5" />
-                  <div className="relative flex flex-col gap-3 pl-6 sm:flex-row sm:items-center sm:justify-between">
-                    <div className="flex flex-col gap-1">
-                      <h2 className="text-base font-semibold text-brand-navy transition-colors group-hover:text-primary-dark">
-                        {r.full_name ?? 'Unnamed client'}
-                      </h2>
-                      <span className="inline-flex items-center gap-2 self-start rounded-full bg-brand-bubble/15 px-3 py-1 text-xs font-medium text-brand-bubble">
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          fill="none"
-                          viewBox="0 0 24 24"
-                          strokeWidth="1.5"
-                          stroke="currentColor"
-                          className="h-4 w-4"
-                          aria-hidden="true"
-                        >
-                          <path
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733C11.285 4.876 9.623 3.75 7.688 3.75 5.099 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z"
-                          />
-                        </svg>
-                        {petLabel}
-                      </span>
+            ) : (
+              rows.map((r) => {
+                const petLabel = r.pet_names?.trim() ? r.pet_names : 'No pets on file';
+                return (
+                  <Link
+                    key={r.id}
+                    href={`/clients/${r.id}`}
+                    className="group relative block overflow-hidden rounded-2xl border border-brand-bubble/40 bg-gradient-to-r from-white/95 via-white/90 to-brand-bubble/10 px-5 py-4 shadow-soft transition duration-200 hover:-translate-y-0.5 hover:shadow-xl"
+                  >
+                    <span className="pointer-events-none absolute inset-y-3 left-3 w-1 rounded-full bg-gradient-to-b from-brand-bubble via-brand-bubble/80 to-brand-lavender opacity-80 transition-all duration-200 group-hover:inset-y-2 group-hover:w-1.5" />
+                    <div className="relative flex flex-col gap-3 pl-6 sm:flex-row sm:items-center sm:justify-between">
+                      <div className="flex flex-col gap-1">
+                        <h2 className="text-base font-semibold text-brand-navy transition-colors group-hover:text-primary-dark">
+                          {r.full_name ?? 'Unnamed client'}
+                        </h2>
+                        <span className="inline-flex items-center gap-2 self-start rounded-full bg-brand-bubble/15 px-3 py-1 text-xs font-medium text-brand-bubble">
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            strokeWidth="1.5"
+                            stroke="currentColor"
+                            className="h-4 w-4"
+                            aria-hidden="true"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733C11.285 4.876 9.623 3.75 7.688 3.75 5.099 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z"
+                            />
+                          </svg>
+                          {petLabel}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-2 text-sm font-semibold text-primary">
+                        <span className="hidden text-xs uppercase tracking-wide text-brand-navy/60 transition-colors group-hover:text-primary sm:inline">
+                          View profile
+                        </span>
+                        <span className="flex h-9 w-9 items-center justify-center rounded-full bg-brand-bubble text-white shadow-inner transition-transform duration-200 group-hover:scale-105">
+                          →
+                        </span>
+                      </div>
                     </div>
-                    <div className="flex items-center gap-2 text-sm font-semibold text-primary">
-                      <span className="hidden text-xs uppercase tracking-wide text-brand-navy/60 transition-colors group-hover:text-primary sm:inline">
-                        View profile
-                      </span>
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        fill="none"
-                        viewBox="0 0 24 24"
-                        strokeWidth="1.5"
-                        stroke="currentColor"
-                        className="h-5 w-5 text-primary transition-transform duration-200 group-hover:translate-x-1"
-                        aria-hidden="true"
-                      >
-                        <path strokeLinecap="round" strokeLinejoin="round" d="m9 5 7 7-7 7" />
-                      </svg>
-                    </div>
-                  </div>
-                </Link>
-              );
-            })
-          )}
-        </div>
+                  </Link>
+                );
+              })
+            )}
+          </div>
+        )}
       </Card>
     </PageContainer>
   );

--- a/app/messages/page.tsx
+++ b/app/messages/page.tsx
@@ -1,49 +1,47 @@
-"use client";
-import PageContainer from "@/components/PageContainer";
-import Card from "@/components/Card";
-import { useEffect, useState } from "react";
-import { supabase } from "@/lib/supabase/client";
+import Card from '@/components/Card';
+import PageContainer from '@/components/PageContainer';
+import { createClient } from '@/lib/supabase/server';
 
-// Message record type.  Adjust fields to match your Supabase schema.
-interface Msg {
+type Msg = {
   id: string;
   to_employee: string | null;
   from_name: string | null;
   body: string | null;
   created_at: string;
-}
+};
 
-/**
- * Messages page lists recent messages from the `messages` table.  This
- * could later be expanded to allow replying or filtering by employee.
- */
-export default function MessagesPage() {
-  const [rows, setRows] = useState<Msg[]>([]);
+export const dynamic = 'force-dynamic';
 
-  useEffect(() => {
-    supabase
-      .from("messages")
-      .select("id, to_employee, from_name, body, created_at")
-      .order("created_at", { ascending: false })
-      .then(({ data }) => {
-        setRows((data || []) as Msg[]);
-      });
-  }, []);
+export default async function MessagesPage() {
+  const supabase = createClient();
+  const { data, error } = await supabase
+    .from('messages')
+    .select('id, to_employee, from_name, body, created_at')
+    .order('created_at', { ascending: false });
+
+  const rows = (data ?? []) as Msg[];
+  const err = error?.message ?? null;
 
   return (
     <PageContainer>
       <Card>
         <h1 className="mb-4 text-3xl font-bold text-primary-dark">Messages</h1>
-        <ul className="divide-y">
-          {rows.map((m) => (
-            <li key={m.id} className="py-3">
-              <div className="text-sm text-gray-500">
-                {new Date(m.created_at).toLocaleString()} — To {m.to_employee || "—"} from {m.from_name || "—"}
-              </div>
-              <div>{m.body}</div>
-            </li>
-          ))}
-        </ul>
+        {err ? (
+          <div className="rounded-2xl border border-red-300/40 bg-red-100/40 px-4 py-3 text-sm text-red-700">
+            Failed to load messages: {err}
+          </div>
+        ) : (
+          <ul className="divide-y">
+            {rows.map((m) => (
+              <li key={m.id} className="py-3">
+                <div className="text-sm text-gray-500">
+                  {new Date(m.created_at).toLocaleString()} — To {m.to_employee || '—'} from {m.from_name || '—'}
+                </div>
+                <div>{m.body}</div>
+              </li>
+            ))}
+          </ul>
+        )}
       </Card>
     </PageContainer>
   );

--- a/app/reports/RangeSelect.tsx
+++ b/app/reports/RangeSelect.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useTransition } from 'react';
+
+import { RANGE_LABELS, RANGE_OPTIONS, type RangeOption } from './range';
+
+type RangeSelectProps = {
+  id?: string;
+  value: RangeOption;
+  className?: string;
+};
+
+export default function RangeSelect({ id, value, className = '' }: RangeSelectProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
+
+  return (
+    <select
+      id={id}
+      value={value}
+      onChange={(event) => {
+        const next = event.target.value as RangeOption;
+        const params = new URLSearchParams(searchParams.toString());
+        if (next === 'today') {
+          params.delete('range');
+        } else {
+          params.set('range', next);
+        }
+        const query = params.toString();
+        startTransition(() => {
+          router.replace(query ? `/reports?${query}` : '/reports');
+        });
+      }}
+      disabled={isPending}
+      className={`rounded-full border border-gray-300 px-3 py-2 ${className}`}
+    >
+      {RANGE_OPTIONS.map((option) => (
+        <option key={option} value={option}>
+          {RANGE_LABELS[option]}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/app/reports/page.tsx
+++ b/app/reports/page.tsx
@@ -1,14 +1,11 @@
-"use client";
-import PageContainer from "@/components/PageContainer";
-import Card from "@/components/Card";
-import { useEffect, useState } from "react";
-import { supabase } from "@/lib/supabase/client";
+import Card from '@/components/Card';
+import PageContainer from '@/components/PageContainer';
+import { createClient } from '@/lib/supabase/server';
 
-// Supported date ranges for the reports page
-type RangeOption = "today" | "week" | "month" | "year" | "all";
+import RangeSelect from './RangeSelect';
+import { parseRangeParam, type RangeOption } from './range';
 
-// Data structure for counts and metrics
-interface Counts {
+type Counts = {
   clients: number;
   newClients: number;
   pets: number;
@@ -22,171 +19,41 @@ interface Counts {
   expectedRevenue: number;
   sales: number;
   topServices: [string, number][];
-}
+};
 
-// Helper to calculate start and end dates for a given range relative to now
-function getRangeDates(range: RangeOption): { start?: Date; end?: Date } {
-  const now = new Date();
-  const start = new Date(now);
-  const end = new Date(now);
-  switch (range) {
-    case "today":
-      start.setHours(0, 0, 0, 0);
-      end.setHours(24, 0, 0, 0);
-      return { start, end };
-    case "week": {
-      // start of week (Sunday)
-      const day = now.getDay();
-      start.setDate(now.getDate() - day);
-      start.setHours(0, 0, 0, 0);
-      end.setDate(start.getDate() + 7);
-      end.setHours(0, 0, 0, 0);
-      return { start, end };
-    }
-    case "month": {
-      start.setDate(1);
-      start.setHours(0, 0, 0, 0);
-      end.setMonth(start.getMonth() + 1, 1);
-      end.setHours(0, 0, 0, 0);
-      return { start, end };
-    }
-    case "year": {
-      start.setMonth(0, 1);
-      start.setHours(0, 0, 0, 0);
-      end.setFullYear(start.getFullYear() + 1, 0, 1);
-      end.setHours(0, 0, 0, 0);
-      return { start, end };
-    }
-    case "all":
-    default:
-      return {};
+type ReportsPageProps = {
+  searchParams?: Record<string, string | string[] | undefined>;
+};
+
+export const dynamic = 'force-dynamic';
+
+export default async function ReportsPage({ searchParams }: ReportsPageProps) {
+  const range = parseRangeParam(searchParams?.range);
+
+  let counts: Counts | null = null;
+  let errorMessage: string | null = null;
+
+  try {
+    counts = await loadCounts(range);
+  } catch (error) {
+    errorMessage = error instanceof Error ? error.message : 'Unable to load reports';
   }
-}
-
-export default function ReportsPage() {
-  const [range, setRange] = useState<RangeOption>("today");
-  const [counts, setCounts] = useState<Counts>({
-    clients: 0,
-    newClients: 0,
-    pets: 0,
-    newPets: 0,
-    employees: 0,
-    appointments: 0,
-    completed: 0,
-    canceled: 0,
-    noShow: 0,
-    revenue: 0,
-    expectedRevenue: 0,
-    sales: 0,
-    topServices: [],
-  });
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    const fetchData = async () => {
-      setLoading(true);
-      const { start, end } = getRangeDates(range);
-
-      // Build queries for counts
-      const clientsQuery = supabase.from("clients").select("id", { count: "exact", head: true });
-      const petsQuery = supabase.from("pets").select("id", { count: "exact", head: true });
-      const employeesQuery = supabase.from("employees").select("id", { count: "exact", head: true });
-      const apptCountQuery = supabase.from("appointments").select("id", { count: "exact", head: true });
-
-      // Filtered queries for new clients and pets
-      const newClientsQuery = start && end
-        ? supabase.from("clients").select("id", { count: "exact", head: true }).gte("created_at", start.toISOString()).lt("created_at", end.toISOString())
-        : supabase.from("clients").select("id", { count: "exact", head: true });
-      const newPetsQuery = start && end
-        ? supabase.from("pets").select("id", { count: "exact", head: true }).gte("created_at", start.toISOString()).lt("created_at", end.toISOString())
-        : supabase.from("pets").select("id", { count: "exact", head: true });
-
-      // Payments query for sales
-      let paymentsQuery = supabase.from("payments").select("amount");
-      if (start && end) {
-        paymentsQuery = paymentsQuery.gte("created_at", start.toISOString()).lt("created_at", end.toISOString());
-      }
-
-      // Appointments details for the selected range
-      let apptDetailQuery = supabase.from("appointments").select("service, status, price");
-      if (start && end) {
-        apptDetailQuery = apptDetailQuery.gte("start_time", start.toISOString()).lt("start_time", end.toISOString());
-      }
-
-      const [clientsRes, petsRes, employeesRes, apptCountRes, newClientsRes, newPetsRes, apptDetailRes, paymentsRes] = await Promise.all([
-        clientsQuery,
-        petsQuery,
-        employeesQuery,
-        apptCountQuery,
-        newClientsQuery,
-        newPetsQuery,
-        apptDetailQuery,
-        paymentsQuery,
-      ]);
-
-      // Process appointment details
-      const appts = (apptDetailRes.data || []) as any[];
-      const completed = appts.filter((a) => a.status === "Completed").length;
-      const canceled = appts.filter((a) => a.status === "Cancelled").length;
-      // Count no-shows
-      const noShow = appts.filter((a) => a.status === "No show" || a.status === "No-show").length;
-      const revenue = appts.reduce((sum, a) => sum + (a.status === "Completed" ? Number(a.price || 0) : 0), 0);
-      // Expected revenue: sum of all appointment prices regardless of status
-      const expectedRevenue = appts.reduce((sum, a) => sum + (a.price ? Number(a.price) : 0), 0);
-      // Sales: sum of payments amounts in range
-      const payments = (paymentsRes.data || []) as any[];
-      const sales = payments.reduce((s, p) => s + Number(p.amount || 0), 0);
-      const serviceCounts: Record<string, number> = {};
-      appts.forEach((a) => {
-        const service = a.service || "Other";
-        serviceCounts[service] = (serviceCounts[service] || 0) + 1;
-      });
-      const topServices = Object.entries(serviceCounts)
-        .sort((a, b) => b[1] - a[1])
-        .slice(0, 3) as [string, number][];
-
-      setCounts({
-        clients: clientsRes.count || 0,
-        newClients: newClientsRes.count || 0,
-        pets: petsRes.count || 0,
-        newPets: newPetsRes.count || 0,
-        employees: employeesRes.count || 0,
-        appointments: apptCountRes.count || 0,
-        completed,
-        canceled,
-        noShow,
-        revenue,
-        expectedRevenue,
-        sales,
-        topServices,
-      });
-      setLoading(false);
-    };
-    fetchData();
-  }, [range]);
 
   return (
     <PageContainer>
       <Card>
         <h1 className="mb-4 text-3xl font-bold text-primary-dark">Reports</h1>
-        <div className="mb-4">
-          <label htmlFor="range" className="mr-2 font-medium">Date range:</label>
-          <select
-            id="range"
-            value={range}
-            onChange={(e) => setRange(e.target.value as RangeOption)}
-            className="rounded-full border border-gray-300 px-3 py-2"
-          >
-            <option value="today">Today</option>
-            <option value="week">This Week</option>
-            <option value="month">This Month</option>
-            <option value="year">This Year</option>
-            <option value="all">All Time</option>
-          </select>
+        <div className="mb-4 flex flex-col gap-2 sm:flex-row sm:items-center">
+          <label htmlFor="range" className="font-medium">
+            Date range:
+          </label>
+          <RangeSelect id="range" value={range} className="sm:w-48" />
         </div>
-        {loading ? (
-          <p>Loading…</p>
-        ) : (
+        {errorMessage ? (
+          <div className="rounded-2xl border border-red-300/40 bg-red-100/40 px-4 py-3 text-sm text-red-700">
+            Failed to load reports: {errorMessage}
+          </div>
+        ) : counts ? (
           <div className="space-y-6">
             <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
               <ReportCard title="Total Clients" value={counts.clients} />
@@ -218,10 +85,156 @@ export default function ReportsPage() {
               )}
             </Card>
           </div>
-        )}
+        ) : null}
       </Card>
     </PageContainer>
   );
+}
+
+type AppointmentRow = {
+  service: string | null;
+  status: string | null;
+  price: number | string | null;
+};
+
+type PaymentRow = {
+  amount: number | string | null;
+};
+
+async function loadCounts(range: RangeOption): Promise<Counts> {
+  const supabase = createClient();
+  const { start, end } = getRangeDates(range);
+
+  const clientsQuery = supabase.from('clients').select('id', { count: 'exact', head: true });
+  const petsQuery = supabase.from('pets').select('id', { count: 'exact', head: true });
+  const employeesQuery = supabase.from('employees').select('id', { count: 'exact', head: true });
+  const apptCountQuery = supabase.from('appointments').select('id', { count: 'exact', head: true });
+
+  let newClientsQuery = supabase.from('clients').select('id', { count: 'exact', head: true });
+  let newPetsQuery = supabase.from('pets').select('id', { count: 'exact', head: true });
+  let paymentsQuery = supabase.from('payments').select('amount');
+  let apptDetailQuery = supabase.from('appointments').select('service, status, price');
+
+  if (start && end) {
+    const startISO = start.toISOString();
+    const endISO = end.toISOString();
+    newClientsQuery = newClientsQuery.gte('created_at', startISO).lt('created_at', endISO);
+    newPetsQuery = newPetsQuery.gte('created_at', startISO).lt('created_at', endISO);
+    paymentsQuery = paymentsQuery.gte('created_at', startISO).lt('created_at', endISO);
+    apptDetailQuery = apptDetailQuery.gte('start_time', startISO).lt('start_time', endISO);
+  }
+
+  const [
+    clientsRes,
+    petsRes,
+    employeesRes,
+    apptCountRes,
+    newClientsRes,
+    newPetsRes,
+    apptDetailRes,
+    paymentsRes,
+  ] = await Promise.all([
+    clientsQuery,
+    petsQuery,
+    employeesQuery,
+    apptCountQuery,
+    newClientsQuery,
+    newPetsQuery,
+    apptDetailQuery,
+    paymentsQuery,
+  ]);
+
+  const errors = [
+    clientsRes.error,
+    petsRes.error,
+    employeesRes.error,
+    apptCountRes.error,
+    newClientsRes.error,
+    newPetsRes.error,
+    apptDetailRes.error,
+    paymentsRes.error,
+  ].filter(Boolean);
+
+  if (errors.length > 0) {
+    throw new Error(errors[0]!.message);
+  }
+
+  const appts = (apptDetailRes.data ?? []) as AppointmentRow[];
+  const payments = (paymentsRes.data ?? []) as PaymentRow[];
+
+  const completed = appts.filter((a) => a.status === 'Completed').length;
+  const canceled = appts.filter((a) => a.status === 'Cancelled').length;
+  const noShow = appts.filter((a) => a.status === 'No show' || a.status === 'No-show').length;
+  const revenue = appts.reduce(
+    (sum, a) => sum + (a.status === 'Completed' ? Number(a.price || 0) : 0),
+    0
+  );
+  const expectedRevenue = appts.reduce((sum, a) => sum + Number(a.price || 0), 0);
+  const sales = payments.reduce((sum, p) => sum + Number(p.amount || 0), 0);
+
+  const serviceCounts: Record<string, number> = {};
+  appts.forEach((a) => {
+    const service = a.service || 'Other';
+    serviceCounts[service] = (serviceCounts[service] || 0) + 1;
+  });
+
+  const topServices = Object.entries(serviceCounts)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3) as [string, number][];
+
+  return {
+    clients: clientsRes.count ?? 0,
+    newClients: newClientsRes.count ?? 0,
+    pets: petsRes.count ?? 0,
+    newPets: newPetsRes.count ?? 0,
+    employees: employeesRes.count ?? 0,
+    appointments: apptCountRes.count ?? 0,
+    completed,
+    canceled,
+    noShow,
+    revenue,
+    expectedRevenue,
+    sales,
+    topServices,
+  };
+}
+
+function getRangeDates(range: RangeOption): { start?: Date; end?: Date } {
+  const now = new Date();
+  const start = new Date(now);
+  const end = new Date(now);
+
+  switch (range) {
+    case 'today':
+      start.setHours(0, 0, 0, 0);
+      end.setHours(24, 0, 0, 0);
+      return { start, end };
+    case 'week': {
+      const day = now.getDay();
+      start.setDate(now.getDate() - day);
+      start.setHours(0, 0, 0, 0);
+      end.setDate(start.getDate() + 7);
+      end.setHours(0, 0, 0, 0);
+      return { start, end };
+    }
+    case 'month': {
+      start.setDate(1);
+      start.setHours(0, 0, 0, 0);
+      end.setMonth(start.getMonth() + 1, 1);
+      end.setHours(0, 0, 0, 0);
+      return { start, end };
+    }
+    case 'year': {
+      start.setMonth(0, 1);
+      start.setHours(0, 0, 0, 0);
+      end.setFullYear(start.getFullYear() + 1, 0, 1);
+      end.setHours(0, 0, 0, 0);
+      return { start, end };
+    }
+    case 'all':
+    default:
+      return {};
+  }
 }
 
 function ReportCard({ title, value }: { title: string; value: string | number }) {

--- a/app/reports/range.ts
+++ b/app/reports/range.ts
@@ -1,0 +1,18 @@
+export const RANGE_OPTIONS = ['today', 'week', 'month', 'year', 'all'] as const;
+
+export type RangeOption = (typeof RANGE_OPTIONS)[number];
+
+export const RANGE_LABELS: Record<RangeOption, string> = {
+  today: 'Today',
+  week: 'This Week',
+  month: 'This Month',
+  year: 'This Year',
+  all: 'All Time',
+};
+
+export function parseRangeParam(value: string | string[] | undefined): RangeOption {
+  if (!value) return 'today';
+  const first = Array.isArray(value) ? value[0] : value;
+  if (!first) return 'today';
+  return RANGE_OPTIONS.includes(first as RangeOption) ? (first as RangeOption) : 'today';
+}


### PR DESCRIPTION
## Summary
- refactor the clients, reports, and messages dashboard pages into server components that query Supabase on the server
- add a reusable range helper and small client-side range selector to keep reports filtering interactive while reducing bundle size
- surface friendly empty and error states directly from the server-rendered markup

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d3b485443c8324a82867b9bb1ce8c9