### PR TITLE
Improve payroll fallback staff lookups

### DIFF
--- a/app/employees/[id]/EmployeeDetailClient.tsx
+++ b/app/employees/[id]/EmployeeDetailClient.tsx
@@ -24,6 +24,7 @@ export type StaffRecord = {
   name: string | null;
   email: string | null;
   phone: string | null;
+  user_id?: string | null;
   role: string | null;
   avatar_url: string | null;
   active: boolean | null;

--- a/app/employees/[id]/data-helpers.ts
+++ b/app/employees/[id]/data-helpers.ts
@@ -24,6 +24,13 @@ export function isPermissionError(error: PostgrestError | null) {
   return error.message?.toLowerCase().includes("permission denied");
 }
 
+export function isInvalidInputError(error: PostgrestError | null) {
+  if (!error) return false;
+  if (error.code === "22P02") return true;
+  const message = error.message?.toLowerCase() ?? "";
+  return message.includes("invalid input syntax") || message.includes("invalid input value");
+}
+
 export function shouldFallbackToAppointments(error: PostgrestError | null) {
   return isMissingFunctionError(error) || isMissingRelationError(error) || isPermissionError(error);
 }


### PR DESCRIPTION
## Summary
- expose the optional user_id on staff records so fallback payroll queries can target legacy schemas
- add helper coverage for invalid-input Postgrest errors when probing alternate schemas
- broaden the payroll fallback loader to consider multiple staff/time columns, support string identifiers, and filter results safely when only unfiltered reads succeed

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d3e30ce5dc8324995ae52b03ba6858