### PR TITLE
Harden staff settings actions with permission and table fallbacks

### DIFF
--- a/app/employees/[id]/settings/actions.ts
+++ b/app/employees/[id]/settings/actions.ts
@@ -2,9 +2,124 @@
 
 import { revalidatePath } from "next/cache";
 
-import { createClient } from "@/lib/supabase/server";
+import type { PostgrestError, SupabaseClient } from "@supabase/supabase-js";
+
+import { createClient, getSupabaseAdmin } from "@/lib/supabase/server";
 import type { CompensationPlan } from "@/lib/compensationPlan";
 import { toStoredPlan } from "@/lib/compensationPlan";
+import {
+  cleanNullableText,
+  normalizeStatusLabel,
+  normalizeTagList,
+  toOptionalNumber,
+} from "@/lib/employees/profile";
+import { normaliseRole } from "@/lib/auth/profile";
+
+const STAFF_TABLE_CANDIDATES = ["employees", "staff"] as const;
+
+function revalidateStaffSettings(staffId: number) {
+  revalidatePath(`/employees/${staffId}/settings`);
+  revalidatePath(`/staff/${staffId}/settings`);
+}
+
+function isMissingTableError(error: PostgrestError | null): boolean {
+  if (!error) return false;
+  if (error.code === "42P01") return true;
+  return /relation ["']?(employees|staff)["']? does not exist/i.test(error.message ?? "");
+}
+
+function isTruthyFlag(value: unknown): boolean {
+  if (value === true) return true;
+  if (value === false || value === null || value === undefined) return false;
+  if (typeof value === "string") {
+    const normalised = value.trim().toLowerCase();
+    return ["true", "1", "yes", "y", "on"].includes(normalised);
+  }
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value !== 0 : false;
+  }
+  return false;
+}
+
+type StaffPermissionResult = "allowed" | "forbidden" | "unauthenticated";
+
+async function viewerCanEditStaff(supabase: SupabaseClient): Promise<StaffPermissionResult> {
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return "unauthenticated";
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("role")
+    .eq("id", user.id)
+    .maybeSingle();
+
+  const role = normaliseRole(profile?.role);
+  if (role === "master" || role === "admin") {
+    return "allowed";
+  }
+
+  const { data: employee } = await supabase
+    .from("employees")
+    .select("role, app_permissions")
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  const employeeRole = typeof employee?.role === "string" ? employee.role.toLowerCase() : "";
+  if (employeeRole.includes("manager") || employeeRole.includes("owner") || employeeRole.includes("admin")) {
+    return "allowed";
+  }
+
+  const perms = employee?.app_permissions;
+  if (perms && typeof perms === "object") {
+    const flags = perms as Record<string, unknown>;
+    if (
+      isTruthyFlag(flags.can_manage_staff) ||
+      isTruthyFlag(flags.can_edit_schedule) ||
+      isTruthyFlag(flags.can_manage_discounts) ||
+      isTruthyFlag(flags.can_view_reports) ||
+      isTruthyFlag(flags.is_manager)
+    ) {
+      return "allowed";
+    }
+  }
+
+  return "forbidden";
+}
+
+async function resolveStaffClient(): Promise<
+  | { supabase: SupabaseClient; client: SupabaseClient; permission: "allowed" }
+  | { supabase: SupabaseClient; client: null; permission: StaffPermissionResult }
+> {
+  const supabase = createClient();
+  const permission = await viewerCanEditStaff(supabase);
+  if (permission !== "allowed") {
+    return { supabase, client: null, permission };
+  }
+
+  try {
+    const admin = getSupabaseAdmin();
+    return { supabase, client: admin, permission };
+  } catch {
+    return { supabase, client: supabase, permission };
+  }
+}
+
+async function updateStaffRecord(client: SupabaseClient, staffId: number, payload: Record<string, unknown>) {
+  let lastError: PostgrestError | null = null;
+  for (const table of STAFF_TABLE_CANDIDATES) {
+    const { error } = await client.from(table).update(payload).eq("id", staffId);
+    if (!error) {
+      return null;
+    }
+    lastError = error;
+    if (!isMissingTableError(error)) {
+      break;
+    }
+  }
+  return lastError;
+}
 
 export async function saveProfileAction(
   staffId: number,
@@ -23,28 +138,36 @@ export async function saveProfileAction(
     emergency_contact_phone: string;
   }
 ) {
-  const supabase = createClient();
-  const status = input.status || "Active";
+  const { client, permission } = await resolveStaffClient();
+  if (!client) {
+    const message =
+      permission === "unauthenticated"
+        ? "You must be signed in to update staff profiles"
+        : "You do not have permission to update staff profiles";
+    return { success: false, error: message };
+  }
+  const { status, isActive } = normalizeStatusLabel(input.status);
+  const email = cleanNullableText(input.email)?.toLowerCase() ?? null;
   const payload = {
-    name: input.name || null,
-    role: input.role || null,
-    email: input.email || null,
-    phone: input.phone || null,
-    avatar_url: input.avatar_url || null,
-    address_street: input.address_street || null,
-    address_city: input.address_city || null,
-    address_state: input.address_state || null,
-    address_zip: input.address_zip || null,
-    emergency_contact_name: input.emergency_contact_name || null,
-    emergency_contact_phone: input.emergency_contact_phone || null,
+    name: cleanNullableText(input.name),
+    role: cleanNullableText(input.role),
+    email,
+    phone: cleanNullableText(input.phone),
+    avatar_url: cleanNullableText(input.avatar_url),
+    address_street: cleanNullableText(input.address_street),
+    address_city: cleanNullableText(input.address_city),
+    address_state: cleanNullableText(input.address_state),
+    address_zip: cleanNullableText(input.address_zip),
+    emergency_contact_name: cleanNullableText(input.emergency_contact_name),
+    emergency_contact_phone: cleanNullableText(input.emergency_contact_phone),
     status,
-    active: status.toLowerCase().includes("active"),
+    active: isActive,
   };
-  const { error } = await supabase.from("employees").update(payload).eq("id", staffId);
+  const error = await updateStaffRecord(client, staffId, payload);
   if (error) {
     return { success: false, error: error.message };
   }
-  revalidatePath(`/employees/${staffId}/settings`);
+  revalidateStaffSettings(staffId);
   return { success: true };
 }
 
