### PR TITLE
Wire appointment communications controls in appointment drawer

### DIFF
--- a/app/api/appointments/reschedule-link/route.ts
+++ b/app/api/appointments/reschedule-link/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { z } from "zod";
+
+import { createRescheduleLink } from "../../../../src/server/scheduling";
+
+const payloadSchema = z.object({
+  appointmentId: z.string().uuid(),
+});
+
+export async function POST(req: Request) {
+  const supabase = createRouteHandlerClient({ cookies });
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 });
+  }
+
+  const parsed = payloadSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  try {
+    const link = await createRescheduleLink({
+      appointmentId: parsed.data.appointmentId,
+      createdBy: session.user.id,
+    });
+
+    return NextResponse.json({ data: link });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to create reschedule link";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/app/api/notifications/send-pickup/route.ts
+++ b/app/api/notifications/send-pickup/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { z } from "zod";
+
+import { sendPickupReady } from "../../../../src/server/scheduling";
+
+const payloadSchema = z.object({
+  appointmentId: z.string().uuid(),
+});
+
+export async function POST(req: Request) {
+  const supabase = createRouteHandlerClient({ cookies });
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 });
+  }
+
+  const parsed = payloadSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  try {
+    await sendPickupReady(parsed.data.appointmentId, session.user.id);
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to send pickup notification";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/app/api/notifications/send-reminder/route.ts
+++ b/app/api/notifications/send-reminder/route.ts
@@ -1,0 +1,41 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { z } from "zod";
+
+import { sendReminder } from "../../../../src/server/scheduling";
+
+const payloadSchema = z.object({
+  appointmentId: z.string().uuid(),
+});
+
+export async function POST(req: Request) {
+  const supabase = createRouteHandlerClient({ cookies });
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid JSON payload" }, { status: 400 });
+  }
+
+  const parsed = payloadSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid request" }, { status: 400 });
+  }
+
+  try {
+    await sendReminder(parsed.data.appointmentId, session.user.id);
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Failed to send reminder";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/hooks/useAppointmentNotificationActions.ts
+++ b/hooks/useAppointmentNotificationActions.ts
@@ -1,0 +1,181 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { fetchLatestAuditTimestamp, type AuditLogAction } from "@/lib/audit-log";
+
+type ActionKey = "reminder" | "pickup" | "reschedule";
+
+type ActionResult = {
+  ok: boolean;
+  message?: string;
+  url?: string;
+  copied?: boolean;
+};
+
+type LastSentState = Record<ActionKey, Date | null>;
+
+const AUDIT_ACTIONS: Record<ActionKey, AuditLogAction> = {
+  reminder: "appointment_reminder_queued",
+  pickup: "appointment_pickup_ready",
+  reschedule: "appointment_reschedule_link_created",
+};
+
+const INITIAL_TIMESTAMPS: LastSentState = {
+  reminder: null,
+  pickup: null,
+  reschedule: null,
+};
+
+async function parseResponse(response: Response) {
+  const text = await response.text();
+  if (!text) {
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+    return {};
+  }
+
+  try {
+    const json = JSON.parse(text);
+    if (!response.ok) {
+      const message = typeof json?.error === "string" ? json.error : undefined;
+      throw new Error(message ?? `Request failed with status ${response.status}`);
+    }
+    return json;
+  } catch (error) {
+    if (!response.ok) {
+      throw new Error(`Request failed with status ${response.status}`);
+    }
+    throw error;
+  }
+}
+
+export function useAppointmentNotificationActions(appointmentId: string | null) {
+  const [loadingAction, setLoadingAction] = useState<ActionKey | null>(null);
+  const [lastSent, setLastSent] = useState<LastSentState>(INITIAL_TIMESTAMPS);
+  const [fetching, setFetching] = useState(false);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+
+  const canQuery = useMemo(() => Boolean(appointmentId), [appointmentId]);
+
+  const refreshTimestamps = useCallback(async () => {
+    if (!appointmentId) {
+      setLastSent(INITIAL_TIMESTAMPS);
+      setFetchError(null);
+      return;
+    }
+
+    setFetching(true);
+    try {
+      const [reminder, pickup, reschedule] = await Promise.all([
+        fetchLatestAuditTimestamp(appointmentId, AUDIT_ACTIONS.reminder).catch(() => null),
+        fetchLatestAuditTimestamp(appointmentId, AUDIT_ACTIONS.pickup).catch(() => null),
+        fetchLatestAuditTimestamp(appointmentId, AUDIT_ACTIONS.reschedule).catch(() => null),
+      ]);
+      setLastSent({ reminder, pickup, reschedule });
+      setFetchError(null);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to load activity";
+      setFetchError(message);
+    } finally {
+      setFetching(false);
+    }
+  }, [appointmentId]);
+
+  useEffect(() => {
+    if (!canQuery) {
+      setLastSent(INITIAL_TIMESTAMPS);
+      setFetchError(null);
+      return;
+    }
+    void refreshTimestamps();
+  }, [canQuery, refreshTimestamps]);
+
+  const sendReminder = useCallback(async (): Promise<ActionResult> => {
+    if (!appointmentId) {
+      return { ok: false, message: "Appointment is not saved yet" };
+    }
+    setLoadingAction("reminder");
+    try {
+      const response = await fetch("/api/notifications/send-reminder", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ appointmentId }),
+      });
+      await parseResponse(response);
+      await refreshTimestamps();
+      return { ok: true };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to send reminder";
+      return { ok: false, message };
+    } finally {
+      setLoadingAction((current) => (current === "reminder" ? null : current));
+    }
+  }, [appointmentId, refreshTimestamps]);
+
+  const sendPickupReady = useCallback(async (): Promise<ActionResult> => {
+    if (!appointmentId) {
+      return { ok: false, message: "Appointment is not saved yet" };
+    }
+    setLoadingAction("pickup");
+    try {
+      const response = await fetch("/api/notifications/send-pickup", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ appointmentId }),
+      });
+      await parseResponse(response);
+      await refreshTimestamps();
+      return { ok: true };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to send pickup alert";
+      return { ok: false, message };
+    } finally {
+      setLoadingAction((current) => (current === "pickup" ? null : current));
+    }
+  }, [appointmentId, refreshTimestamps]);
+
+  const createReschedule = useCallback(async (): Promise<ActionResult> => {
+    if (!appointmentId) {
+      return { ok: false, message: "Appointment is not saved yet" };
+    }
+    setLoadingAction("reschedule");
+    try {
+      const response = await fetch("/api/appointments/reschedule-link", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ appointmentId }),
+      });
+      const json = await parseResponse(response);
+      const url: string | undefined = json?.data?.url ?? json?.url;
+      let copied = false;
+      if (url && typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+        try {
+          await navigator.clipboard.writeText(url);
+          copied = true;
+        } catch (error) {
+          copied = false;
+        }
+      }
+      await refreshTimestamps();
+      return { ok: true, url, copied, message: copied ? undefined : url ? "Copy to clipboard failed" : undefined };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Failed to create reschedule link";
+      return { ok: false, message };
+    } finally {
+      setLoadingAction((current) => (current === "reschedule" ? null : current));
+    }
+  }, [appointmentId, refreshTimestamps]);
+
+  return {
+    lastSent,
+    loadingAction,
+    fetching,
+    fetchError,
+    refreshTimestamps,
+    sendReminder,
+    sendPickupReady,
+    createReschedule,
+  };
+}

