### PR TITLE
feat: business onboarding + invites + transfer master + architecture doc

### DIFF
--- a/app/api/admin/transfer-master/route.ts
+++ b/app/api/admin/transfer-master/route.ts
@@ -1,0 +1,38 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+
+export async function POST(request: Request) {
+  const supabase = createRouteHandlerClient({ cookies });
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const me = await supabase.from("profiles").select("id, role, business_id").eq("id", session.user.id).maybeSingle();
+  if (me.error || !me.data?.business_id) return NextResponse.json({ error: "No business" }, { status: 403 });
+  if (String(me.data.role) !== "Master Account") return NextResponse.json({ error: "Only Master can transfer" }, { status: 403 });
+
+  const { targetUserId } = await request.json().catch(() => ({}));
+  if (!targetUserId) return NextResponse.json({ error: "Missing targetUserId" }, { status: 400 });
+
+  // Demote any master in same business except target
+  const demote = await supabase.from("profiles").update({ role: "Manager" })
+    .eq("business_id", me.data.business_id)
+    .eq("role", "Master Account")
+    .neq("id", targetUserId);
+  if (demote.error) return NextResponse.json({ error: demote.error.message }, { status: 400 });
+
+  // Promote target
+  const promote = await supabase.from("profiles").update({ role: "Master Account" })
+    .eq("id", targetUserId).eq("business_id", me.data.business_id);
+  if (promote.error) return NextResponse.json({ error: promote.error.message }, { status: 400 });
+
+  // Ensure employees row for target
+  await supabase.from("employees").upsert({
+    user_id: targetUserId, name: "Owner", active: true, role: "Manager",
+    business_id: me.data.business_id, app_permissions: { dashboard: true }
+  }, { onConflict: "user_id" });
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/onboarding/first-owner/route.ts
+++ b/app/api/onboarding/first-owner/route.ts
@@ -1,0 +1,24 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+
+export async function POST(request: Request) {
+  const supabase = createRouteHandlerClient({ cookies });
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const body = await request.json().catch(() => ({}));
+  const businessName = typeof body?.businessName === "string" && body.businessName.trim().length
+    ? body.businessName.trim()
+    : "My Grooming Business";
+
+  const { data, error } = await supabase.rpc("claim_first_owner", {
+    p_user: session.user.id,
+    p_business_name: businessName
+  });
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+  return NextResponse.json({ ok: true, businessId: data });
+}

--- a/app/api/staff/accept-invite/route.ts
+++ b/app/api/staff/accept-invite/route.ts
@@ -1,0 +1,49 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+
+export async function POST(request: Request) {
+  const supabase = createRouteHandlerClient({ cookies });
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { token } = await request.json().catch(() => ({}));
+  if (!token) return NextResponse.json({ error: "Missing token" }, { status: 400 });
+
+  const { data: inv, error: invErr } = await supabase
+    .from("staff_invites")
+    .select("id, business_id, email, role, accepted_at")
+    .eq("token", token)
+    .maybeSingle();
+  if (invErr || !inv) return NextResponse.json({ error: "Invalid invite" }, { status: 404 });
+  if (inv.accepted_at) return NextResponse.json({ error: "Invite already used" }, { status: 400 });
+  if (session.user.email?.toLowerCase() !== inv.email.toLowerCase()) {
+    return NextResponse.json({ error: "Invite email mismatch" }, { status: 403 });
+  }
+
+  // Link profile to business and role
+  const { error: upErr } = await supabase.from("profiles").update({
+    business_id: inv.business_id,
+    role: inv.role
+  }).eq("id", session.user.id);
+  if (upErr) return NextResponse.json({ error: upErr.message }, { status: 400 });
+
+  // Ensure employees row
+  const { error: empErr } = await supabase.from("employees").upsert({
+    user_id: session.user.id,
+    name: session.user.email ?? "Staff",
+    active: true,
+    role: inv.role,
+    business_id: inv.business_id,
+    app_permissions: inv.role === "Manager" ? { dashboard: true } : {}
+  }, { onConflict: "user_id" });
+  if (empErr) return NextResponse.json({ error: empErr.message }, { status: 400 });
+
+  // Mark accepted
+  const { error: accErr } = await supabase.from("staff_invites").update({ accepted_at: new Date().toISOString() }).eq("id", inv.id);
+  if (accErr) return NextResponse.json({ error: accErr.message }, { status: 400 });
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/staff/invite/route.ts
+++ b/app/api/staff/invite/route.ts
@@ -1,0 +1,34 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { randomBytes } from "crypto";
+
+export async function POST(request: Request) {
+  const supabase = createRouteHandlerClient({ cookies });
+  const { data: { session } } = await supabase.auth.getSession();
+  if (!session) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const me = await supabase.from("profiles").select("id, role, business_id").eq("id", session.user.id).maybeSingle();
+  if (me.error || !me.data?.business_id) return NextResponse.json({ error: "No business" }, { status: 403 });
+  if (!["Master Account","Manager"].includes(String(me.data.role))) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+  const { email, role } = await request.json().catch(() => ({}));
+  if (!email || !role || !["Manager","Front Desk","Groomer"].includes(role)) {
+    return NextResponse.json({ error: "Invalid email/role" }, { status: 400 });
+  }
+
+  const token = randomBytes(24).toString("hex");
+  const { error } = await supabase.from("staff_invites").insert({
+    business_id: me.data.business_id,
+    email,
+    role,
+    token,
+    created_by: me.data.id
+  });
+  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
+
+  // Integrate email later. For now return token so owner can share the link manually.
+  return NextResponse.json({ ok: true, token });
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,42 @@
+# SB App Architecture (Bible)
+
+## Roles
+- Master Account: one per business. Full control.
+- Manager, Front Desk, Groomer: invited by Master/Manager.
+- Client: default for new auth users unless invited as staff.
+
+## Tenancy
+- `businesses` = root. `profiles.business_id` links users to a business.
+- `employees.business_id` mirrors profiles for staff.
+- Other tables derive business via joins (e.g., appointments -> employees -> profiles.business_id).
+
+## Onboarding
+- First signup calls `/api/onboarding/first-owner` to create business and promote caller to Master.
+- Later signups remain Client until invited.
+
+## Staff Invites
+- `/api/staff/invite`: Master/Manager creates invite with role.
+- `/api/staff/accept-invite`: invited user accepts; profile role + business_id set; employees row ensured.
+
+## Transfer Master
+- `/api/admin/transfer-master`: current Master can transfer to another user in same business.
+
+## Notifications, Scheduling, Photos
+- Notifications: tokens in `notification_tokens`; audit in `audit_log`.
+- Availability/Blackout: `availability_rules`, `blackout_dates`.
+- Pet photos: `pet_photos` (bigint pet_id).
+
+## RLS (high level)
+- Scope queries by `profiles.business_id` OR by joins that resolve to a single business.
+- Policies must ensure `auth.uid()` belongs to the same business to see data.
+
+## File Map (new endpoints)
+- `app/api/onboarding/first-owner/route.ts`
+- `app/api/staff/invite/route.ts`
+- `app/api/staff/accept-invite/route.ts`
+- `app/api/admin/transfer-master/route.ts`
+
+## Next Steps (optional)
+- Add `business_id` columns to appointments/services and enforce via RLS.
+- Email integration for invites.
+- Owner-facing onboarding UI wizard.

--- a/sql/2025-09-business-onboarding.sql
+++ b/sql/2025-09-business-onboarding.sql
@@ -1,0 +1,115 @@
+BEGIN;
+
+-- 1. Business
+CREATE TABLE IF NOT EXISTS public.businesses (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  name         text NOT NULL,
+  timezone     text NOT NULL DEFAULT 'America/Chicago',
+  logo_url     text,
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+
+-- 2. Profiles link to business and role enum already exists (role_t)
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS business_id uuid;
+
+ALTER TABLE public.profiles
+  ADD CONSTRAINT IF NOT EXISTS profiles_business_fk
+  FOREIGN KEY (business_id) REFERENCES public.businesses(id) ON DELETE SET NULL;
+
+-- 3. Employees link to business too
+ALTER TABLE public.employees
+  ADD COLUMN IF NOT EXISTS business_id uuid;
+
+ALTER TABLE public.employees
+  ADD CONSTRAINT IF NOT EXISTS employees_business_fk
+  FOREIGN KEY (business_id) REFERENCES public.businesses(id) ON DELETE SET NULL;
+
+-- 4. Default profile row on auth user creation = Client. (Keeps clients simple.)
+CREATE OR REPLACE FUNCTION public.set_default_client_profile()
+RETURNS trigger AS $$
+BEGIN
+  INSERT INTO public.profiles (id, role)
+  VALUES (NEW.id, 'Client'::role_t)
+  ON CONFLICT (id) DO NOTHING;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS t_default_client_profile ON auth.users;
+CREATE TRIGGER t_default_client_profile
+AFTER INSERT ON auth.users
+FOR EACH ROW EXECUTE FUNCTION public.set_default_client_profile();
+
+-- 5. First-owner onboarding helper. If NO businesses exist, create one and promote caller to Master.
+CREATE OR REPLACE FUNCTION public.claim_first_owner(p_user uuid, p_business_name text)
+RETURNS uuid
+LANGUAGE plpgsql
+AS $$
+DECLARE v_bid uuid;
+BEGIN
+  SELECT id INTO v_bid FROM public.businesses LIMIT 1;
+
+  IF v_bid IS NULL THEN
+    INSERT INTO public.businesses (name) VALUES (COALESCE(p_business_name,'My Grooming Business')) RETURNING id INTO v_bid;
+
+    UPDATE public.profiles
+      SET role='Master Account'::role_t, business_id=v_bid
+      WHERE id = p_user;
+
+    INSERT INTO public.employees (user_id, name, active, role, business_id, app_permissions)
+    VALUES (p_user, 'Owner', true, 'Manager', v_bid, '{"dashboard":true}'::jsonb)
+    ON CONFLICT (user_id) DO UPDATE
+      SET business_id=EXCLUDED.business_id,
+          active=true,
+          app_permissions=COALESCE(public.employees.app_permissions,'{}'::jsonb) || '{"dashboard":true}'::jsonb;
+
+    RETURN v_bid;
+  ELSE
+    -- Business already exists => require invite flow. No change to role.
+    RETURN v_bid;
+  END IF;
+END;
+$$;
+
+-- 6. Staff invites
+CREATE TABLE IF NOT EXISTS public.staff_invites (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  business_id  uuid NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
+  email        text NOT NULL,
+  role         text NOT NULL CHECK (role IN ('Manager','Front Desk','Groomer')),
+  token        text UNIQUE NOT NULL,
+  created_by   uuid REFERENCES public.profiles(id),
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  accepted_at  timestamptz
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_staff_invites_business_email
+  ON public.staff_invites(business_id, email) WHERE accepted_at IS NULL;
+
+-- 7. RLS scoping by business for invites (admins can manage; others only see own)
+ALTER TABLE public.staff_invites ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS si_admin_all ON public.staff_invites;
+CREATE POLICY si_admin_all ON public.staff_invites
+FOR ALL USING (
+  EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid()
+      AND p.business_id = staff_invites.business_id
+      AND p.role::text IN ('Master Account','Manager')
+  )
+)
+WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM public.profiles p
+    WHERE p.id = auth.uid()
+      AND p.business_id = staff_invites.business_id
+      AND p.role::text IN ('Master Account','Manager')
+  )
+);
+
+COMMIT;
+
+-- NOTE: We intentionally do NOT rewrite all tables to add business_id today.
+-- RLS for other tables can derive business via joins (employees.user_id -> profiles.business_id).


### PR DESCRIPTION
## Summary
- add businesses core table, onboarding helper, and staff invite schema with RLS
- expose onboarding, invite management, and master transfer APIs for authenticated users
- document architecture and new flows in repo bible

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68d4b3b1da088324a25092600f7cb8b0