### PR TITLE
feat: add scheduling service layer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react": "^18.2.0",
         "react-beautiful-dnd": "^13.1.1",
         "react-dom": "^18.2.0",
+        "rrule": "^2.8.1",
         "swr": "^2.3.6",
         "zod": "^4.1.9",
         "zustand": "^5.0.8"
@@ -5942,6 +5943,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/rrule": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/rrule/-/rrule-2.8.1.tgz",
+      "integrity": "sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/rrweb-cssom": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react": "^18.2.0",
     "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^18.2.0",
+    "rrule": "^2.8.1",
     "swr": "^2.3.6",
     "zod": "^4.1.9",
     "zustand": "^5.0.8"

--- a/src/server/scheduling/appointments.ts
+++ b/src/server/scheduling/appointments.ts
@@ -1,0 +1,261 @@
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+import {
+  cancelAppointmentSchema,
+  createAppointmentSchema,
+  listDaySchema,
+  listWeekSchema,
+  updateAppointmentSchema,
+  type CancelAppointmentInput,
+  type CreateAppointmentInput,
+  type ListDayInput,
+  type ListWeekInput,
+  type UpdateAppointmentInput,
+} from './schemas';
+import { listSlots } from './slots';
+import type { AppointmentRow, AddOnRow, ServiceRow } from './types';
+import { MINUTE, addMinutes } from './utils';
+
+function roundToDay(date: Date): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
+function startOfNextDay(date: Date): Date {
+  return new Date(roundToDay(date).getTime() + 24 * 60 * MINUTE);
+}
+
+function startOfNextWeek(date: Date): Date {
+  return new Date(roundToDay(date).getTime() + 7 * 24 * 60 * MINUTE);
+}
+
+function toIso(date: Date): string {
+  return date.toISOString();
+}
+
+async function fetchService(serviceId: string) {
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('services')
+    .select('id, base_price, duration_min, buffer_pre_min, buffer_post_min')
+    .eq('id', serviceId)
+    .maybeSingle();
+  if (error) throw error;
+  const service = data as ServiceRow | null;
+  if (!service) throw new Error('Service not found');
+  return service;
+}
+
+async function fetchAppointment(id: string) {
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('appointments')
+    .select('*')
+    .eq('id', id)
+    .maybeSingle();
+  if (error) throw error;
+  const appointment = data as AppointmentRow | null;
+  if (!appointment) throw new Error('Appointment not found');
+  return appointment;
+}
+
+function normalisePrice(value: number | string | null | undefined): number {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+  return 0;
+}
+
+export async function createAppointment(rawPayload: CreateAppointmentInput) {
+  const payload = createAppointmentSchema.parse(rawPayload);
+  const service = await fetchService(payload.serviceId);
+  const supabase = getSupabaseAdmin();
+
+  const durationMin = payload.durationMin ?? service.duration_min ?? 60;
+  const startsAt = payload.startsAt;
+  const endsAt = addMinutes(startsAt, durationMin);
+
+  const windowFrom = addMinutes(startsAt, -durationMin);
+  const windowTo = addMinutes(endsAt, Math.max(service.buffer_post_min ?? 0, 60));
+  const slots = await listSlots({
+    staffId: payload.staffId,
+    serviceId: payload.serviceId,
+    from: windowFrom,
+    to: windowTo,
+  });
+  const hasSlot = slots.some(
+    (slot) => slot.staffId === payload.staffId && slot.start.getTime() === startsAt.getTime(),
+  );
+  if (!hasSlot) {
+    throw new Error('Selected slot is no longer available.');
+  }
+
+  let addOnTotal = 0;
+  let addOnRows: AddOnRow[] = [];
+  if (payload.addOnIds.length > 0) {
+    const { data: addOns, error: addOnError } = await supabase
+      .from('add_ons')
+      .select('id, price')
+      .in('id', payload.addOnIds);
+    if (addOnError) throw addOnError;
+    addOnRows = (addOns as AddOnRow[] | null) ?? [];
+    const missing = payload.addOnIds.filter((id) => !addOnRows.some((row) => row.id === id));
+    if (missing.length > 0) {
+      throw new Error(`Unknown add-ons: ${missing.join(', ')}`);
+    }
+    addOnTotal = addOnRows.reduce((sum, row) => sum + normalisePrice(row.price), 0);
+  }
+
+  const priceService = normalisePrice(service.base_price);
+  const appointmentInsert = {
+    staff_id: payload.staffId,
+    client_id: payload.clientId,
+    pet_id: payload.petId ?? null,
+    service_id: payload.serviceId,
+    starts_at: toIso(startsAt),
+    ends_at: toIso(endsAt),
+    price_service: priceService,
+    price_addons: addOnTotal,
+    discount: payload.discount,
+    tax: payload.tax,
+    status: payload.status ?? 'booked',
+    notes: payload.notes ?? null,
+    created_by: payload.createdBy ?? null,
+  };
+
+  const { data: inserted, error: insertError } = await supabase
+    .from('appointments')
+    .insert(appointmentInsert)
+    .select('id')
+    .single();
+  if (insertError) throw insertError;
+
+  if (addOnRows.length > 0) {
+    const addOnPayload = addOnRows.map((row) => ({
+      appointment_id: inserted.id,
+      add_on_id: row.id,
+      price: normalisePrice(row.price),
+    }));
+    const { error: addOnInsertError } = await supabase
+      .from('appointment_add_ons')
+      .upsert(addOnPayload, { onConflict: 'appointment_id,add_on_id' });
+    if (addOnInsertError) throw addOnInsertError;
+  }
+
+  await supabase.from('audit_log').insert({
+    actor_id: payload.createdBy ?? payload.clientId,
+    action: 'appointment_created',
+    entity: 'appointments',
+    entity_id: inserted.id,
+  });
+
+  return {
+    id: inserted.id,
+    startsAt,
+    endsAt,
+    priceService,
+    priceAddOns: addOnTotal,
+  };
+}
+
+export async function updateAppointment(id: string, rawPayload: UpdateAppointmentInput) {
+  const payload = updateAppointmentSchema.parse(rawPayload);
+  const supabase = getSupabaseAdmin();
+  const existing = await fetchAppointment(id);
+
+  const updates: Record<string, unknown> = {};
+  if (payload.status) updates.status = payload.status;
+  if (payload.discount !== undefined) updates.discount = payload.discount;
+  if (payload.tax !== undefined) updates.tax = payload.tax;
+  if (payload.notes !== undefined) updates.notes = payload.notes;
+
+  if (Object.keys(updates).length === 0) return existing;
+
+  const { data, error } = await supabase
+    .from('appointments')
+    .update(updates)
+    .eq('id', id)
+    .select('*')
+    .maybeSingle();
+  if (error) throw error;
+
+  await supabase.from('audit_log').insert({
+    actor_id: existing.created_by,
+    action: 'appointment_updated',
+    entity: 'appointments',
+    entity_id: id,
+  });
+
+  return data ?? existing;
+}
+
+export async function cancelAppointment(id: string, reason?: string) {
+  const payload: CancelAppointmentInput = cancelAppointmentSchema.parse({ id, reason });
+  const supabase = getSupabaseAdmin();
+  const appointment = await fetchAppointment(payload.id);
+
+  const updates: Record<string, unknown> = { status: 'canceled' };
+  if (payload.reason) {
+    const existingNotes = appointment.notes?.trim();
+    const newNote = `Cancellation reason: ${payload.reason}`;
+    updates.notes = existingNotes ? `${existingNotes}\n${newNote}` : newNote;
+  }
+
+  const { data, error } = await supabase
+    .from('appointments')
+    .update(updates)
+    .eq('id', payload.id)
+    .select('*')
+    .maybeSingle();
+  if (error) throw error;
+
+  await supabase.from('audit_log').insert({
+    actor_id: appointment.created_by,
+    action: 'appointment_canceled',
+    entity: 'appointments',
+    entity_id: payload.id,
+  });
+
+  return data ?? appointment;
+}
+
+export async function listDay(rawInput: ListDayInput) {
+  const input = listDaySchema.parse(rawInput);
+  const supabase = getSupabaseAdmin();
+  const dayStart = roundToDay(input.date);
+  const dayEnd = startOfNextDay(input.date);
+  const query = supabase
+    .from('appointments')
+    .select('*')
+    .gte('starts_at', toIso(dayStart))
+    .lt('starts_at', toIso(dayEnd))
+    .order('starts_at', { ascending: true });
+  if (input.staffId) query.eq('staff_id', input.staffId);
+  const { data, error } = await query;
+  if (error) throw error;
+  return (data as AppointmentRow[] | null) ?? [];
+}
+
+export async function listWeek(rawInput: ListWeekInput) {
+  const input = listWeekSchema.parse(rawInput);
+  const supabase = getSupabaseAdmin();
+  const weekStart = roundToDay(input.weekStart);
+  const weekEnd = startOfNextWeek(input.weekStart);
+  const query = supabase
+    .from('appointments')
+    .select('*')
+    .gte('starts_at', toIso(weekStart))
+    .lt('starts_at', toIso(weekEnd))
+    .order('starts_at', { ascending: true });
+  if (input.staffId) query.eq('staff_id', input.staffId);
+  const { data, error } = await query;
+  if (error) throw error;
+  return (data as AppointmentRow[] | null) ?? [];
+}
+
+export function computeCommissionBase(appointment: Pick<AppointmentRow, 'price_service' | 'price_addons' | 'discount'>) {
+  const servicePrice = normalisePrice(appointment.price_service ?? 0);
+  const addOnPrice = normalisePrice(appointment.price_addons ?? 0);
+  const discount = normalisePrice(appointment.discount ?? 0);
+  return servicePrice + addOnPrice - discount;
+}

