### PR TITLE
Implement client reschedule flow and tests

### DIFF
--- a/app/api/reschedule/apply/route.ts
+++ b/app/api/reschedule/apply/route.ts
@@ -1,0 +1,99 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { applyReschedule } from "@/server/scheduling";
+import { getSupabaseAdmin } from "@/lib/supabase/server";
+
+const payloadSchema = z.object({
+  token: z.string().min(10, "Missing reschedule token"),
+  starts_at: z.string(),
+  staff_id: z.string().uuid().optional(),
+  service_id: z.string().uuid().optional(),
+});
+
+function parseStart(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new Error("Invalid start time provided");
+  }
+  return date;
+}
+
+async function resolveServiceId(token: string): Promise<{ serviceId: string; staffId: string | null } | null> {
+  const admin = getSupabaseAdmin();
+  const { data: linkRow, error: linkError } = await admin
+    .from("reschedule_links")
+    .select("appointment_id")
+    .eq("token", token)
+    .maybeSingle();
+  if (linkError) throw linkError;
+  const link = linkRow as { appointment_id: string } | null;
+  if (!link) {
+    return null;
+  }
+  const { data: appointmentRow, error: appointmentError } = await admin
+    .from("appointments")
+    .select("service_id, staff_id")
+    .eq("id", link.appointment_id)
+    .maybeSingle();
+  if (appointmentError) throw appointmentError;
+  const appointment = appointmentRow as { service_id: string | null; staff_id: string | null } | null;
+  if (!appointment?.service_id) {
+    return null;
+  }
+  return { serviceId: appointment.service_id, staffId: appointment.staff_id ?? null };
+}
+
+function normaliseErrorStatus(message: string) {
+  if (/not found|missing|expired|already been used|available/i.test(message)) {
+    return 400;
+  }
+  return 500;
+}
+
+export async function POST(request: Request) {
+  try {
+    const raw = await request.json();
+    const payload = payloadSchema.parse(raw);
+    const startsAt = parseStart(payload.starts_at);
+
+    let serviceId = payload.service_id;
+    let defaultStaffId: string | null = null;
+
+    if (!serviceId) {
+      const resolved = await resolveServiceId(payload.token);
+      if (!resolved) {
+        return NextResponse.json(
+          { error: "Reschedule link could not be located." },
+          { status: 404 },
+        );
+      }
+      serviceId = resolved.serviceId;
+      defaultStaffId = resolved.staffId;
+    }
+
+    const result = await applyReschedule({
+      token: payload.token,
+      newSlot: {
+        serviceId,
+        staffId: payload.staff_id ?? defaultStaffId ?? undefined,
+        startsAt,
+      },
+    });
+
+    return NextResponse.json({ appointment: result });
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      const first = error.issues[0];
+      return NextResponse.json(
+        { error: first?.message ?? "Invalid request" },
+        { status: 400 },
+      );
+    }
+    console.error("Failed to apply reschedule", error);
+    const message = error instanceof Error ? error.message : "Unable to reschedule appointment.";
+    return NextResponse.json(
+      { error: message },
+      { status: normaliseErrorStatus(message) },
+    );
+  }
+}

--- a/app/client/page.tsx
+++ b/app/client/page.tsx
@@ -1,12 +1,179 @@
 import Link from "next/link";
+import { redirect } from "next/navigation";
+import { createClient, getSupabaseAdmin } from "@/lib/supabase/server";
 