--- a/lib/audit-log.ts
+++ b/lib/audit-log.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { supabase } from "@/lib/supabase/client";
+
+export type AuditLogAction =
+  | "appointment_reminder_queued"
+  | "appointment_pickup_ready"
+  | "appointment_reschedule_link_created";
+
+type AuditLogRow = {
+  created_at: string | null;
+};
+
+export async function fetchLatestAuditTimestamp(
+  appointmentId: string,
+  action: AuditLogAction
+): Promise<Date | null> {
+  const { data, error } = await supabase
+    .from("audit_log")
+    .select("created_at")
+    .eq("entity", "appointments")
+    .eq("entity_id", appointmentId)
+    .eq("action", action)
+    .order("created_at", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message ?? "Failed to load audit log");
+  }
+
+  const row = data as AuditLogRow | null;
+  if (!row || !row.created_at) {
+    return null;
+  }
+
+  return new Date(row.created_at);
+}

--- a/src/server/scheduling/links.ts
+++ b/src/server/scheduling/links.ts
@@ -83,6 +83,13 @@ export async function createRescheduleLink(rawInput: RescheduleLinkInput) {
     }
     if (error) throw error;
     if (data) {
+      const { error: auditError } = await supabase.from('audit_log').insert({
+        actor_id: input.createdBy ?? null,
+        action: 'appointment_reschedule_link_created',
+        entity: 'appointments',
+        entity_id: input.appointmentId,
+      });
+      if (auditError) throw auditError;
       return {
         token,
         url: buildRescheduleUrl(token),

--- a/types/rrule.d.ts
+++ b/types/rrule.d.ts
@@ -1,0 +1,7 @@
+declare module "rrule" {
+  export type RRuleSet = {
+    between: (after: Date, before: Date, inc?: boolean) => Date[];
+  };
+
+  export function rrulestr(rrule: string, options?: { forceset?: boolean }): RRuleSet;
+}


### PR DESCRIPTION
## Summary
- add API endpoints for sending reminder/pickup notifications and creating reschedule links
- add client hook to trigger notification actions and surface audit-log timestamps
- enhance appointment detail drawer with gated action buttons, toast feedback, and audit fetches
- log reschedule link creation in the audit log and stub rrule types for type safety

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d47d1a9de48324b1707f04b854d540