### PR TITLE
feat: add one-click Claim Owner

### DIFF
--- a/app/api/admin/claim-owner/route.ts
+++ b/app/api/admin/claim-owner/route.ts
@@ -1,0 +1,38 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { getSupabaseAdmin } from "@/lib/supabase/server";
+
+export async function POST() {
+  const supabase = createRouteHandlerClient({ cookies });
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const admin = getSupabaseAdmin();
+  const uid = session.user.id;
+
+  // Demote any existing master except me
+  const demote = await admin
+    .from("profiles")
+    .update({ role: "Manager" })
+    .eq("role", "Master Account")
+    .neq("id", uid);
+  if (demote.error) return NextResponse.json({ error: demote.error.message }, { status: 400 });
+
+  // Ensure my profile exists & is Master Account
+  const upsertProfile = await admin
+    .from("profiles")
+    .upsert({ id: uid, full_name: session.user.email ?? "Owner", role: "Master Account" }, { onConflict: "id" });
+  if (upsertProfile.error) return NextResponse.json({ error: upsertProfile.error.message }, { status: 400 });
+
+  // Ensure employees row with dashboard access
+  const upsertEmp = await admin
+    .from("employees")
+    .upsert(
+      { user_id: uid, name: "Owner", active: true, role: "Manager", app_permissions: { dashboard: true } },
+      { onConflict: "user_id" }
+    );
+  if (upsertEmp.error) return NextResponse.json({ error: upsertEmp.error.message }, { status: 400 });
+
+  return NextResponse.json({ ok: true });
+}

--- a/components/ClaimOwnerButton.tsx
+++ b/components/ClaimOwnerButton.tsx
@@ -1,0 +1,22 @@
+"use client";
+import { useState } from "react";
+
+export default function ClaimOwnerButton() {
+  const [busy, setBusy] = useState(false);
+  async function run() {
+    setBusy(true);
+    const r = await fetch("/api/admin/claim-owner", { method: "POST" });
+    setBusy(false);
+    if (!r.ok) {
+      const { error } = await r.json().catch(() => ({ error: "Failed" }));
+      alert(error || "Failed");
+      return;
+    }
+    location.reload();
+  }
+  return (
+    <button onClick={run} disabled={busy} style={{ marginLeft: 8 }}>
+      {busy ? "Fixing…" : "Claim Owner"}
+    </button>
+  );
+}

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import clsx from "clsx";
 
 import { useAuth } from "@/components/AuthProvider";
+import ClaimOwnerButton from "@/components/ClaimOwnerButton";
 
 const navLinks = [
   { href: "/dashboard", label: "Dashboard" },
@@ -67,6 +68,7 @@ export default function TopNav() {
             )}
             {role && <span className="uppercase tracking-[0.22em] text-[11px] text-white/60">{role}</span>}
           </div>
+          <ClaimOwnerButton />
           <button
             type="button"
             onClick={handleSignOut}


### PR DESCRIPTION
## Summary
- add admin route to let the current session claim master ownership while demoting any other master
- introduce a claim owner button that calls the endpoint and reloads on success
- surface the button in the top navigation alongside the current user details

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68d4a8f183d88324a8266d22b4a2977e