-export default function ClientHome() {
+const dateTimeFormatter = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "full",
+  timeStyle: "short",
+});
+
+interface AppointmentSummary {
+  id: string;
+  startsAt: string;
+  endsAt: string;
+  serviceName: string | null;
+  staffName: string | null;
+  rescheduleToken: string | null;
+}
+
+async function loadNextAppointment(userId: string): Promise<AppointmentSummary | null> {
+  const admin = getSupabaseAdmin();
+  const nowIso = new Date().toISOString();
+
+  const { data: appointmentRow, error: appointmentError } = await admin
+    .from("appointments")
+    .select("id, starts_at, ends_at, service_id, staff_id")
+    .eq("client_id", userId)
+    .gte("starts_at", nowIso)
+    .order("starts_at", { ascending: true })
+    .limit(1)
+    .maybeSingle();
+
+  if (appointmentError) throw appointmentError;
+
+  const appointment = appointmentRow as
+    | {
+        id: string;
+        starts_at: string;
+        ends_at: string;
+        service_id: string | null;
+        staff_id: string | null;
+      }
+    | null;
+
+  if (!appointment) {
+    return null;
+  }
+
+  let serviceName: string | null = null;
+  if (appointment.service_id) {
+    const { data: serviceRow, error: serviceError } = await admin
+      .from("services")
+      .select("name")
+      .eq("id", appointment.service_id)
+      .maybeSingle();
+    if (serviceError) throw serviceError;
+    const service = serviceRow as { name: string | null } | null;
+    serviceName = service?.name ?? null;
+  }
+
+  let staffName: string | null = null;
+  if (appointment.staff_id) {
+    const { data: staffRow, error: staffError } = await admin
+      .from("profiles")
+      .select("full_name")
+      .eq("id", appointment.staff_id)
+      .maybeSingle();
+    if (staffError) throw staffError;
+    const staff = staffRow as { full_name: string | null } | null;
+    staffName = staff?.full_name ?? null;
+  }
+
+  const { data: linkRow, error: linkError } = await admin
+    .from("reschedule_links")
+    .select("token, expires_at, used_at")
+    .eq("appointment_id", appointment.id)
+    .order("expires_at", { ascending: true })
+    .limit(1)
+    .maybeSingle();
+
+  if (linkError) throw linkError;
+
+  const link = linkRow as { token: string; expires_at: string | null; used_at: string | null } | null;
+  let rescheduleToken: string | null = null;
+  if (link && !link.used_at) {
+    if (!link.expires_at || new Date(link.expires_at).getTime() > Date.now()) {
+      rescheduleToken = link.token;
+    }
+  }
+
+  return {
+    id: appointment.id,
+    startsAt: appointment.starts_at,
+    endsAt: appointment.ends_at,
+    serviceName,
+    staffName,
+    rescheduleToken,
+  };
+}
+
+function formatDateTime(iso: string): string {
+  return dateTimeFormatter.format(new Date(iso));
+}
+
+export default async function ClientHome() {
+  const supabase = createClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    redirect("/login");
+  }
+
+  let upcoming: AppointmentSummary | null = null;
+  let loadError: string | null = null;
+
+  try {
+    upcoming = await loadNextAppointment(session.user.id);
+  } catch (error) {
+    console.error("Failed to load next appointment", error);
+    loadError = "We couldn't load your upcoming appointment just now.";
+  }
+
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-6 px-6 py-10">
       <h1 className="text-3xl font-semibold text-white">Welcome back!</h1>
       <p className="text-sm text-white/80">
         From here you can review your upcoming grooming appointments or update your personal details.
       </p>
+
+      {loadError ? (
+        <div className="rounded-2xl border border-red-500/40 bg-red-500/10 px-6 py-5 text-sm text-red-100">
+          {loadError}
+        </div>
+      ) : upcoming ? (
+        <div className="rounded-2xl border border-white/10 bg-white/5 px-6 py-5 text-white">
+          <h2 className="text-lg font-semibold">Next appointment</h2>
+          <p className="mt-2 text-sm text-white/80">{formatDateTime(upcoming.startsAt)}</p>
+          {upcoming.serviceName && (
+            <p className="mt-1 text-sm text-white/70">Service: {upcoming.serviceName}</p>
+          )}
+          {upcoming.staffName && (
+            <p className="mt-1 text-sm text-white/70">With: {upcoming.staffName}</p>
+          )}
+          <div className="mt-4 flex flex-wrap gap-3">
+            <Link
+              href="/client/appointments"
+              className="inline-flex items-center rounded-full border border-white/20 px-4 py-2 text-sm font-semibold transition hover:border-white/40 hover:bg-white/10"
+            >
+              View details
+            </Link>
+            {upcoming.rescheduleToken && (
+              <Link
+                href={`/client/reschedule?t=${encodeURIComponent(upcoming.rescheduleToken)}`}
+                className="inline-flex items-center rounded-full bg-white px-4 py-2 text-sm font-semibold text-brand-navy transition hover:bg-white/90"
+              >
+                Reschedule
+              </Link>
+            )}
+          </div>
+        </div>
+      ) : (
+        <div className="rounded-2xl border border-white/10 bg-white/5 px-6 py-5 text-white/80">
+          <h2 className="text-lg font-semibold text-white">No upcoming appointments</h2>
+          <p className="mt-2 text-sm">
+            When you book your next visit it will appear here. Need to make one now?
+          </p>
+          <Link
+            href="/book"
+            className="mt-4 inline-flex items-center rounded-full bg-white px-4 py-2 text-sm font-semibold text-brand-navy transition hover:bg-white/90"
+          >
+            Book an appointment
+          </Link>
+        </div>
+      )}
+
       <div className="grid gap-4 md:grid-cols-2">
         <Link
           href="/client/appointments"