@@ -59,20 +182,29 @@ export async function saveCompensationAction(
     app_permissions: Record<string, boolean>;
   }
 ) {
-  const supabase = createClient();
+  const { client, permission } = await resolveStaffClient();
+  if (!client) {
+    const message =
+      permission === "unauthenticated"
+        ? "You must be signed in to update staff compensation"
+        : "You do not have permission to update staff compensation";
+    return { success: false, error: message };
+  }
   const payload = {
     pay_type: input.pay_type,
     commission_rate: Number.isFinite(input.commission_rate) ? input.commission_rate : 0,
     hourly_rate: Number.isFinite(input.hourly_rate) ? input.hourly_rate : 0,
     salary_rate: Number.isFinite(input.salary_rate) ? input.salary_rate : 0,
     compensation_plan: toStoredPlan(input.compensation_plan),
-    app_permissions: input.app_permissions,
+    app_permissions: Object.fromEntries(
+      Object.entries(input.app_permissions ?? {}).map(([key, value]) => [key, Boolean(value)]),
+    ),
   };
-  const { error } = await supabase.from("employees").update(payload).eq("id", staffId);
+  const error = await updateStaffRecord(client, staffId, payload);
   if (error) {
     return { success: false, error: error.message };
   }
-  revalidatePath(`/employees/${staffId}/settings`);
+  revalidateStaffSettings(staffId);
   return { success: true };
 }
 
