### PR TITLE
Add PWA manifest and web push client scaffolding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ out
 .DS_Store
 .env.local
 tsconfig.tsbuildinfo
+public/icons/*
+!public/icons/.keep

--- a/app/api/notifications/register/route.ts
+++ b/app/api/notifications/register/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+  if (!body || typeof body.token !== "string" || body.platform !== "web") {
+    return NextResponse.json({ ok: false }, { status: 400 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/notifications/send-pickup/route.ts
+++ b/app/api/notifications/send-pickup/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  await request.json().catch(() => null);
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/notifications/send-reminder/route.ts
+++ b/app/api/notifications/send-reminder/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from "next/server";
+
+export async function POST(request: Request) {
+  await request.json().catch(() => null);
+  return NextResponse.json({ ok: true });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,16 +1,19 @@
 import Link from "next/link";
 import { Nunito } from "next/font/google";
+import type { Metadata } from "next";
 
 import AuthProvider from "@/components/AuthProvider";
 import LogoutButton from "@/components/LogoutButton";
+import PushToggle from "@/components/PushToggle";
 import { navItemsForRole, roleDisplayName } from "@/lib/auth/access";
 import { mapProfileRow, type Role, type UserProfile } from "@/lib/auth/profile";
 import { createClient } from "@/lib/supabase/server";
 import "./globals.css";
 
-export const metadata = {
+export const metadata: Metadata = {
   title: "Scruffy Butts",
   description: "Grooming dashboard",
+  manifest: "/manifest.json",
 };
 export const runtime = "nodejs";
 
@@ -90,6 +93,7 @@ export default async function RootLayout({
                   )}
                 </nav>
                 <div className="flex items-center gap-4 text-right text-xs leading-tight text-white/80">
+                  {session?.user ? <PushToggle /> : null}
                   <div className="hidden sm:flex sm:flex-col sm:items-end">
                     <span className="font-semibold text-white">{profile?.full_name ?? session?.user?.email ?? ""}</span>
                     <span className="uppercase tracking-[0.22em] text-[11px] text-white/60">{roleLabel}</span>

--- a/components/PushToggle.tsx
+++ b/components/PushToggle.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function PushToggle() {
+  const [enabled, setEnabled] = useState(false);
+  useEffect(() => {
+    if ("serviceWorker" in navigator) {
+      navigator.serviceWorker.register("/service-worker.js").catch(() => {});
+    }
+  }, []);
+  async function enable() {
+    if (!("Notification" in window)) return;
+    const perm = await Notification.requestPermission();
+    if (perm !== "granted") return;
+    // placeholder token flow; backend can replace later
+    await fetch("/api/notifications/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token: "placeholder", platform: "web" }),
+    });
+    setEnabled(true);
+  }
+  return (
+    <button onClick={enable} disabled={enabled}>
+      {enabled ? "Push Enabled" : "Enable Push"}
+    </button>
+  );
+}

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,8 @@
+{
+  "name": "Scruffy Butts",
+  "short_name": "Scruffy Butts",
+  "start_url": "/",
+  "display": "standalone",
+  "theme_color": "#ffffff",
+  "background_color": "#ffffff"
+}

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,12 @@
+self.addEventListener('push', (e) => {
+  const data = (e.data && e.data.json()) || {};
+  e.waitUntil(self.registration.showNotification(data.title || 'Notification', {
+    body: data.body || '',
+    data: { url: data.url || '/' }
+  }));
+});
+self.addEventListener('notificationclick', (e) => {
+  e.notification.close();
+  const url = (e.notification?.data && e.notification.data.url) || '/';
+  e.waitUntil(clients.openWindow(url));
+});


### PR DESCRIPTION
## Summary
- add a minimal web app manifest and push service worker
- introduce a push toggle UI and wire it into the global layout
- stub notification API routes and ignore future icon assets

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d489ba84d483248a290d119f4d082c