--- a/src/server/scheduling/index.ts
+++ b/src/server/scheduling/index.ts
@@ -1,0 +1,23 @@
+export { listSlots, type AvailableSlot } from './slots';
+export {
+  createAppointment,
+  updateAppointment,
+  cancelAppointment,
+  listDay,
+  listWeek,
+  computeCommissionBase,
+} from './appointments';
+export { createRescheduleLink, applyReschedule } from './links';
+export { registerPushToken, sendReminder, sendPickupReady } from './notifications';
+export type {
+  SlotQueryInput,
+  CreateAppointmentInput,
+  UpdateAppointmentInput,
+  CancelAppointmentInput,
+  ListDayInput,
+  ListWeekInput,
+  RescheduleLinkInput,
+  ApplyRescheduleInput,
+  RegisterPushTokenInput,
+  AppointmentStatus,
+} from './schemas';

--- a/src/server/scheduling/links.ts
+++ b/src/server/scheduling/links.ts
@@ -1,0 +1,162 @@
+import { randomBytes } from 'node:crypto';
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+import { applyRescheduleSchema, rescheduleLinkSchema, type ApplyRescheduleInput, type RescheduleLinkInput } from './schemas';
+import { listSlots } from './slots';
+import type {
+  AppointmentRow,
+  AppointmentWithServiceRow,
+  RescheduleLinkRow,
+  ServiceRow,
+} from './types';
+import { MINUTE, addMinutes, toDate } from './utils';
+
+const DEFAULT_TTL_HOURS = 48;
+
+function resolveBaseUrl(): string {
+  const envUrl = process.env.NEXT_PUBLIC_APP_URL ?? process.env.APP_URL;
+  if (envUrl) return envUrl.endsWith('/') ? envUrl : `${envUrl}/`;
+  const vercel = process.env.VERCEL_URL;
+  if (vercel) {
+    const normalized = vercel.startsWith('http') ? vercel : `https://${vercel}`;
+    return normalized.endsWith('/') ? normalized : `${normalized}/`;
+  }
+  return 'http://localhost:3000/';
+}
+
+function buildRescheduleUrl(token: string): string {
+  const base = resolveBaseUrl();
+  const url = new URL(`book/reschedule/${token}`, base);
+  return url.toString();
+}
+
+function generateToken(): string {
+  return randomBytes(24).toString('base64url');
+}
+
+async function loadRescheduleLink(token: string) {
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('reschedule_links')
+    .select('id, appointment_id, token, expires_at, used_at')
+    .eq('token', token)
+    .maybeSingle();
+  if (error) throw error;
+  const link = data as RescheduleLinkRow | null;
+  if (!link) throw new Error('Reschedule token not found');
+  return link;
+}
+
+async function loadAppointmentWithService(id: string) {
+  const supabase = getSupabaseAdmin();
+  const { data, error } = await supabase
+    .from('appointments')
+    .select('*, services:service_id (id, base_price, duration_min, buffer_pre_min, buffer_post_min)')
+    .eq('id', id)
+    .maybeSingle();
+  if (error) throw error;
+  const record = data as AppointmentWithServiceRow | null;
+  if (!record) throw new Error('Appointment not found for reschedule');
+  const { services, ...appointment } = record;
+  return { appointment: appointment as AppointmentRow, service: services ?? null };
+}
+
+export async function createRescheduleLink(rawInput: RescheduleLinkInput) {
+  const input = rescheduleLinkSchema.parse(rawInput);
+  const supabase = getSupabaseAdmin();
+
+  const ttlHours = input.ttlHours ?? DEFAULT_TTL_HOURS;
+  const expiresAt = new Date(Date.now() + ttlHours * 60 * MINUTE);
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const token = generateToken();
+    const { data, error } = await supabase
+      .from('reschedule_links')
+      .insert({
+        appointment_id: input.appointmentId,
+        token,
+        expires_at: expiresAt.toISOString(),
+      })
+      .select('id')
+      .maybeSingle();
+    if (error && error.code === '23505') {
+      continue;
+    }
+    if (error) throw error;
+    if (data) {
+      return {
+        token,
+        url: buildRescheduleUrl(token),
+        expiresAt,
+      };
+    }
+  }
+
+  throw new Error('Unable to allocate reschedule token');
+}
+
+export async function applyReschedule(rawInput: ApplyRescheduleInput) {
+  const input = applyRescheduleSchema.parse(rawInput);
+  const link = await loadRescheduleLink(input.token);
+  if (link.used_at) {
+    throw new Error('Reschedule link has already been used.');
+  }
+  if (link.expires_at && new Date(link.expires_at) < new Date()) {
+    throw new Error('Reschedule link has expired.');
+  }
+
+  const { appointment, service } = await loadAppointmentWithService(link.appointment_id);
+  const startsAt = input.newSlot.startsAt;
+  const serviceId = input.newSlot.serviceId;
+  if (appointment.service_id && appointment.service_id !== serviceId) {
+    throw new Error('Service mismatch for reschedule.');
+  }
+
+  const staffId = input.newSlot.staffId ?? appointment.staff_id ?? undefined;
+  const validationSlots = await listSlots({
+    staffId,
+    serviceId,
+    from: addMinutes(startsAt, -180),
+    to: addMinutes(startsAt, 180),
+  });
+  const isAvailable = validationSlots.some(
+    (slot) => slot.staffId === staffId && slot.start.getTime() === startsAt.getTime(),
+  );
+  if (!isAvailable) {
+    throw new Error('Requested slot is not available.');
+  }
+
+  const originalDuration = Math.max(
+    Math.round((toDate(appointment.ends_at).getTime() - toDate(appointment.starts_at).getTime()) / MINUTE),
+    service?.duration_min ?? 0,
+  );
+  const effectiveDuration = originalDuration > 0 ? originalDuration : service?.duration_min ?? 60;
+  const newEnd = addMinutes(startsAt, effectiveDuration);
+
+  const supabase = getSupabaseAdmin();
+  const { data: updated, error: updateError } = await supabase
+    .from('appointments')
+    .update({
+      starts_at: startsAt.toISOString(),
+      ends_at: newEnd.toISOString(),
+      staff_id: staffId ?? null,
+    })
+    .eq('id', appointment.id)
+    .select('*')
+    .maybeSingle();
+  if (updateError) throw updateError;
+
+  const { error: markUsedError } = await supabase
+    .from('reschedule_links')
+    .update({ used_at: new Date().toISOString() })
+    .eq('id', link.id);
+  if (markUsedError) throw markUsedError;
+
+  await supabase.from('audit_log').insert({
+    actor_id: appointment.created_by,
+    action: 'appointment_rescheduled',
+    entity: 'appointments',
+    entity_id: appointment.id,
+  });
+
+  return updated ?? appointment;
+}

