### PR TITLE
Move dashboard widgets to server-side data fetching

### DIFF
--- a/components/dashboard/EmployeeWorkload.tsx
+++ b/components/dashboard/EmployeeWorkload.tsx
@@ -1,56 +1,52 @@
-"use client";
-import { useEffect, useState } from 'react'
-import { supabase } from '@/lib/supabase/client'
+import { createClient } from '@/lib/supabase/server'
+
+interface AppointmentRow {
+  groomer_name: string | null
+  status: string | null
+  start_time: string | null
+}
 
 interface Workload {
   employee_name: string
   count: number
 }
 
-export default function EmployeeWorkload() {
-  const [workloads, setWorkloads] = useState<Workload[]>([])
-  const [loading, setLoading] = useState(true)
+function buildWorkloads(rows: AppointmentRow[] | null | undefined): Workload[] {
+  if (!rows?.length) return []
 
-  useEffect(() => {
-    const fetchWorkloads = async () => {
-      const now = new Date()
-      const startOfDay = new Date(now)
-      startOfDay.setHours(0, 0, 0, 0)
-      const endOfDay = new Date(now)
-      endOfDay.setHours(23, 59, 59, 999)
+  const counts: Record<string, number> = {}
+  for (const row of rows) {
+    const name = row.groomer_name?.trim() || 'Unassigned'
+    counts[name] = (counts[name] ?? 0) + 1
+  }
 
-      // Only fetch the appointments that could still be "active" today so we avoid
-      // loading the entire historical appointments table (which had started to slow
-      // the dashboard down as more records were added).
-      const { data, error } = await supabase
-        .from('appointments')
-        .select('groomer_name, status, start_time')
-        .in('status', ['Checked In', 'In Progress'])
-        .gte('start_time', startOfDay.toISOString())
-        .lte('start_time', endOfDay.toISOString())
+  return Object.entries(counts).map(([employee_name, count]) => ({ employee_name, count }))
+}
 
-      if (!error && data) {
-        const counts: Record<string, number> = {}
-        data.forEach((row) => {
-          const name = row.groomer_name || 'Unassigned'
-          counts[name] = (counts[name] || 0) + 1
-        })
-        setWorkloads(Object.entries(counts).map(([employee_name, count]) => ({ employee_name, count })))
-      }
-      setLoading(false)
-    }
-    fetchWorkloads()
-  }, [])
+export default async function EmployeeWorkload() {
+  const now = new Date()
+  const startOfDay = new Date(now)
+  startOfDay.setHours(0, 0, 0, 0)
+  const endOfDay = new Date(now)
+  endOfDay.setHours(23, 59, 59, 999)
 
-  if (loading) return <div className="text-white/80">Loading...</div>
-  if (workloads.length === 0)
+  const supabase = createClient()
+  const { data } = await supabase
+    .from('appointments')
+    .select('groomer_name, status, start_time')
+    .in('status', ['Checked In', 'In Progress'])
+    .gte('start_time', startOfDay.toISOString())
+    .lte('start_time', endOfDay.toISOString())
+
+  const workloads = buildWorkloads(data)
+  if (!workloads.length)
     return (
       <div className="rounded-3xl border border-white/25 bg-white/10 p-6 text-white/85 backdrop-blur-lg">
         No active jobs.
       </div>
     )
 
-  const max = workloads.length ? Math.max(...workloads.map((w) => w.count), 1) : 1
+  const max = Math.max(...workloads.map((w) => w.count), 1)
 
   return (
     <ul className="space-y-3 text-white/90">
@@ -69,10 +65,7 @@ export default function EmployeeWorkload() {
               </span>
             </div>
             <div className="mt-3 h-2 rounded-full bg-white/15">
-              <div
-                className="h-full rounded-full bg-white/80"
-                style={{ width: `${width}%` }}
-              />
+              <div className="h-full rounded-full bg-white/80" style={{ width: `${width}%` }} />
             </div>
           </li>
         )

--- a/components/dashboard/Revenue.tsx
+++ b/components/dashboard/Revenue.tsx
@@ -1,48 +1,45 @@
-"use client";
-import { useEffect, useState } from 'react'
-import { supabase } from '@/lib/supabase/client'
+import { createClient } from '@/lib/supabase/server'
 
-export default function Revenue() {
-  const [todayRevenue, setTodayRevenue] = useState<number | null>(null)
-  const [weekRevenue, setWeekRevenue] = useState<number | null>(null)
-  const [loading, setLoading] = useState(true)
+type RevenueRow = {
+  total_price: number | null
+}
 
-  useEffect(() => {
-    const fetchRevenue = async () => {
-      const now = new Date()
-      const startOfDay = new Date(now)
-      startOfDay.setHours(0, 0, 0, 0)
-      const startOfWeek = new Date(now)
-      const day = now.getDay()
-      const diff = now.getDate() - day + (day === 0 ? -6 : 1) // Monday = 1
-      startOfWeek.setDate(diff)
-      startOfWeek.setHours(0, 0, 0, 0)
+function format(value: number) {
+  return value.toFixed(2)
+}
 
-      const { data: todayData } = await supabase
-        .from('appointments')
-        .select('total_price')
-        .gte('completed_at', startOfDay.toISOString())
-        .lte('completed_at', now.toISOString())
-        .eq('status', 'Completed')
+export default async function Revenue() {
+  const now = new Date()
+  const startOfDay = new Date(now)
+  startOfDay.setHours(0, 0, 0, 0)
 
-      const { data: weekData } = await supabase
-        .from('appointments')
-        .select('total_price')
-        .gte('completed_at', startOfWeek.toISOString())
-        .lte('completed_at', now.toISOString())
-        .eq('status', 'Completed')
+  const startOfWeek = new Date(now)
+  const day = now.getDay()
+  const diff = now.getDate() - day + (day === 0 ? -6 : 1) // Monday = 1
+  startOfWeek.setDate(diff)
+  startOfWeek.setHours(0, 0, 0, 0)
 
-      const sum = (rows: any[] | null) => rows?.reduce((acc, row) => acc + (row.total_price || 0), 0) ?? 0
-      setTodayRevenue(sum(todayData))
-      setWeekRevenue(sum(weekData))
-      setLoading(false)
-    }
-    fetchRevenue()
-  }, [])
+  const supabase = createClient()
+  const { data: todayData } = await supabase
+    .from('appointments')
+    .select('total_price')
+    .gte('completed_at', startOfDay.toISOString())
+    .lte('completed_at', now.toISOString())
+    .eq('status', 'Completed')
 
-  const format = (value: number | null) => (value ?? 0).toFixed(2)
+  const { data: weekData } = await supabase
+    .from('appointments')
+    .select('total_price')
+    .gte('completed_at', startOfWeek.toISOString())
+    .lte('completed_at', now.toISOString())
+    .eq('status', 'Completed')
 
-  if (loading) return <div className="text-white/80">Loading...</div>
+  const sum = (rows: RevenueRow[] | null | undefined) =>
+    rows?.reduce((acc, row) => acc + (row.total_price ?? 0), 0) ?? 0
+
+  const todayRevenue = sum(todayData)
+  const weekRevenue = sum(weekData)
+
   return (
     <div className="space-y-4 text-white">
       <div className="rounded-3xl border border-white/20 bg-white/10 p-5 shadow-inner backdrop-blur">


### PR DESCRIPTION
## Summary
- refactor the Revenue dashboard widget to fetch appointment totals with the server Supabase client
- move EmployeeWorkload aggregation to the server and reuse the existing UI with precomputed counts
- convert the Messages widget to a server component that loads the latest messages without client-side effects

## Testing
- npm run lint
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3cbbbf498832483953af113cab290