--- a/app/client/reschedule/RescheduleForm.tsx
+++ b/app/client/reschedule/RescheduleForm.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import type { RescheduleReadyContext, SlotOption } from "./types";
+
+const slotTimeFormatter = new Intl.DateTimeFormat("en-US", {
+  weekday: "short",
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+});
+
+const confirmationFormatter = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "full",
+  timeStyle: "short",
+});
+
+function formatSlotLabel(slot: SlotOption) {
+  return slotTimeFormatter.format(new Date(slot.startIso));
+}
+
+function formatSuccessTime(iso: string) {
+  return confirmationFormatter.format(new Date(iso));
+}
+
+function findSlot(slots: SlotOption[], id: string | null) {
+  if (!id) return null;
+  return slots.find((slot) => slot.id === id) ?? null;
+}
+
+export default function RescheduleForm({ context }: { context: RescheduleReadyContext }) {
+  const { appointment, slots, token } = context;
+  const [selectedSlotId, setSelectedSlotId] = useState<string | null>(slots[0]?.id ?? null);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [success, setSuccess] = useState<{ startsAtIso: string; staffName: string | null } | null>(null);
+
+  const hasSlots = slots.length > 0;
+  const submitDisabled = !hasSlots || !selectedSlotId || submitting;
+
+  const selectedSlot = useMemo(() => findSlot(slots, selectedSlotId), [slots, selectedSlotId]);
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!selectedSlot) return;
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/reschedule/apply", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          token,
+          starts_at: selectedSlot.startIso,
+          staff_id: selectedSlot.staffId,
+          service_id: appointment.serviceId,
+        }),
+      });
+
+      const payload = await response.json().catch(() => ({ error: "Unexpected response from server." }));
+
+      if (!response.ok) {
+        setError(typeof payload.error === "string" ? payload.error : "Could not reschedule this appointment.");
+        setSubmitting(false);
+        return;
+      }
+
+      const newStartIso = (payload.appointment?.starts_at as string | undefined) ?? selectedSlot.startIso;
+      const newStaffName = selectedSlot.staffName ?? null;
+      setSuccess({ startsAtIso: newStartIso, staffName: newStaffName });
+    } catch (err) {
+      console.error("Reschedule submission failed", err);
+      setError("Something went wrong while rescheduling. Please try again.");
+      setSubmitting(false);
+    }
+  }
+
+  if (success) {
+    return (
+      <div className="mt-8 rounded-2xl border border-emerald-500/40 bg-emerald-500/10 px-6 py-5 text-sm text-emerald-100">
+        <p>
+          Your appointment has been moved to {formatSuccessTime(success.startsAtIso)}
+          {success.staffName ? ` with ${success.staffName}` : ""}.
+        </p>
+        <Link
+          href="/client"
+          className="mt-4 inline-flex items-center rounded-full bg-white px-4 py-2 text-sm font-semibold text-brand-navy transition hover:bg-white/90"
+        >
+          Back to Home
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="mt-8 space-y-6">
+      <div>
+        <h2 className="text-lg font-semibold">Choose a new time</h2>
+        <p className="mt-1 text-sm text-white/70">
+          Select one of the open time slots below and we&apos;ll update your booking instantly.
+        </p>
+      </div>
+
+      {error && (
+        <div className="rounded-2xl border border-red-500/40 bg-red-500/10 px-6 py-4 text-sm text-red-100">{error}</div>
+      )}
+
+      {hasSlots ? (
+        <div className="grid gap-3 md:grid-cols-2">
+          {slots.map((slot) => {
+            const isSelected = slot.id === selectedSlotId;
+            return (
+              <button
+                key={slot.id}
+                type="button"
+                onClick={() => setSelectedSlotId(slot.id)}
+                className={`rounded-2xl border px-4 py-3 text-left transition ${
+                  isSelected
+                    ? "border-white bg-white/20 text-white"
+                    : "border-white/20 bg-white/10 text-white/90 hover:border-white/40 hover:bg-white/20"
+                }`}
+              >
+                <span className="block text-sm font-semibold">{formatSlotLabel(slot)}</span>
+                <span className="mt-1 block text-xs text-white/70">With {slot.staffName}</span>
+              </button>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="rounded-2xl border border-white/10 bg-white/5 px-6 py-4 text-sm text-white/80">
+          We couldn&apos;t find any open slots in the next few weeks. Please contact the salon and we&apos;ll help you reschedule.
+        </div>
+      )}
+
+      <div className="flex flex-wrap gap-3">
+        <button
+          type="submit"
+          disabled={submitDisabled}
+          className={`inline-flex items-center rounded-full px-5 py-2 text-sm font-semibold transition ${
+            submitDisabled
+              ? "cursor-not-allowed border border-white/10 bg-white/10 text-white/50"
+              : "bg-white text-brand-navy hover:bg-white/90"
+          }`}
+        >
+          {submitting ? "Rescheduling…" : "Confirm new time"}
+        </button>
+        <Link
+          href="/client"
+          className="inline-flex items-center rounded-full border border-white/20 px-5 py-2 text-sm font-semibold text-white/80 transition hover:border-white/40 hover:bg-white/10"
+        >
+          Cancel
+        </Link>
+      </div>
+    </form>
+  );
+}

--- a/app/client/reschedule/page.tsx
+++ b/app/client/reschedule/page.tsx
@@ -1,0 +1,240 @@
+import Link from "next/link";
+import { redirect } from "next/navigation";
+import { createClient, getSupabaseAdmin } from "@/lib/supabase/server";
+import { listSlots } from "@/server/scheduling";
+import type { AvailableSlot } from "@/server/scheduling";
+import RescheduleForm from "./RescheduleForm";
+import type { RescheduleReadyContext, SlotOption } from "./types";
+
+const appointmentFormatter = new Intl.DateTimeFormat("en-US", {
+  dateStyle: "full",
+  timeStyle: "short",
+});
+
+type SearchParams = {
+  t?: string | string[];
+};
+
+type RescheduleContext = { status: "error"; message: string } | RescheduleReadyContext;
+
+const SLOT_WINDOW_DAYS = 30;
+
+function normaliseToken(raw: string | string[] | undefined): string | null {
+  if (!raw) return null;
+  if (Array.isArray(raw)) return raw[0] ?? null;
+  return raw;
+}
+
+function isExpired(expiresAt: string | null): boolean {
+  if (!expiresAt) return false;
+  return new Date(expiresAt).getTime() <= Date.now();
+}
+
+async function resolveStaffNames(ids: string[]): Promise<Map<string, string>> {
+  if (ids.length === 0) return new Map();
+  const admin = getSupabaseAdmin();
+  const { data, error } = await admin
+    .from("profiles")
+    .select("id, full_name")
+    .in("id", ids);
+  if (error) throw error;
+  const rows = (data as { id: string; full_name: string | null }[] | null) ?? [];
+  const map = new Map<string, string>();
+  for (const row of rows) {
+    map.set(row.id, row.full_name?.trim() || "Team Member");
+  }
+  return map;
+}
+
+async function loadRescheduleContext(token: string, userId: string): Promise<RescheduleContext> {
+  try {
+    const admin = getSupabaseAdmin();
+    const { data: linkRow, error: linkError } = await admin
+      .from("reschedule_links")
+      .select("id, appointment_id, token, expires_at, used_at")
+      .eq("token", token)
+      .maybeSingle();
+
+    if (linkError) throw linkError;
+
+    const link = linkRow as
+      | {
+          id: string;
+          appointment_id: string;
+          token: string;
+          expires_at: string | null;
+          used_at: string | null;
+        }
+      | null;
+
+    if (!link || link.used_at || isExpired(link.expires_at)) {
+      return {
+        status: "error",
+        message: "This reschedule link is no longer valid. Please request a new one from our team.",
+      };
+    }
+
+    const { data: appointmentRow, error: appointmentError } = await admin
+      .from("appointments")
+      .select("id, client_id, service_id, staff_id, starts_at, ends_at")
+      .eq("id", link.appointment_id)
+      .maybeSingle();
+
+    if (appointmentError) throw appointmentError;
+
+    const appointment = appointmentRow as
+      | {
+          id: string;
+          client_id: string | null;
+          service_id: string | null;
+          staff_id: string | null;
+          starts_at: string;
+          ends_at: string;
+        }
+      | null;
+
+    if (!appointment || appointment.client_id !== userId) {
+      return {
+        status: "error",
+        message: "We couldn't find an appointment that matches this reschedule request.",
+      };
+    }
+
+    if (!appointment.service_id) {
+      return {
+        status: "error",
+        message: "This appointment is missing its service details and can't be rescheduled online.",
+      };
+    }
+
+    const { data: serviceRow, error: serviceError } = await admin
+      .from("services")
+      .select("id, name")
+      .eq("id", appointment.service_id)
+      .maybeSingle();
+    if (serviceError) throw serviceError;
+    const service = serviceRow as { id: string; name: string | null } | null;
+
+    const now = new Date();
+    const from = now;
+    const to = new Date(now.getTime() + SLOT_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+
+    let slots: AvailableSlot[] = [];
+    try {
+      slots = await listSlots({
+        serviceId: appointment.service_id,
+        from,
+        to,
+      });
+    } catch (slotError) {
+      console.error("Failed to load reschedule slots", slotError);
+      slots = [];
+    }
+
+    const futureSlots = slots
+      .filter((slot) => slot.start.getTime() > now.getTime())
+      .sort((a, b) => a.start.getTime() - b.start.getTime());
+
+    const staffIds = new Set<string>();
+    if (appointment.staff_id) {
+      staffIds.add(appointment.staff_id);
+    }
+    for (const slot of futureSlots) {
+      staffIds.add(slot.staffId);
+    }
+
+    const staffMap = await resolveStaffNames([...staffIds]);
+
+    const slotOptions: SlotOption[] = futureSlots.slice(0, 60).map((slot) => ({
+      id: `${slot.staffId}-${slot.start.toISOString()}`,
+      staffId: slot.staffId,
+      staffName: staffMap.get(slot.staffId) ?? "Team Member",
+      startIso: slot.start.toISOString(),
+      endIso: slot.end.toISOString(),
+    }));
+
+    return {
+      status: "ready",
+      token,
+      appointment: {
+        id: appointment.id,
+        serviceId: appointment.service_id,
+        serviceName: service?.name ?? null,
+        startsAtIso: appointment.starts_at,
+        staffId: appointment.staff_id,
+        staffName: appointment.staff_id ? staffMap.get(appointment.staff_id) ?? "Team Member" : null,
+      },
+      slots: slotOptions,
+    };
+  } catch (error) {
+    console.error("Failed to prepare reschedule context", error);
+    return {
+      status: "error",
+      message: "We couldn't load this reschedule request. Please try again later.",
+    };
+  }
+}
+
+export default async function ClientReschedulePage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const token = normaliseToken(searchParams.t);
+  const supabase = createClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+
+  if (!session) {
+    const redirectTo = token ? `/client/reschedule?t=${encodeURIComponent(token)}` : "/client";
+    redirect(`/login?redirectTo=${encodeURIComponent(redirectTo)}`);
+  }
+
+  if (!token) {
+    return (
+      <div className="mx-auto max-w-3xl px-6 py-10">
+        <h1 className="text-3xl font-semibold text-white">Reschedule appointment</h1>
+        <div className="mt-6 rounded-2xl border border-red-500/40 bg-red-500/10 px-6 py-5 text-sm text-red-100">
+          We couldn't find that reschedule request. Please return to the client portal and try again.
+        </div>
+        <Link
+          href="/client"
+          className="mt-6 inline-flex items-center rounded-full bg-white px-4 py-2 text-sm font-semibold text-brand-navy transition hover:bg-white/90"
+        >
+          Back to Home
+        </Link>
+      </div>
+    );
+  }
+
+  const context = await loadRescheduleContext(token, session!.user.id);
+
+  if (context.status === "error") {
+    return (
+      <div className="mx-auto max-w-3xl px-6 py-10">
+        <h1 className="text-3xl font-semibold text-white">Reschedule appointment</h1>
+        <div className="mt-6 rounded-2xl border border-red-500/40 bg-red-500/10 px-6 py-5 text-sm text-red-100">
+          {context.message}
+        </div>
+        <Link
+          href="/client"
+          className="mt-6 inline-flex items-center rounded-full bg-white px-4 py-2 text-sm font-semibold text-brand-navy transition hover:bg-white/90"
+        >
+          Back to Home
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-6 py-10 text-white">
+      <h1 className="text-3xl font-semibold">Reschedule appointment</h1>
+      <p className="mt-2 text-sm text-white/80">
+        Currently booked for {appointmentFormatter.format(new Date(context.appointment.startsAtIso))}
+        {context.appointment.staffName ? ` with ${context.appointment.staffName}` : ""}.
+      </p>
+      <RescheduleForm context={context} />
+    </div>
+  );
+}

--- a/app/client/reschedule/types.ts
+++ b/app/client/reschedule/types.ts
@@ -1,0 +1,21 @@
+export type SlotOption = {
+  id: string;
+  staffId: string;
+  staffName: string;
+  startIso: string;
+  endIso: string;
+};
+
+export type RescheduleReadyContext = {
+  status: "ready";
+  token: string;
+  appointment: {
+    id: string;
+    serviceId: string;
+    serviceName: string | null;
+    startsAtIso: string;
+    staffId: string | null;
+    staffName: string | null;
+  };
+  slots: SlotOption[];
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react-beautiful-dnd": "^13.1.1",
         "react-dom": "^18.2.0",
         "rrule": "^2.8.1",
+        "server-only": "^0.0.1",
         "swr": "^2.3.6",
         "zod": "^4.1.9",
         "zustand": "^5.0.8"
@@ -6081,6 +6082,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/server-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/server-only/-/server-only-0.0.1.tgz",
+      "integrity": "sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==",
+      "license": "MIT"
     },
     "node_modules/set-cookie-parser": {
       "version": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^18.2.0",
     "rrule": "^2.8.1",
+    "server-only": "^0.0.1",
     "swr": "^2.3.6",
     "zod": "^4.1.9",
     "zustand": "^5.0.8"

--- a/src/server/scheduling/appointments.ts
+++ b/src/server/scheduling/appointments.ts
@@ -1,4 +1,4 @@
-import { getSupabaseAdmin } from '@/lib/supabase/server';
+import { getSupabaseAdmin } from '../../../lib/supabase/server';
 import {
   cancelAppointmentSchema,
   createAppointmentSchema,

--- a/src/server/scheduling/notifications.ts
+++ b/src/server/scheduling/notifications.ts
@@ -1,4 +1,4 @@
-import { getSupabaseAdmin } from '@/lib/supabase/server';
+import { getSupabaseAdmin } from '../../../lib/supabase/server';
 import {
   appointmentIdSchema,
   registerPushTokenSchema,

--- a/src/server/scheduling/slots.ts
+++ b/src/server/scheduling/slots.ts
@@ -1,5 +1,6 @@
-import { rrulestr, type RRuleSet } from 'rrule';
-import { getSupabaseAdmin } from '@/lib/supabase/server';
+import RRuleModule from 'rrule';
+import type { RRuleSet } from 'rrule';
+import { getSupabaseAdmin } from '../../../lib/supabase/server';
 import type { SlotQueryInput } from './schemas';
 import { slotQuerySchema } from './schemas';
 import type { AppointmentRow, AvailabilityRuleRow, BlackoutRow, ServiceRow } from './types';
@@ -49,6 +50,8 @@ function parseISODurationMinutes(input: string): number | null {
     (seconds ? Math.ceil(Number.parseInt(seconds, 10) / 60) : 0);
   return Number.isFinite(total) && total > 0 ? total : null;
 }
+
+const { rrulestr } = RRuleModule as { rrulestr: typeof import('rrule').rrulestr };
 
 function extractDurationMinutes(rruleText: string): number | null {
   const custom = rruleText.match(/X-[A-Z-]*DURATION-MINUTES:(\d+)/i);

--- a/tests/reschedule.test.ts
+++ b/tests/reschedule.test.ts
@@ -1,0 +1,254 @@
+import "tsconfig-paths/register";
+process.env.TS_NODE_TRANSPILE_ONLY = "1";
+process.env.NEXT_PUBLIC_SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL ?? "https://example.test";
+process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? "anon";
+process.env.SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "service-role";
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const TOKEN = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const SERVICE_ID = "11111111-1111-4111-8111-111111111111";
+const STAFF_ID = "22222222-2222-4222-8222-222222222222";
+const SLOT_START = new Date("2025-01-10T15:00:00.000Z");
+const FIXED_NOW = new Date("2024-01-01T12:00:00.000Z");
+
+type Row = Record<string, unknown> | null;
+
+type AvailableSlotStub = {
+  staffId: string;
+  start: Date;
+  end: Date;
+};
+
+interface StubConfig {
+  link?: Row;
+  appointment?: Row;
+  updatedAppointment?: Row;
+  appointmentError?: Error | null;
+  updatedError?: Error | null;
+  linkUpdateError?: Error | null;
+  auditError?: Error | null;
+}
+
+interface StubState {
+  appointmentUpdate?: Record<string, unknown>;
+  linkUpdate?: Record<string, unknown>;
+  auditPayload?: Record<string, unknown>;
+}
+
+function createSupabaseStub(config: StubConfig = {}) {
+  const state: StubState = {};
+  let appointmentCallCount = 0;
+
+  const supabase = {
+    from(table: string) {
+      if (table === "reschedule_links") {
+        return {
+          select() {
+            return this;
+          },
+          eq() {
+            return this;
+          },
+          async maybeSingle() {
+            return { data: config.link ?? null, error: null };
+          },
+          update(values: Record<string, unknown>) {
+            state.linkUpdate = values;
+            return {
+              eq() {
+                return Promise.resolve({ error: config.linkUpdateError ?? null });
+              },
+            };
+          },
+        };
+      }
+
+      if (table === "appointments") {
+        appointmentCallCount += 1;
+        if (appointmentCallCount === 1) {
+          return {
+            select() {
+              return this;
+            },
+            eq() {
+              return this;
+            },
+            async maybeSingle() {
+              if (config.appointmentError) {
+                return { data: null, error: config.appointmentError };
+              }
+              return { data: config.appointment ?? null, error: null };
+            },
+          };
+        }
+        return {
+          update(values: Record<string, unknown>) {
+            state.appointmentUpdate = values;
+            return {
+              eq() {
+                return {
+                  select() {
+                    return {
+                      async maybeSingle() {
+                        if (config.updatedError) {
+                          return { data: null, error: config.updatedError };
+                        }
+                        return { data: config.updatedAppointment ?? null, error: null };
+                      },
+                    };
+                  },
+                };
+              },
+            };
+          },
+        };
+      }
+
+      if (table === "audit_log") {
+        return {
+          async insert(values: Record<string, unknown>) {
+            state.auditPayload = values;
+            return { error: config.auditError ?? null };
+          },
+        };
+      }
+
+      throw new Error(`Unexpected table ${table}`);
+    },
+  };
+
+  return { supabase: supabase as unknown, state };
+}
+
+async function loadApplyRescheduleImpl() {
+  const module = await import("../src/server/scheduling/links");
+  return module.applyReschedule;
+}
+
+async function createApplyReschedule(
+  config: StubConfig,
+  slots: AvailableSlotStub[] | null,
+) {
+  const { supabase, state } = createSupabaseStub(config);
+  const fixedNow = FIXED_NOW;
+
+  async function listSlotsStub() {
+    if (slots === null) {
+      throw new Error("listSlots should not be called");
+    }
+    return slots;
+  }
+
+  const applyRescheduleImpl = await loadApplyRescheduleImpl();
+
+  async function applyReschedule(input: Parameters<typeof applyRescheduleImpl>[0]) {
+    return applyRescheduleImpl(input, {
+      getSupabaseAdmin: () => supabase as any,
+      listSlots: listSlotsStub,
+      now: () => fixedNow,
+    });
+  }
+
+  return { applyReschedule, state };
+}
+
+test("applyReschedule rejects unknown tokens", async (t) => {
+  const { applyReschedule } = await createApplyReschedule({ link: null }, null);
+
+  await assert.rejects(
+    applyReschedule({
+      token: TOKEN,
+      newSlot: {
+        serviceId: SERVICE_ID,
+        startsAt: SLOT_START,
+      },
+    }),
+    /Reschedule token not found/,
+  );
+});
+
+test("applyReschedule rejects expired tokens", async (t) => {
+  const expiredLink = {
+    id: "link-1",
+    appointment_id: "appt-1",
+    token: TOKEN,
+    expires_at: new Date(FIXED_NOW.getTime() - 1000).toISOString(),
+    used_at: null,
+  };
+  const { applyReschedule } = await createApplyReschedule({ link: expiredLink }, null);
+
+  await assert.rejects(
+    applyReschedule({
+      token: TOKEN,
+      newSlot: {
+        serviceId: SERVICE_ID,
+        startsAt: SLOT_START,
+      },
+    }),
+    /expired/i,
+  );
+});
+
+test("applyReschedule updates appointment and marks token used", async (t) => {
+  const linkRow = {
+    id: "link-1",
+    appointment_id: "appt-1",
+    token: TOKEN,
+    expires_at: new Date(Date.now() + 60_000).toISOString(),
+    used_at: null,
+  };
+
+  const appointmentRow = {
+    id: "appt-1",
+    staff_id: STAFF_ID,
+    service_id: SERVICE_ID,
+    starts_at: new Date("2025-01-02T10:00:00.000Z").toISOString(),
+    ends_at: new Date("2025-01-02T11:30:00.000Z").toISOString(),
+    created_by: "client-1",
+    services: {
+      id: SERVICE_ID,
+      duration_min: 90,
+      buffer_pre_min: 0,
+      buffer_post_min: 0,
+    },
+  };
+
+  const updatedRow = {
+    id: "appt-1",
+    staff_id: STAFF_ID,
+    service_id: SERVICE_ID,
+    starts_at: SLOT_START.toISOString(),
+    ends_at: new Date(SLOT_START.getTime() + 90 * 60 * 1000).toISOString(),
+  };
+
+  const slots: AvailableSlotStub[] = [
+    {
+      staffId: STAFF_ID,
+      start: new Date(SLOT_START),
+      end: new Date(SLOT_START.getTime() + 90 * 60 * 1000),
+    },
+  ];
+
+  const { applyReschedule, state } = await createApplyReschedule(
+    { link: linkRow, appointment: appointmentRow, updatedAppointment: updatedRow },
+    slots,
+  );
+
+  const result = await applyReschedule({
+    token: TOKEN,
+    newSlot: {
+      serviceId: SERVICE_ID,
+      staffId: STAFF_ID,
+      startsAt: SLOT_START,
+    },
+  });
+
+  assert.deepEqual(result, updatedRow, "Should return the updated appointment row");
+  assert.ok(state.appointmentUpdate, "Appointment update payload should be captured");
+  assert.equal(state.appointmentUpdate?.starts_at, SLOT_START.toISOString());
+  assert.ok(state.linkUpdate, "Reschedule link should be marked used");
+  assert.match(String(state.linkUpdate?.used_at), /T/);
+  assert.ok(state.auditPayload, "Audit log entry should be created");
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,10 @@
       "react-dom",
       "jsdom"
     ],
+    "typeRoots": [
+      "./types",
+      "./node_modules/@types"
+    ],
     "baseUrl": ".",
     "paths": {
       "@/components/*": [
@@ -33,6 +37,9 @@
       ],
       "@/hooks/*": [
         "hooks/*"
+      ],
+      "@/server/*": [
+        "src/server/*"
       ],
       "@/types/*": [
         "types/*"
@@ -56,6 +63,7 @@
     "**/*.ts",
     "**/*.tsx",
     "**/*.js",
+    "**/*.d.ts",
     ".next/types/**/*.ts"
   ],
   "exclude": [

--- a/types/rrule.d.ts
+++ b/types/rrule.d.ts
@@ -1,0 +1,4 @@
+declare module 'rrule' {
+  export type RRuleSet = any;
+  export function rrulestr(input: string, options?: Record<string, unknown>): RRuleSet;
+}


### PR DESCRIPTION
## Summary
- add client portal UI for viewing upcoming appointments and starting the reschedule flow
- implement client reschedule page, supporting components, and server API endpoint for applying reschedules
- update scheduling logic for easier testing, add targeted unit tests, and configure TypeScript/build tooling to support new dependencies

## Testing
- npm test
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d47d2501488324acf146410142acc2