--- a/src/server/scheduling/notifications.ts
+++ b/src/server/scheduling/notifications.ts
@@ -1,0 +1,44 @@
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+import {
+  appointmentIdSchema,
+  registerPushTokenSchema,
+  type AppointmentIdInput,
+  type RegisterPushTokenInput,
+} from './schemas';
+
+export async function registerPushToken(rawInput: RegisterPushTokenInput) {
+  const input = registerPushTokenSchema.parse(rawInput);
+  const supabase = getSupabaseAdmin();
+  const { error } = await supabase
+    .from('notification_tokens')
+    .upsert(
+      {
+        user_id: input.userId,
+        platform: input.platform,
+        token: input.token,
+        last_seen_at: new Date().toISOString(),
+      },
+      { onConflict: 'token' },
+    );
+  if (error) throw error;
+}
+
+async function logNotification(action: string, rawInput: AppointmentIdInput) {
+  const input = appointmentIdSchema.parse(rawInput);
+  const supabase = getSupabaseAdmin();
+  const { error } = await supabase.from('audit_log').insert({
+    actor_id: input.actorId ?? null,
+    action,
+    entity: 'appointments',
+    entity_id: input.appointmentId,
+  });
+  if (error) throw error;
+}
+
+export async function sendReminder(appointmentId: string, actorId?: string) {
+  await logNotification('appointment_reminder_queued', { appointmentId, actorId });
+}
+
+export async function sendPickupReady(appointmentId: string, actorId?: string) {
+  await logNotification('appointment_pickup_ready', { appointmentId, actorId });
+}