@@ -86,43 +218,62 @@ export async function savePreferencesAction(
     dogsPerDay: number | null;
   }
 ) {
-  const supabase = createClient();
-  const { error: employeeError } = await supabase
-    .from("employees")
-    .update({
-      preferred_breeds: input.preferred_breeds,
-      not_accepted_breeds: input.not_accepted_breeds,
-      specialties: input.specialties,
-    })
-    .eq("id", staffId);
+  const { client, permission } = await resolveStaffClient();
+  if (!client) {
+    const message =
+      permission === "unauthenticated"
+        ? "You must be signed in to update staff preferences"
+        : "You do not have permission to update staff preferences";
+    return { success: false, error: message };
+  }
+  const preferredBreeds = normalizeTagList(input.preferred_breeds);
+  const notAcceptedBreeds = normalizeTagList(input.not_accepted_breeds);
+  const specialties = normalizeTagList(input.specialties);
+  const weeklyTarget = toOptionalNumber(input.weeklyTarget);
+  const dogsPerDay = toOptionalNumber(input.dogsPerDay);
 
-  const { error: goalsError } = await supabase
+  const employeeError = await updateStaffRecord(client, staffId, {
+    preferred_breeds: preferredBreeds,
+    not_accepted_breeds: notAcceptedBreeds,
+    specialties,
+  });
+
+  const { error: goalsError } = await client
     .from("staff_goals")
     .upsert(
       {
         staff_id: staffId,
-        weekly_revenue_target: input.weeklyTarget,
-        desired_dogs_per_day: input.dogsPerDay,
+        weekly_revenue_target: weeklyTarget,
+        desired_dogs_per_day: dogsPerDay,
       },
       { onConflict: "staff_id" }
     );
 
   if (employeeError || goalsError) {
-    return { success: false, error: employeeError?.message ?? goalsError?.message ?? "Unable to save preferences" };
+    return {
+      success: false,
+      error: employeeError?.message ?? goalsError?.message ?? "Unable to save preferences",
+    };
   }
-  revalidatePath(`/employees/${staffId}/settings`);
+  revalidateStaffSettings(staffId);
   return { success: true };
 }
 
 export async function saveManagerNotesAction(staffId: number, notes: string) {
-  const supabase = createClient();
-  const { error } = await supabase
-    .from("employees")
-    .update({ manager_notes: notes?.trim() ? notes : null })
-    .eq("id", staffId);
+  const { client, permission } = await resolveStaffClient();
+  if (!client) {
+    const message =
+      permission === "unauthenticated"
+        ? "You must be signed in to update manager notes"
+        : "You do not have permission to update manager notes";
+    return { success: false, error: message };
+  }
+  const error = await updateStaffRecord(client, staffId, {
+    manager_notes: notes?.trim() ? notes : null,
+  });
   if (error) {
     return { success: false, error: error.message };
   }
-  revalidatePath(`/employees/${staffId}/settings`);
+  revalidateStaffSettings(staffId);
   return { success: true };
 }

--- a/app/employees/[id]/settings/page.tsx
+++ b/app/employees/[id]/settings/page.tsx
@@ -24,6 +24,13 @@ import {
   toStoredPlan,
 } from "@/lib/compensationPlan";
 import { supabase } from "@/lib/supabase/client";
+import {
+  STAFF_STATUS_LABELS,
+  cleanNullableText,
+  normalizeStatusLabel,
+  normalizeTagList,
+  toOptionalNumber,
+} from "@/lib/employees/profile";
 
 type PermissionKey =
   | "can_view_reports"
@@ -40,7 +47,7 @@ const PERMISSION_OPTIONS: PermissionOption[] = [
   { key: "can_manage_staff", label: "Manage staff" },
 ];
 
-const STATUS_OPTIONS = ["Active", "Inactive", "On leave"];
+const STATUS_OPTIONS = STAFF_STATUS_LABELS;
 
 export default function EmployeeSettingsPage() {
   const { employee, goals, viewerCanEditStaff, pushToast } = useEmployeeDetail();
@@ -60,19 +67,24 @@ export default function EmployeeSettingsPage() {
     return base;
   }, [employee.app_permissions]);
 
