### PR TITLE
Fix notifications routing and scheduling exports

### DIFF
--- a/app/api/appointments/reschedule-link/route.ts
+++ b/app/api/appointments/reschedule-link/route.ts
@@ -5,6 +5,8 @@ import { z } from "zod";
 
 import { createRescheduleLink } from "../../../../src/server/scheduling";
 
+export const runtime = "nodejs";
+
 const payloadSchema = z.object({
   appointmentId: z.string().uuid(),
 });

--- a/app/api/notifications/register/route.ts
+++ b/app/api/notifications/register/route.ts
@@ -4,6 +4,8 @@ import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { z } from "zod";
 import { registerNotificationToken } from "@/src/server/scheduling";
 
+export const runtime = "nodejs";
+
 const bodySchema = z.object({
   token: z.string().min(1, "Token is required"),
   platform: z.literal("web"),
@@ -22,16 +24,14 @@ export async function POST(req: Request) {
   try {
     const body = await req.json();
     const parsed = bodySchema.parse(body);
-
     await registerNotificationToken({
       userId: session.user.id,
       token: parsed.token,
       platform: parsed.platform,
     });
-
     return NextResponse.json({ ok: true });
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : "Unknown error";
+    const message = error instanceof Error ? error.message : "Invalid body";
     return NextResponse.json({ error: message }, { status: 400 });
   }
 }

--- a/app/client/reschedule/page.tsx
+++ b/app/client/reschedule/page.tsx
@@ -196,7 +196,7 @@ export default async function ClientReschedulePage({
       <div className="mx-auto max-w-3xl px-6 py-10">
         <h1 className="text-3xl font-semibold text-white">Reschedule appointment</h1>
         <div className="mt-6 rounded-2xl border border-red-500/40 bg-red-500/10 px-6 py-5 text-sm text-red-100">
-          We couldn't find that reschedule request. Please return to the client portal and try again.
+          We couldn&apos;t find that reschedule request. Please return to the client portal and try again.
         </div>
         <Link
           href="/client"

--- a/src/server/scheduling/index.ts
+++ b/src/server/scheduling/index.ts
@@ -1,23 +1,7 @@
-export { listSlots, type AvailableSlot } from './slots';
-export {
-  createAppointment,
-  updateAppointment,
-  cancelAppointment,
-  listDay,
-  listWeek,
-  computeCommissionBase,
-} from './appointments';
-export { createRescheduleLink, applyReschedule } from './links';
-export { registerPushToken, sendReminder, sendPickupReady } from './notifications';
-export type {
-  SlotQueryInput,
-  CreateAppointmentInput,
-  UpdateAppointmentInput,
-  CancelAppointmentInput,
-  ListDayInput,
-  ListWeekInput,
-  RescheduleLinkInput,
-  ApplyRescheduleInput,
-  RegisterPushTokenInput,
-  AppointmentStatus,
-} from './schemas';
+export * from "./appointments";
+export * from "./links";
+export * from "./notifications";
+export * from "./schemas";
+export * from "./slots";
+export * from "./types";
+export * from "./utils";

--- a/src/server/scheduling/notifications.ts
+++ b/src/server/scheduling/notifications.ts
@@ -1,4 +1,4 @@
-import { enqueueAudit, registerNotificationToken } from "@/lib/notifications";
+import { enqueueAudit, registerNotificationToken as registerToken } from "@/lib/notifications";
 import {
   appointmentIdSchema,
   registerPushTokenSchema,
@@ -6,9 +6,9 @@ import {
   type RegisterPushTokenInput,
 } from "./schemas";
 
-export async function registerPushToken(rawInput: RegisterPushTokenInput) {
+export async function registerNotificationToken(rawInput: RegisterPushTokenInput) {
   const input = registerPushTokenSchema.parse(rawInput);
-  await registerNotificationToken({
+  await registerToken({
     userId: input.userId,
     platform: input.platform,
     token: input.token,

--- a/src/server/scheduling/schemas.ts
+++ b/src/server/scheduling/schemas.ts
@@ -95,7 +95,7 @@ export const applyRescheduleSchema = z.object({
 
 export const registerPushTokenSchema = z.object({
   userId: z.string().uuid(),
-  platform: z.enum(['web', 'ios', 'android']),
+  platform: z.literal('web'),
   token: z.string().min(16),
 });
 

--- a/src/server/scheduling/slots.ts
+++ b/src/server/scheduling/slots.ts
@@ -1,4 +1,4 @@
-import RRuleModule from 'rrule';
+import { rrulestr } from 'rrule';
 import type { RRuleSet } from 'rrule';
 import { getSupabaseAdmin } from '../../../lib/supabase/server';
 import type { SlotQueryInput } from './schemas';
@@ -50,8 +50,6 @@ function parseISODurationMinutes(input: string): number | null {
     (seconds ? Math.ceil(Number.parseInt(seconds, 10) / 60) : 0);
   return Number.isFinite(total) && total > 0 ? total : null;
 }
-
-const { rrulestr } = RRuleModule as { rrulestr: typeof import('rrule').rrulestr };
 
 function extractDurationMinutes(rruleText: string): number | null {
   const custom = rruleText.match(/X-[A-Z-]*DURATION-MINUTES:(\d+)/i);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,6 +49,9 @@
       ],
       "@/supabase/*": [
         "supabase/*"
+      ],
+      "@/src/*": [
+        "src/*"
       ]
     },
     "incremental": true,

--- a/types/rrule.d.ts
+++ b/types/rrule.d.ts
@@ -2,6 +2,5 @@ declare module "rrule" {
   export type RRuleSet = {
     between: (after: Date, before: Date, inc?: boolean) => Date[];
   };
-
   export function rrulestr(rrule: string, options?: { forceset?: boolean }): RRuleSet;
 }


### PR DESCRIPTION
## Summary
- restore the notification registration route to validate the request body and save web tokens through the scheduling layer
- consolidate scheduling exports so reschedule helpers and notification utilities are available again and align the notification registration flow with the updated schema
- add the `@/src/*` path alias, limit push-token registration to web, clean up lint/type issues (including the reschedule copy and rrule typings), and force Node runtime for API routes that depend on Supabase
- correct the rrule import in the scheduling slots helper to call `rrulestr` directly

## Testing
- npm run lint
- npm run typecheck
- CI=1 npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d4982f2cc88324ac6586bd0fdf65c5