### PR TITLE
Fix calendar page stuck on loading when range missing

### DIFF
--- a/app/(app)/calendar/page.tsx
+++ b/app/(app)/calendar/page.tsx
@@ -85,7 +85,10 @@ export default function CalendarPage() {
   }, [weekDays]);
 
   const load = useCallback(async () => {
-    if (!session || !permissions.canManageCalendar || !activeRange) return;
+    if (!session || !permissions.canManageCalendar || !activeRange) {
+      setLoading(false);
+      return;
+    }
 
     setLoading(true);
     setErr(null);
@@ -171,13 +174,14 @@ export default function CalendarPage() {
 
   useEffect(() => {
     if (authLoading) return;
-    if (!session || !permissions.canManageCalendar) {
+    if (!session || !permissions.canManageCalendar || !activeRange) {
       setRows([]);
+      setErr(null);
       setLoading(false);
       return;
     }
     void load();
-  }, [authLoading, load, permissions.canManageCalendar, session]);
+  }, [activeRange, authLoading, load, permissions.canManageCalendar, session]);
 
   if (authLoading) {
     return null;


### PR DESCRIPTION
## Summary
- ensure the calendar loader exits when the active date range has not been initialised
- clear any stale error state and include the active range in the fetch effect dependencies so the fetch can re-run when ready

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d4009b10688324b633313fbaeafe2c