--- a/src/server/scheduling/schemas.ts
+++ b/src/server/scheduling/schemas.ts
@@ -1,0 +1,118 @@
+import { z } from 'zod';
+
+export const appointmentStatuses = [
+  'booked',
+  'checked_in',
+  'in_progress',
+  'completed',
+  'canceled',
+  'no_show',
+] as const;
+
+export const appointmentStatusSchema = z.enum(appointmentStatuses);
+
+export const slotQuerySchema = z.object({
+  staffId: z.string().uuid().optional(),
+  serviceId: z.string().uuid(),
+  from: z.coerce.date(),
+  to: z.coerce.date(),
+});
+
+export const createAppointmentSchema = z
+  .object({
+    staffId: z.string().uuid(),
+    clientId: z.string().uuid(),
+    petId: z.string().uuid().optional(),
+    serviceId: z.string().uuid(),
+    startsAt: z.coerce.date(),
+    addOnIds: z.array(z.string().uuid()).default([]),
+    discount: z.coerce.number().min(0).default(0),
+    tax: z.coerce.number().min(0).default(0),
+    status: appointmentStatusSchema.optional(),
+    notes: z
+      .string()
+      .max(5000)
+      .optional(),
+    createdBy: z.string().uuid().optional(),
+    durationMin: z.number().int().positive().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.addOnIds.length !== new Set(data.addOnIds).size) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Duplicate add-on ids are not allowed',
+        path: ['addOnIds'],
+      });
+    }
+  });
+
+export const updateAppointmentSchema = z
+  .object({
+    status: appointmentStatusSchema.optional(),
+    discount: z.coerce.number().min(0).optional(),
+    tax: z.coerce.number().min(0).optional(),
+    notes: z
+      .string()
+      .max(5000)
+      .optional(),
+  })
+  .refine((payload) => Object.keys(payload).length > 0, {
+    message: 'At least one field must be provided',
+  });
+
+export const cancelAppointmentSchema = z.object({
+  id: z.string().uuid(),
+  reason: z
+    .string()
+    .max(500)
+    .optional(),
+});
+
+export const listDaySchema = z.object({
+  date: z.coerce.date(),
+  staffId: z.string().uuid().optional(),
+});
+
+export const listWeekSchema = z.object({
+  weekStart: z.coerce.date(),
+  staffId: z.string().uuid().optional(),
+});
+
+export const rescheduleLinkSchema = z.object({
+  appointmentId: z.string().uuid(),
+  ttlHours: z.number().int().positive().optional(),
+  createdBy: z.string().uuid().optional(),
+});
+
+export const applyRescheduleSchema = z.object({
+  token: z.string().min(10),
+  newSlot: z.object({
+    serviceId: z.string().uuid(),
+    staffId: z.string().uuid().optional(),
+    startsAt: z.coerce.date(),
+  }),
+});
+
+export const registerPushTokenSchema = z.object({
+  userId: z.string().uuid(),
+  platform: z.enum(['web', 'ios', 'android']),
+  token: z.string().min(16),
+});
+
+export const appointmentIdSchema = z.object({
+  appointmentId: z.string().uuid(),
+  actorId: z.string().uuid().optional(),
+  notes: z.string().optional(),
+});
+
+export type SlotQueryInput = z.infer<typeof slotQuerySchema>;
+export type CreateAppointmentInput = z.infer<typeof createAppointmentSchema>;
+export type UpdateAppointmentInput = z.infer<typeof updateAppointmentSchema>;
+export type CancelAppointmentInput = z.infer<typeof cancelAppointmentSchema>;
+export type ListDayInput = z.infer<typeof listDaySchema>;
+export type ListWeekInput = z.infer<typeof listWeekSchema>;
+export type RescheduleLinkInput = z.infer<typeof rescheduleLinkSchema>;
+export type ApplyRescheduleInput = z.infer<typeof applyRescheduleSchema>;
+export type RegisterPushTokenInput = z.infer<typeof registerPushTokenSchema>;
+export type AppointmentIdInput = z.infer<typeof appointmentIdSchema>;
+export type AppointmentStatus = (typeof appointmentStatuses)[number];