-  const [profile, setProfile] = useState({
-    name: employee.name ?? "",
-    role: employee.role ?? "",
-    email: employee.email ?? "",
-    phone: employee.phone ?? "",
-    avatar_url: employee.avatar_url ?? "",
-    status: employee.status ?? (employee.active ? "Active" : "Inactive"),
-    address_street: employee.address_street ?? "",
-    address_city: employee.address_city ?? "",
-    address_state: employee.address_state ?? "",
-    address_zip: employee.address_zip ?? "",
-    emergency_contact_name: employee.emergency_contact_name ?? "",
-    emergency_contact_phone: employee.emergency_contact_phone ?? "",
+  const [profile, setProfile] = useState(() => {
+    const { status } = normalizeStatusLabel(
+      employee.status ?? (employee.active ? "Active" : "Inactive"),
+    );
+    return {
+      name: cleanNullableText(employee.name) ?? "",
+      role: cleanNullableText(employee.role) ?? "",
+      email: cleanNullableText(employee.email) ?? "",
+      phone: cleanNullableText(employee.phone) ?? "",
+      avatar_url: cleanNullableText(employee.avatar_url) ?? "",
+      status,
+      address_street: cleanNullableText(employee.address_street) ?? "",
+      address_city: cleanNullableText(employee.address_city) ?? "",
+      address_state: cleanNullableText(employee.address_state) ?? "",
+      address_zip: cleanNullableText(employee.address_zip) ?? "",
+      emergency_contact_name: cleanNullableText(employee.emergency_contact_name) ?? "",
+      emergency_contact_phone: cleanNullableText(employee.emergency_contact_phone) ?? "",
+    };
   });
 
   const {
@@ -108,15 +120,15 @@ export default function EmployeeSettingsPage() {
   const [appPermissions, setAppPermissions] = useState(permissionState);
   const [staffOptions, setStaffOptions] = useState<{ id: number; name: string | null }[]>([]);
 
-  const [preferences, setPreferences] = useState({
-    preferred_breeds: [...(employee.preferred_breeds ?? [])],
-    not_accepted_breeds: [...(employee.not_accepted_breeds ?? [])],
-    specialties: [...(employee.specialties ?? [])],
-    weekly_revenue_target: goals?.weekly_revenue_target ?? 0,
-    desired_dogs_per_day: goals?.desired_dogs_per_day ?? 0,
-  });
+  const [preferences, setPreferences] = useState(() => ({
+    preferred_breeds: normalizeTagList(employee.preferred_breeds),
+    not_accepted_breeds: normalizeTagList(employee.not_accepted_breeds),
+    specialties: normalizeTagList(employee.specialties),
+    weekly_revenue_target: toOptionalNumber(goals?.weekly_revenue_target),
+    desired_dogs_per_day: toOptionalNumber(goals?.desired_dogs_per_day),
+  }));
 
-  const [notes, setNotes] = useState(employee.manager_notes ?? "");
+  const [notes, setNotes] = useState(cleanNullableText(employee.manager_notes) ?? "");
 
   const [editing, setEditing] = useState({
     profile: false,
@@ -149,6 +161,70 @@ export default function EmployeeSettingsPage() {
       hasConfiguration: planHasConfiguration(plan),
     };
   }, [compensationDraft, staffNameMap]);
+
+  useEffect(() => {
+    if (editing.profile) return;
+    const { status } = normalizeStatusLabel(
+      employee.status ?? (employee.active ? "Active" : "Inactive"),
+    );
+    setProfile({
+      name: cleanNullableText(employee.name) ?? "",
+      role: cleanNullableText(employee.role) ?? "",
+      email: cleanNullableText(employee.email) ?? "",
+      phone: cleanNullableText(employee.phone) ?? "",
+      avatar_url: cleanNullableText(employee.avatar_url) ?? "",
+      status,
+      address_street: cleanNullableText(employee.address_street) ?? "",
+      address_city: cleanNullableText(employee.address_city) ?? "",
+      address_state: cleanNullableText(employee.address_state) ?? "",
+      address_zip: cleanNullableText(employee.address_zip) ?? "",
+      emergency_contact_name: cleanNullableText(employee.emergency_contact_name) ?? "",
+      emergency_contact_phone: cleanNullableText(employee.emergency_contact_phone) ?? "",
+    });
+  }, [
+    editing.profile,
+    employee.active,
+    employee.address_city,
+    employee.address_state,
+    employee.address_street,
+    employee.address_zip,
+    employee.avatar_url,
+    employee.email,
+    employee.emergency_contact_name,
+    employee.emergency_contact_phone,
+    employee.name,
+    employee.phone,
+    employee.role,
+    employee.status,
+  ]);
+
+  useEffect(() => {
+    if (editing.prefs) return;
+    setPreferences({
+      preferred_breeds: normalizeTagList(employee.preferred_breeds),
+      not_accepted_breeds: normalizeTagList(employee.not_accepted_breeds),
+      specialties: normalizeTagList(employee.specialties),
+      weekly_revenue_target: toOptionalNumber(goals?.weekly_revenue_target),
+      desired_dogs_per_day: toOptionalNumber(goals?.desired_dogs_per_day),
+    });
+  }, [
+    editing.prefs,
+    employee.not_accepted_breeds,
+    employee.preferred_breeds,
+    employee.specialties,
+    goals?.desired_dogs_per_day,
+    goals?.weekly_revenue_target,
+  ]);
+
+  useEffect(() => {
+    if (editing.notes) return;
+    setNotes(cleanNullableText(employee.manager_notes) ?? "");
+  }, [editing.notes, employee.manager_notes]);
+
+  useEffect(() => {
+    setEditing({ profile: false, comp: false, perms: false, prefs: false, notes: false });
+    setSaving({ profile: false, comp: false, perms: false, prefs: false, notes: false });
+  }, [employee.id]);
 
   useEffect(() => {
     setAppPermissions(permissionState);
@@ -256,11 +332,11 @@ export default function EmployeeSettingsPage() {
   const handlePreferencesSave = async () => {
     setSaving((s) => ({ ...s, prefs: true }));
     const result = await savePreferencesAction(employee.id, {
-      preferred_breeds: preferences.preferred_breeds,
-      not_accepted_breeds: preferences.not_accepted_breeds,
-      specialties: preferences.specialties,
-      weeklyTarget: Number(preferences.weekly_revenue_target) || null,
-      dogsPerDay: Number(preferences.desired_dogs_per_day) || null,
+      preferred_breeds: normalizeTagList(preferences.preferred_breeds),
+      not_accepted_breeds: normalizeTagList(preferences.not_accepted_breeds),
+      specialties: normalizeTagList(preferences.specialties),
+      weeklyTarget: toOptionalNumber(preferences.weekly_revenue_target),
+      dogsPerDay: toOptionalNumber(preferences.desired_dogs_per_day),
     });
     setSaving((s) => ({ ...s, prefs: false }));
     if (!result.success) {
@@ -307,7 +383,11 @@ export default function EmployeeSettingsPage() {
           <TextField label="Avatar URL" value={profile.avatar_url} onChange={(v) => setProfile((p) => ({ ...p, avatar_url: v }))}
             disabled={!editing.profile || saving.profile} />
           <SelectField label="Status" value={profile.status} options={STATUS_OPTIONS}
-            onChange={(v) => setProfile((p) => ({ ...p, status: v }))} disabled={!editing.profile || saving.profile} />
+            onChange={(v) =>
+              setProfile((p) => ({ ...p, status: normalizeStatusLabel(v).status }))
+            }
+            disabled={!editing.profile || saving.profile}
+          />
         </div>
         <div className="mt-4 grid gap-4 md:grid-cols-2">
           <TextField label="Street" value={profile.address_street}
@@ -745,13 +825,13 @@ export default function EmployeeSettingsPage() {
         <div className="mt-4 grid gap-4 md:grid-cols-2">
           <NumberField
             label="Weekly revenue target"
-            value={Number(preferences.weekly_revenue_target ?? 0)}
+            value={preferences.weekly_revenue_target}
             onChange={(v) => setPreferences((p) => ({ ...p, weekly_revenue_target: v }))}
             disabled={!editing.prefs || saving.prefs}
           />
           <NumberField
             label="Desired dogs per day"
-            value={Number(preferences.desired_dogs_per_day ?? 0)}
+            value={preferences.desired_dogs_per_day}
             onChange={(v) => setPreferences((p) => ({ ...p, desired_dogs_per_day: v }))}
             disabled={!editing.prefs || saving.prefs}
           />
@@ -870,7 +950,13 @@ function TextField({ label, value, onChange, disabled }: TextFieldProps) {
   );
 }
 
-type SelectFieldProps = { label: string; value: string; options: string[]; onChange: (v: string) => void; disabled?: boolean };
+type SelectFieldProps = {
+  label: string;
+  value: string;
+  options: readonly string[];
+  onChange: (v: string) => void;
+  disabled?: boolean;
+};
 function SelectField({ label, value, options, onChange, disabled }: SelectFieldProps) {
   return (
     <label className="flex flex-col gap-1 text-sm text-slate-600">
@@ -889,15 +975,30 @@ function SelectField({ label, value, options, onChange, disabled }: SelectFieldP
   );
 }
 
-type NumberFieldProps = { label: string; value: number; onChange: (v: number) => void; disabled?: boolean };
+type NumberFieldProps = {
+  label: string;
+  value: number | null;
+  onChange: (v: number | null) => void;
+  disabled?: boolean;
+};
 function NumberField({ label, value, onChange, disabled }: NumberFieldProps) {
+  const displayValue =
+    typeof value === "number" && Number.isFinite(value) ? value : "";
   return (
     <label className="flex flex-col gap-1 text-sm text-slate-600">
       <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">{label}</span>
       <input
         type="number"
-        value={Number.isFinite(value) ? value : 0}
-        onChange={(e) => onChange(Number(e.target.value))}
+        value={displayValue}
+        onChange={(e) => {
+          const next = e.target.value;
+          if (next === "") {
+            onChange(null);
+            return;
+          }
+          const numeric = Number(next);
+          onChange(Number.isFinite(numeric) ? numeric : null);
+        }}
         disabled={disabled}
         className="rounded-lg border border-slate-300 px-3 py-2 text-sm disabled:bg-slate-100"
       />
@@ -919,7 +1020,8 @@ function TagInput({ label, values, onChange, placeholder, disabled }: TagInputPr
   const addValue = () => {
     const trimmed = input.trim();
     if (!trimmed) return;
-    if (values.includes(trimmed)) {
+    const normalized = trimmed.toLowerCase();
+    if (values.some((value) => value.toLowerCase() === normalized)) {
       setInput("");
       return;
     }

--- a/lib/employees/profile.ts
+++ b/lib/employees/profile.ts
@@ -1,0 +1,78 @@
+export const STAFF_STATUS_LABELS = ["Active", "Inactive", "On leave"] as const;
+
+export type StaffStatus = (typeof STAFF_STATUS_LABELS)[number];
+
+const STATUS_LOOKUP = new Map<string, StaffStatus>(
+  STAFF_STATUS_LABELS.map((label) => [label.toLowerCase(), label]),
+);
+
+function normaliseStatusText(value: string): string {
+  return value
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+export function normalizeStatusLabel(
+  rawStatus: string | null | undefined,
+): { status: StaffStatus; isActive: boolean } {
+  const text = typeof rawStatus === "string" ? rawStatus : "";
+  const normalized = normaliseStatusText(text);
+  if (!normalized) {
+    return { status: "Active", isActive: true };
+  }
+
+  const exactMatch = STATUS_LOOKUP.get(normalized);
+  if (exactMatch) {
+    return { status: exactMatch, isActive: exactMatch === "Active" };
+  }
+
+  if (normalized.includes("leave")) {
+    return { status: "On leave", isActive: false };
+  }
+
+  if (normalized.includes("inactive")) {
+    return { status: "Inactive", isActive: false };
+  }
+
+  if (normalized.includes("active")) {
+    return { status: "Active", isActive: true };
+  }
+
+  return { status: "Active", isActive: true };
+}
+
+export function cleanNullableText(value: string | null | undefined): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function normalizeTagList(values: string[] | null | undefined): string[] {
+  if (!Array.isArray(values)) return [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+export function toOptionalNumber(value: unknown): number | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const numeric = Number(trimmed);
+    return Number.isFinite(numeric) ? numeric : null;
+  }
+  return null;
+}

--- a/tests/employees-profile-utils.test.ts
+++ b/tests/employees-profile-utils.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  cleanNullableText,
+  normalizeStatusLabel,
+  normalizeTagList,
+  toOptionalNumber,
+} from "../lib/employees/profile";
+
+test("normalizeStatusLabel handles canonical statuses", () => {
+  assert.deepEqual(normalizeStatusLabel("Active"), {
+    status: "Active",
+    isActive: true,
+  });
+  assert.deepEqual(normalizeStatusLabel("inactive"), {
+    status: "Inactive",
+    isActive: false,
+  });
+  assert.deepEqual(normalizeStatusLabel("On Leave"), {
+    status: "On leave",
+    isActive: false,
+  });
+});
+
+test("normalizeStatusLabel understands partial matches", () => {
+  assert.deepEqual(normalizeStatusLabel("Temporarily inactive"), {
+    status: "Inactive",
+    isActive: false,
+  });
+  assert.deepEqual(normalizeStatusLabel("currently active"), {
+    status: "Active",
+    isActive: true,
+  });
+  assert.deepEqual(normalizeStatusLabel("Leave of absence"), {
+    status: "On leave",
+    isActive: false,
+  });
+});
+
+test("normalizeStatusLabel defaults to Active", () => {
+  assert.deepEqual(normalizeStatusLabel(undefined), {
+    status: "Active",
+    isActive: true,
+  });
+  assert.deepEqual(normalizeStatusLabel(""), {
+    status: "Active",
+    isActive: true,
+  });
+});
+
+test("cleanNullableText trims and nulls empty input", () => {
+  assert.equal(cleanNullableText("  hello "), "hello");
+  assert.equal(cleanNullableText("   "), null);
+  assert.equal(cleanNullableText(null), null);
+});
+
+test("normalizeTagList trims, filters, and deduplicates case-insensitively", () => {
+  const values = normalizeTagList(["  Poodle  ", "poodle", "  ", "Labrador", "labRador"]);
+  assert.deepEqual(values, ["Poodle", "Labrador"]);
+});
+
+test("toOptionalNumber converts strings and ignores invalid values", () => {
+  assert.equal(toOptionalNumber(5), 5);
+  assert.equal(toOptionalNumber(" 6.5 "), 6.5);
+  assert.equal(toOptionalNumber(""), null);
+  assert.equal(toOptionalNumber("abc"), null);
+  assert.equal(toOptionalNumber(null), null);
+});


### PR DESCRIPTION
## Summary
- gate staff settings server actions behind explicit viewer permission checks and reuse admin credentials when available
- fall back to updating a `staff` table name if present and revalidate both /employees and /staff settings routes after changes
- normalize staff preference saves to reuse the shared updater so every field is sanitized consistently

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4041dbe148324b9f77b05dc42df17