--- a/src/server/scheduling/slots.ts
+++ b/src/server/scheduling/slots.ts
@@ -1,0 +1,246 @@
+import { rrulestr, type RRuleSet } from 'rrule';
+import { getSupabaseAdmin } from '@/lib/supabase/server';
+import type { SlotQueryInput } from './schemas';
+import { slotQuerySchema } from './schemas';
+import type { AppointmentRow, AvailabilityRuleRow, BlackoutRow, ServiceRow } from './types';
+import { MINUTE, addMinutes, toDate } from './utils';
+const ACTIVE_APPOINTMENT_STATUSES = new Set([
+  'booked',
+  'checked_in',
+  'in_progress',
+  'completed',
+]);
+
+export interface AvailableSlot {
+  staffId: string;
+  start: Date;
+  end: Date;
+}
+
+type Interval = { start: Date; end: Date };
+
+function roundUpToInterval(date: Date, intervalMinutes: number): Date {
+  const ms = intervalMinutes * MINUTE;
+  return new Date(Math.ceil(date.getTime() / ms) * ms);
+}
+
+function parseICalDate(raw: string | undefined | null): Date | null {
+  if (!raw) return null;
+  const [, value] = raw.split(':', 2);
+  const actual = value ?? raw;
+  if (actual.endsWith('Z')) return new Date(actual);
+  const match = actual.match(/^(\d{4})(\d{2})(\d{2})T?(\d{2})(\d{2})(\d{2})?$/);
+  if (match) {
+    const [, y, m, d, hh, mm, ss] = match;
+    const iso = `${y}-${m}-${d}T${hh}:${mm}:${ss ?? '00'}`;
+    return new Date(iso);
+  }
+  return new Date(actual);
+}
+
+function parseISODurationMinutes(input: string): number | null {
+  const match = input.match(/P(?:(\d+)D)?(?:T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?)?/);
+  if (!match) return null;
+  const [, days, hours, minutes, seconds] = match;
+  const total =
+    (days ? Number.parseInt(days, 10) * 24 * 60 : 0) +
+    (hours ? Number.parseInt(hours, 10) * 60 : 0) +
+    (minutes ? Number.parseInt(minutes, 10) : 0) +
+    (seconds ? Math.ceil(Number.parseInt(seconds, 10) / 60) : 0);
+  return Number.isFinite(total) && total > 0 ? total : null;
+}
+
+function extractDurationMinutes(rruleText: string): number | null {
+  const custom = rruleText.match(/X-[A-Z-]*DURATION-MINUTES:(\d+)/i);
+  if (custom) return Number.parseInt(custom[1], 10);
+  const durationLine = rruleText.match(/DURATION:([^\n]+)/i);
+  if (durationLine) {
+    const duration = parseISODurationMinutes(durationLine[1].trim());
+    if (duration) return duration;
+  }
+  const dtStartLine = rruleText.match(/DTSTART[^:]*:([^\n]+)/i);
+  const dtEndLine = rruleText.match(/DTEND[^:]*:([^\n]+)/i);
+  if (dtStartLine && dtEndLine) {
+    const start = parseICalDate(dtStartLine[0].split(':')[1]);
+    const end = parseICalDate(dtEndLine[0].split(':')[1]);
+    if (start && end) {
+      const diffMin = Math.floor((end.getTime() - start.getTime()) / MINUTE);
+      if (diffMin > 0) return diffMin;
+    }
+  }
+  return null;
+}
+
+function ensurePositiveDuration(durationMin: number | null | undefined, fallback: number): number {
+  return durationMin && durationMin > 0 ? durationMin : fallback;
+}
+
+function intervalsOverlap(a: Interval, b: Interval): boolean {
+  return a.start < b.end && b.start < a.end;
+}
+
+function normaliseIntervals(intervals: Interval[]): Interval[] {
+  const sorted = intervals
+    .map((interval) => ({ start: new Date(interval.start), end: new Date(interval.end) }))
+    .filter((interval) => interval.end > interval.start)
+    .sort((a, b) => a.start.getTime() - b.start.getTime());
+  const merged: Interval[] = [];
+  for (const interval of sorted) {
+    const last = merged[merged.length - 1];
+    if (!last || interval.start.getTime() > last.end.getTime()) {
+      merged.push(interval);
+    } else {
+      last.end = new Date(Math.max(last.end.getTime(), interval.end.getTime()));
+    }
+  }
+  return merged;
+}
+
+function expandAvailability(
+  rule: AvailabilityRuleRow,
+  windowStart: Date,
+  windowEnd: Date,
+  defaultDuration: number,
+): Interval[] {
+  const durationMin = ensurePositiveDuration(extractDurationMinutes(rule.rrule_text), defaultDuration);
+  let schedule: RRuleSet;
+  try {
+    schedule = rrulestr(rule.rrule_text, { forceset: true }) as RRuleSet;
+  } catch (error) {
+    console.warn('Failed to parse availability rule', rule.id, error);
+    return [];
+  }
+  const lookBehindMs = durationMin * MINUTE;
+  const occurrences = schedule.between(new Date(windowStart.getTime() - lookBehindMs), windowEnd, true);
+  return occurrences.map((start) => ({
+    start,
+    end: addMinutes(start, durationMin),
+  }));
+}
+
+function buildBusyIntervals(
+  appointments: AppointmentRow[],
+  blackouts: BlackoutRow[],
+  serviceBuffers: { pre: number; post: number },
+): Map<string, Interval[]> {
+  const map = new Map<string, Interval[]>();
+  const extend = (staffId: string, interval: Interval) => {
+    if (!map.has(staffId)) map.set(staffId, []);
+    map.get(staffId)!.push(interval);
+  };
+  for (const blackout of blackouts) {
+    extend(blackout.staff_id, {
+      start: toDate(blackout.starts_at),
+      end: toDate(blackout.ends_at),
+    });
+  }
+  for (const appt of appointments) {
+    if (!appt.staff_id) continue;
+    if (!appt.status || !ACTIVE_APPOINTMENT_STATUSES.has(appt.status)) continue;
+    const start = addMinutes(toDate(appt.starts_at), -serviceBuffers.pre);
+    const end = addMinutes(toDate(appt.ends_at), serviceBuffers.post);
+    extend(appt.staff_id, { start, end });
+  }
+  for (const [staffId, intervals] of map) {
+    map.set(staffId, normaliseIntervals(intervals));
+  }
+  return map;
+}
+
+function slotOverlapsBusy(slot: Interval, busy: Interval[]): boolean {
+  for (const interval of busy) {
+    if (intervalsOverlap(slot, interval)) return true;
+  }
+  return false;
+}
+
+export async function listSlots(rawInput: SlotQueryInput): Promise<AvailableSlot[]> {
+  const input = slotQuerySchema.parse(rawInput);
+  const { staffId, serviceId, from, to } = input;
+  if (from >= to) return [];
+
+  const supabase = getSupabaseAdmin();
+  const [{ data: serviceRecord, error: serviceError }] = await Promise.all([
+    supabase
+      .from('services')
+      .select('id, base_price, duration_min, buffer_pre_min, buffer_post_min')
+      .eq('id', serviceId)
+      .maybeSingle(),
+  ]);
+
+  if (serviceError) throw serviceError;
+  const service = serviceRecord as ServiceRow | null;
+  if (!service) return [];
+
+  const serviceDuration = ensurePositiveDuration(service.duration_min, 60);
+  const serviceBuffers = {
+    pre: service.buffer_pre_min ?? 0,
+    post: service.buffer_post_min ?? 0,
+  };
+
+  const availabilityQuery = supabase
+    .from('availability_rules')
+    .select('id, staff_id, rrule_text, tz, buffer_pre_min, buffer_post_min');
+  if (staffId) availabilityQuery.eq('staff_id', staffId);
+  const blackoutQuery = supabase
+    .from('blackout_dates')
+    .select('staff_id, starts_at, ends_at')
+    .lte('starts_at', to.toISOString())
+    .gte('ends_at', from.toISOString());
+  if (staffId) blackoutQuery.eq('staff_id', staffId);
+  const appointmentsQuery = supabase
+    .from('appointments')
+    .select('id, staff_id, starts_at, ends_at, status')
+    .lte('starts_at', to.toISOString())
+    .gte('ends_at', from.toISOString());
+  if (staffId) appointmentsQuery.eq('staff_id', staffId);
+
+  const [{ data: availabilityRules, error: availabilityError }, { data: blackoutDates, error: blackoutError }, { data: appointments, error: appointmentsError }]
+    = await Promise.all([availabilityQuery, blackoutQuery, appointmentsQuery]);
+
+  if (availabilityError) throw availabilityError;
+  if (blackoutError) throw blackoutError;
+  if (appointmentsError) throw appointmentsError;
+
+  if (!availabilityRules || availabilityRules.length === 0) return [];
+
+  const busyMap = buildBusyIntervals(appointments ?? [], blackoutDates ?? [], serviceBuffers);
+  const slots: AvailableSlot[] = [];
+
+  for (const rule of availabilityRules) {
+    const staff = rule.staff_id;
+    const windowIntervals = expandAvailability(rule, from, to, Math.max(serviceDuration + serviceBuffers.pre + serviceBuffers.post, 60));
+    const busyIntervals = busyMap.get(staff) ?? [];
+    const rulePre = rule.buffer_pre_min ?? 0;
+    const rulePost = rule.buffer_post_min ?? 0;
+
+    for (const window of windowIntervals) {
+      const earliestAllowed = addMinutes(window.start, rulePre);
+      const latestAllowed = addMinutes(window.end, -rulePost);
+      if (latestAllowed <= earliestAllowed) continue;
+
+      let candidate = roundUpToInterval(new Date(Math.max(earliestAllowed.getTime(), from.getTime())), 15);
+      while (candidate < to) {
+        const slotStart = candidate;
+        const slotEnd = addMinutes(slotStart, serviceDuration);
+        const blockStart = addMinutes(slotStart, -serviceBuffers.pre);
+        const blockEnd = addMinutes(slotEnd, serviceBuffers.post);
+        if (blockStart < earliestAllowed || blockEnd > latestAllowed) {
+          candidate = addMinutes(candidate, 15);
+          continue;
+        }
+        if (slotEnd > to || slotStart < from) {
+          candidate = addMinutes(candidate, 15);
+          continue;
+        }
+        const slotInterval: Interval = { start: blockStart, end: blockEnd };
+        if (!slotOverlapsBusy(slotInterval, busyIntervals)) {
+          slots.push({ staffId: staff, start: slotStart, end: slotEnd });
+        }
+        candidate = addMinutes(candidate, 15);
+      }
+    }
+  }
+
+  return slots.sort((a, b) => a.start.getTime() - b.start.getTime());
+}

--- a/src/server/scheduling/types.ts
+++ b/src/server/scheduling/types.ts
@@ -1,0 +1,59 @@
+export type AvailabilityRuleRow = {
+  id: string;
+  staff_id: string;
+  rrule_text: string;
+  tz: string | null;
+  buffer_pre_min: number | null;
+  buffer_post_min: number | null;
+};
+
+export type BlackoutRow = {
+  id?: string;
+  staff_id: string;
+  starts_at: string;
+  ends_at: string;
+};
+
+export type AppointmentRow = {
+  id: string;
+  staff_id: string | null;
+  client_id?: string | null;
+  pet_id?: string | null;
+  service_id?: string | null;
+  starts_at: string;
+  ends_at: string;
+  price_service?: number | null;
+  price_addons?: number | null;
+  discount?: number | null;
+  tax?: number | null;
+  status: string | null;
+  notes?: string | null;
+  created_by?: string | null;
+};
+
+export type ServiceRow = {
+  id: string;
+  name?: string | null;
+  base_price: number;
+  duration_min?: number | null;
+  buffer_pre_min?: number | null;
+  buffer_post_min?: number | null;
+};
+
+export type AddOnRow = {
+  id: string;
+  name?: string | null;
+  price: number;
+};
+
+export type RescheduleLinkRow = {
+  id: string;
+  appointment_id: string;
+  token: string;
+  expires_at: string | null;
+  used_at: string | null;
+};
+
+export type AppointmentWithServiceRow = AppointmentRow & {
+  services: ServiceRow | null;
+};

--- a/src/server/scheduling/utils.ts
+++ b/src/server/scheduling/utils.ts
@@ -1,0 +1,20 @@
+export const MINUTE = 60 * 1000;
+
+export function toDate(value: string | Date): Date {
+  return value instanceof Date ? new Date(value.getTime()) : new Date(value);
+}
+
+export function addMinutes(base: Date, minutes: number): Date {
+  return new Date(base.getTime() + minutes * MINUTE);
+}
+
+export function differenceInMinutes(a: Date, b: Date): number {
+  return Math.round((a.getTime() - b.getTime()) / MINUTE);
+}
+
+export function clampDate(value: Date, { min, max }: { min?: Date; max?: Date }): Date {
+  let time = value.getTime();
+  if (min && time < min.getTime()) time = min.getTime();
+  if (max && time > max.getTime()) time = max.getTime();
+  return new Date(time);
+}


### PR DESCRIPTION
## Summary
- implement scheduling slot calculation, appointment management, and commission helpers on the server
- add deep-link reschedule helpers and push notification stubs built on audit logging
- introduce zod schemas and utilities supporting the scheduling service APIs

## Testing
- npm run lint
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4776e573083249b7c6f96652804a6