### PR TITLE
Add API-backed auth context without client fallback

### DIFF
--- a/app/(app)/booking/page.tsx
+++ b/app/(app)/booking/page.tsx
@@ -8,6 +8,7 @@ import clsx from "clsx";
 
 import { useAuth } from "@/components/AuthProvider";
 import { canAccessRoute } from "@/lib/auth/access";
+import { toLegacyRole } from "@/lib/auth/roles";
 
 const currency = new Intl.NumberFormat(undefined, {
   style: "currency",
@@ -159,6 +160,7 @@ const defaultDraft: BookingDraft = {
 
 export default function BookingPage() {
   const { loading, role } = useAuth();
+  const legacyRole = useMemo(() => toLegacyRole(role), [role]);
   const searchParams = useSearchParams();
   const clientId = searchParams.get("clientId") ?? null;
 
@@ -252,7 +254,7 @@ export default function BookingPage() {
     return <div className="px-6 py-10 text-sm text-white/70">Loading booking flow…</div>;
   }
 
-  if (!role || !canAccessRoute(role, "booking")) {
+  if (!legacyRole || !canAccessRoute(legacyRole, "booking")) {
     return (
       <div className="mx-auto max-w-2xl px-6 py-16 text-white/80">
         <h1 className="text-2xl font-semibold text-white">Booking unavailable</h1>

--- a/app/(app)/calendar/page.tsx
+++ b/app/(app)/calendar/page.tsx
@@ -12,6 +12,7 @@ import AppointmentDetailDrawer, {
   type DrawerStaffOption,
 } from "@/components/scheduling/AppointmentDetailDrawer";
 import { canAccessRoute, isGroomerRole } from "@/lib/auth/access";
+import { toLegacyRole } from "@/lib/auth/roles";
 
 const STEP_MINUTES = 15;
 const DAY_START_MINUTES = 7 * 60;
@@ -263,7 +264,8 @@ function seedAppointments(todayKey: string): Appointment[] {
 }
 
 export default function CalendarPage() {
-  const { loading, role, session } = useAuth();
+  const { loading, role, profile } = useAuth();
+  const legacyRole = useMemo(() => toLegacyRole(role), [role]);
   const today = useMemo(() => {
     const now = new Date();
     now.setHours(0, 0, 0, 0);
@@ -599,15 +601,15 @@ export default function CalendarPage() {
   }, [appointmentForDrawer]);
 
   const staffForViewer = useMemo(() => {
-    if (!role) return staffDirectory;
-    if (!isGroomerRole(role)) return staffDirectory;
-    const viewerId = session?.user?.id;
+    if (!legacyRole) return staffDirectory;
+    if (!isGroomerRole(legacyRole)) return staffDirectory;
+    const viewerId = profile?.id;
     const match = viewerId
       ? staffDirectory.find((staff) => staff.profileId === viewerId)
       : null;
     if (match) return [match];
     return [staffDirectory[0]];
-  }, [role, session?.user?.id]);
+  }, [legacyRole, profile?.id]);
 
   const currentDateKey = useMemo(() => formatDateKey(currentDate), [currentDate]);
 
@@ -639,7 +641,7 @@ export default function CalendarPage() {
     return <div className="px-6 py-10 text-sm text-white/70">Loading calendar…</div>;
   }
 
-  if (!role || !canAccessRoute(role, "calendar")) {
+  if (!legacyRole || !canAccessRoute(legacyRole, "calendar")) {
     return (
       <div className="mx-auto max-w-2xl px-6 py-16 text-white/80">
         <h1 className="text-2xl font-semibold text-white">Calendar unavailable</h1>

--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+
+export async function GET() {
+  const supabase = createRouteHandlerClient({ cookies });
+  const {
+    data: { session },
+    error: sessErr,
+  } = await supabase.auth.getSession();
+
+  if (sessErr) {
+    return NextResponse.json({ error: sessErr.message }, { status: 500 });
+  }
+  if (!session) {
+    return NextResponse.json({ role: null, profile: null }, { status: 200 });
+  }
+
+  const { data: profile, error: profErr } = await supabase
+    .from("profiles")
+    .select("id, email, role")
+    .eq("id", session.user.id)
+    .maybeSingle();
+
+  if (profErr) {
+    return NextResponse.json({ error: profErr.message }, { status: 500 });
+  }
+
+  return NextResponse.json({
+    role: profile?.role ?? null,
+    profile: profile ?? null,
+  });
+}

--- a/app/employees/new/page.tsx
+++ b/app/employees/new/page.tsx
@@ -9,6 +9,7 @@ import clsx from "clsx";
 import Card from "@/components/Card";
 import PageContainer from "@/components/PageContainer";
 import { useAuth } from "@/components/AuthProvider";
+import { derivePermissionFlags } from "@/lib/auth/roles";
 import {
   CompensationPlanDraft,
   defaultCompensationPlan,
@@ -127,7 +128,8 @@ const defaultPermissions: Record<PermissionKey, boolean> = {
 
 export default function NewEmployeePage() {
   const router = useRouter();
-  const { loading: authLoading, session, permissions } = useAuth();
+  const { loading: authLoading, role, profile } = useAuth();
+  const permissions = useMemo(() => derivePermissionFlags(role), [role]);
 
   const [form, setForm] = useState<FormState>({
     name: "",
@@ -294,7 +296,7 @@ export default function NewEmployeePage() {
     );
   }
 
-  if (!session) {
+  if (!profile) {
     return (
       <PageContainer>
         <Card>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,9 +5,7 @@ import type { Metadata } from "next";
 import AuthProvider from "@/components/AuthProvider";
 import LogoutButton from "@/components/LogoutButton";
 import PushToggle from "@/components/PushToggle";
-import { navItemsForRole, roleDisplayName } from "@/lib/auth/access";
-import { mapProfileRow, type Role, type UserProfile } from "@/lib/auth/profile";
-import { createClient } from "@/lib/supabase/server";
+import TopNav from "@/components/TopNav";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -22,40 +20,17 @@ const nunito = Nunito({
   variable: "--font-sans",
 });
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const supabase = createClient();
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-
-  let profile: UserProfile | null = null;
-  let role: Role = "client";
-
-  if (session?.user) {
-    const { data } = await supabase
-      .from("profiles")
-      .select("id, full_name, role")
-      .eq("id", session.user.id)
-      .maybeSingle();
-    profile = mapProfileRow(data) ?? null;
-    if (profile) {
-      role = profile.role;
-    }
-  }
-
-  const tabs = navItemsForRole(role);
-  const roleLabel = roleDisplayName(role);
-
   return (
     <html lang="en" className="scroll-smooth">
       <body
         className={`${nunito.variable} font-sans text-white/90 antialiased bg-gradient-to-br from-brand-blue via-primary to-brand-sky min-h-screen overflow-x-hidden`}
       >
-        <AuthProvider initialSession={session} initialProfile={profile}>
+        <AuthProvider>
           <div className="relative flex min-h-screen flex-col overflow-hidden">
             <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
               <div className="absolute -left-32 -top-40 h-96 w-96 rounded-full bg-brand-bubble/30 blur-[120px]" />
@@ -75,29 +50,11 @@ export default async function RootLayout({
                     </span>
                   </div>
                 </Link>
-                <nav className="flex flex-1 flex-wrap items-center gap-2 text-sm">
-                  {tabs.length === 0 ? (
-                    <span className="rounded-full border border-white/15 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.25em] text-white/70">
-                      No dashboard access
-                    </span>
-                  ) : (
-                    tabs.map((tab) => (
-                      <Link
-                        key={tab.href}
-                        href={tab.href}
-                        className="nav-link text-white/80 transition hover:text-white"
-                      >
-                        {tab.label}
-                      </Link>
-                    ))
-                  )}
-                </nav>
+                <div className="flex flex-1 justify-end">
+                  <TopNav />
+                </div>
                 <div className="flex items-center gap-4 text-right text-xs leading-tight text-white/80">
-                  {session?.user ? <PushToggle /> : null}
-                  <div className="hidden sm:flex sm:flex-col sm:items-end">
-                    <span className="font-semibold text-white">{profile?.full_name ?? session?.user?.email ?? ""}</span>
-                    <span className="uppercase tracking-[0.22em] text-[11px] text-white/60">{roleLabel}</span>
-                  </div>
+                  <PushToggle />
                   <LogoutButton />
                 </div>
               </div>

--- a/components/AuthProvider.tsx
+++ b/components/AuthProvider.tsx
@@ -1,443 +1,66 @@
 "use client";
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
 
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
-import { useRouter } from "next/navigation";
-import type { AuthChangeEvent, Session, User } from "@supabase/supabase-js";
+type Role =
+  | "Master Account"
+  | "Manager"
+  | "Front Desk"
+  | "Groomer"
+  | "Admin"
+  | "Client"
+  | string
+  | null;
 
-import { mapProfileRow, type Role, type UserProfile } from "@/lib/auth/profile";
-import { supabase } from "@/lib/supabase/client";
-
-type AuthProviderProps = {
-  children: React.ReactNode;
-  initialSession?: Session | null;
-  initialProfile?: UserProfile | null;
-};
-
-type Permissions = {
-  canAccessSettings: boolean;
-  canManageCalendar: boolean;
-  canManageEmployees: boolean;
-  canViewReports: boolean;
-  raw: Record<string, unknown>;
-};
-
-type AuthContextValue = {
+type AuthState = {
   loading: boolean;
-  session: Session | null;
-  user: User | null;
-  email: string | null;
-  displayName: string | null;
   role: Role;
-  profile: UserProfile | null;
-  isOwner: boolean;
-  permissions: Permissions;
-  sessionExpiresAt: number | null;
-  refreshProfile: () => Promise<void>;
-  signOut: () => Promise<void>;
+  profile: { id: string; email: string | null; role: Role } | null;
+  refresh: () => Promise<void>;
 };
 
-const defaultPermissions: Permissions = {
-  canAccessSettings: false,
-  canManageCalendar: false,
-  canManageEmployees: false,
-  canViewReports: false,
-  raw: {},
-};
-
-const AuthContext = createContext<AuthContextValue>({
+const AuthCtx = createContext<AuthState>({
   loading: true,
-  session: null,
-  user: null,
-  email: null,
-  displayName: null,
-  role: 'client',
+  role: null,
   profile: null,
-  isOwner: false,
-  permissions: defaultPermissions,
-  sessionExpiresAt: null,
-  refreshProfile: async () => undefined,
-  signOut: async () => undefined,
+  refresh: async () => {},
 });
 
-export function useAuth() {
-  return useContext(AuthContext);
-}
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [loading, setLoading] = useState(true);
+  const [role, setRole] = useState<Role>(null);
+  const [profile, setProfile] = useState<AuthState["profile"]>(null);
 
-function permissionsForRole(role: Role): Permissions {
-  switch (role) {
-    case "master":
-    case "admin":
-      return {
-        canAccessSettings: true,
-        canManageCalendar: true,
-        canManageEmployees: true,
-        canViewReports: true,
-        raw: { role },
-      };
-    case "senior_groomer":
-      return {
-        canAccessSettings: true,
-        canManageCalendar: true,
-        canManageEmployees: true,
-        canViewReports: true,
-        raw: { role },
-      };
-    case "groomer":
-      return {
-        canAccessSettings: false,
-        canManageCalendar: true,
-        canManageEmployees: false,
-        canViewReports: false,
-        raw: { role },
-      };
-    case "receptionist":
-      return {
-        canAccessSettings: false,
-        canManageCalendar: true,
-        canManageEmployees: false,
-        canViewReports: false,
-        raw: { role },
-      };
-    case "client":
-      return {
-        canAccessSettings: false,
-        canManageCalendar: false,
-        canManageEmployees: false,
-        canViewReports: false,
-        raw: { role: role ?? "client" },
-      };
-  }
-}
-
-async function loadUserProfile(user: User | null): Promise<UserProfile | null> {
-  if (!user) return null;
-  const { data, error } = await supabase
-    .from("profiles")
-    .select("id, full_name, role")
-    .eq("id", user.id)
-    .maybeSingle();
-
-  if (error) {
-    console.error("Failed to load user profile", error);
-    return null;
-  }
-
-  return mapProfileRow(data);
-}
-
-export default function AuthProvider({
-  children,
-  initialSession = null,
-  initialProfile = null,
-}: AuthProviderProps) {
-  const router = useRouter();
-  const [session, setSession] = useState<Session | null>(initialSession);
-  const [user, setUser] = useState<User | null>(initialSession?.user ?? null);
-  const [profile, setProfile] = useState<UserProfile | null>(initialProfile);
-  const [loading, setLoading] = useState(() => !initialSession);
-  const [sessionExpiresAt, setSessionExpiresAt] = useState<number | null>(() =>
-    normaliseExpiry(initialSession)
-  );
-
-  useEffect(() => {
-    setSession(initialSession ?? null);
-    setUser(initialSession?.user ?? null);
-    setProfile(initialProfile ?? null);
-    setLoading((prev) => (initialSession ? false : prev));
-    setSessionExpiresAt(normaliseExpiry(initialSession));
-  }, [initialProfile, initialSession]);
-
-  useEffect(() => {
-    let active = true;
-
-    const syncBrowserSession = async () => {
-      try {
-        const { data: current } = await supabase.auth.getSession();
-        if (!initialSession) {
-          if (active && current.session) {
-            await supabase.auth.signOut();
-          }
-          return;
-        }
-
-        const currentSession = current.session;
-        const accessTokenMatches = currentSession?.access_token === initialSession.access_token;
-        const refreshTokenMatches = currentSession?.refresh_token === initialSession.refresh_token;
-
-        if (!active) return;
-
-        if (!accessTokenMatches || !refreshTokenMatches) {
-          if (!initialSession.refresh_token) {
-            console.warn("Missing refresh token for Supabase session sync");
-            return;
-          }
-          const { error } = await supabase.auth.setSession({
-            access_token: initialSession.access_token,
-            refresh_token: initialSession.refresh_token,
-          });
-          if (error) {
-            console.error("Failed to synchronise Supabase session", error);
-          }
-        }
-      } catch (error) {
-        console.error("Failed to prime Supabase session", error);
-      }
-    };
-
-    void syncBrowserSession();
-
-    return () => {
-      active = false;
-    };
-  }, [initialSession]);
-
-  useEffect(() => {
-    let active = true;
-
-    const shouldLoadSession = !initialSession;
-    const shouldLoadProfile = !initialProfile;
-
-    const initialise = async () => {
-      try {
-        let nextSession = initialSession ?? null;
-
-        if (shouldLoadSession) {
-          const {
-            data: { session: currentSession },
-          } = await supabase.auth.getSession();
-
-          if (!active) return;
-
-          nextSession = currentSession ?? null;
-        }
-
-        if (!active) return;
-
-        setSession(nextSession);
-        const nextUser = nextSession?.user ?? null;
-        setUser(nextUser);
-        setSessionExpiresAt(normaliseExpiry(nextSession));
-
-        if (!shouldLoadProfile) return;
-
-        if (!nextUser) {
-          setProfile(null);
-          return;
-        }
-
-        const nextProfile = await loadUserProfile(nextUser);
-        if (!active) return;
-        setProfile(nextProfile);
-      } catch (error) {
-        console.error("Unable to initialise auth session", error);
-      } finally {
-        if (active && (shouldLoadSession || shouldLoadProfile)) {
-          setLoading(false);
-        }
-      }
-    };
-
-    if (shouldLoadSession || shouldLoadProfile) {
-      void initialise();
-    }
-
-    const { data: subscription } = supabase.auth.onAuthStateChange(
-      async (event: AuthChangeEvent, nextSession) => {
-        if (!active) return;
-
-        setSession(nextSession ?? null);
-        const nextUser = nextSession?.user ?? null;
-        setUser(nextUser);
-        setSessionExpiresAt(normaliseExpiry(nextSession));
-
-        if (!nextUser) {
-          setProfile(null);
-          setLoading(false);
-          setSessionExpiresAt(null);
-          if (event === "SIGNED_OUT") {
-            router.push("/login");
-          }
-          return;
-        }
-
-        if (event !== "TOKEN_REFRESHED") {
-          const nextProfile = await loadUserProfile(nextUser);
-          if (!active) return;
-          setProfile(nextProfile);
-        }
-
-        setLoading(false);
-
-        if (event === "SIGNED_IN" || event === "USER_UPDATED") {
-          router.refresh();
-        }
-      }
-    );
-
-    return () => {
-      active = false;
-      subscription.subscription.unsubscribe();
-    };
-  }, [initialProfile, initialSession, router]);
-
-  const refreshProfile = useCallback(async () => {
-    const nextProfile = await loadUserProfile(user);
-    setProfile(nextProfile);
-  }, [user]);
-
-  const signOut = useCallback(async () => {
-    await supabase.auth.signOut();
-    setSession(null);
-    setUser(null);
-    setProfile(null);
-    setSessionExpiresAt(null);
-    router.push("/login");
-  }, [router]);
-
-  const checkSession = useCallback(async () => {
+  const load = async () => {
+    setLoading(true);
     try {
-      const {
-        data: { session: latest },
-      } = await supabase.auth.getSession();
-
-      if (!latest) {
-        console.info("Auth session has expired during inactivity – signing out.");
-        await signOut();
-        return;
-      }
-
-      setSession(latest);
-      setUser(latest.user ?? null);
-      setSessionExpiresAt(normaliseExpiry(latest));
-    } catch (error) {
-      console.error("Failed to verify auth session", error);
+      const res = await fetch("/api/me", { cache: "no-store" });
+      const data = await res.json();
+      setRole((data?.role ?? null) as Role);
+      setProfile(data?.profile ?? null);
+    } catch {
+      setRole(null);
+      setProfile(null);
+    } finally {
+      setLoading(false);
     }
-  }, [signOut]);
-
-  useEffect(() => {
-    if (!Number.isFinite(sessionExpiresAt)) return;
-
-    const expiryTimestamp = sessionExpiresAt * 1000;
-    if (!Number.isFinite(expiryTimestamp)) {
-      console.warn("Received invalid session expiry timestamp", sessionExpiresAt);
-      return;
-    }
-
-    const millisecondsUntilExpiry = expiryTimestamp - Date.now();
-
-    if (millisecondsUntilExpiry <= 0) {
-      void signOut();
-      return;
-    }
-
-    const timeoutId = window.setTimeout(() => {
-      console.info("Auth session reached expiry – logging out user.");
-      void signOut();
-    }, millisecondsUntilExpiry);
-
-    return () => {
-      window.clearTimeout(timeoutId);
-    };
-  }, [sessionExpiresAt, signOut]);
-
-  useEffect(() => {
-    if (!Number.isFinite(sessionExpiresAt)) return;
-
-    const expiryTimestamp = sessionExpiresAt * 1000;
-    if (!Number.isFinite(expiryTimestamp)) {
-      console.warn("Received invalid session expiry timestamp", sessionExpiresAt);
-      return;
-    }
-
-    const millisecondsUntilExpiry = expiryTimestamp - Date.now();
-
-    if (millisecondsUntilExpiry <= 0) {
-      console.info("Auth session already expired – awaiting sign-out.");
-      return;
-    }
-
-    const minutes = Math.floor(millisecondsUntilExpiry / 60000);
-    const seconds = Math.floor((millisecondsUntilExpiry % 60000) / 1000);
-    const formattedExpiry = new Date(expiryTimestamp).toLocaleString();
-
-    console.info(
-      `[auth] Session timeout: ${minutes}m ${seconds}s remaining (expires at ${formattedExpiry}).`
-    );
-  }, [sessionExpiresAt]);
-
-  useEffect(() => {
-    const handleVisibility = () => {
-      if (document.visibilityState === "visible") {
-        void checkSession();
-      }
-    };
-
-    const handleFocus = () => {
-      void checkSession();
-    };
-
-    window.addEventListener("visibilitychange", handleVisibility);
-    window.addEventListener("focus", handleFocus);
-
-    return () => {
-      window.removeEventListener("visibilitychange", handleVisibility);
-      window.removeEventListener("focus", handleFocus);
-    };
-  }, [checkSession]);
-
-  const email = user?.email ?? null;
-  const role = profile?.role ?? "client";
-  const displayName = useMemo(() => {
-    if (profile?.full_name) return profile.full_name;
-    if (user?.user_metadata?.full_name && typeof user.user_metadata.full_name === "string") {
-      const trimmed = user.user_metadata.full_name.trim();
-      if (trimmed.length > 0) return trimmed;
-    }
-    if (email) return email;
-    return null;
-  }, [email, profile?.full_name, user?.user_metadata?.full_name]);
-
-  const permissions = useMemo(() => permissionsForRole(role), [role]);
-  const isOwner = role === "master";
-
-  const value: AuthContextValue = {
-    loading,
-    session,
-    user,
-    email,
-    displayName,
-    role,
-    profile,
-    isOwner,
-    permissions,
-    sessionExpiresAt,
-    refreshProfile,
-    signOut,
   };
 
-  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+  useEffect(() => {
+    load();
+    const onVis = () => {
+      if (document.visibilityState === "visible") load();
+    };
+    document.addEventListener("visibilitychange", onVis);
+    return () => document.removeEventListener("visibilitychange", onVis);
+  }, []);
+
+  const value = useMemo(() => ({ loading, role, profile, refresh: load }), [loading, role, profile]);
+
+  return <AuthCtx.Provider value={value}>{children}</AuthCtx.Provider>;
 }
 
-function normaliseExpiry(session: Session | null | undefined): number | null {
-  if (!session) return null;
-
-  const { expires_at: expiresAt, expires_in: expiresIn } = session;
-
-  if (typeof expiresAt === "number" && Number.isFinite(expiresAt)) {
-    return expiresAt;
-  }
-
-  if (typeof expiresIn === "number" && Number.isFinite(expiresIn)) {
-    const secondsFromNow = Math.max(0, Math.floor(expiresIn));
-    return Math.floor(Date.now() / 1000) + secondsFromNow;
-  }
-
-  return null;
+export function useAuth() {
+  return useContext(AuthCtx);
 }
+
+export default AuthProvider;

--- a/components/LogoutButton.tsx
+++ b/components/LogoutButton.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { useAuth } from '@/components/AuthProvider'
+import { supabase } from '@/lib/supabase/client'
 
 export default function LogoutButton() {
-  const { loading, signOut } = useAuth()
+  const { loading, refresh } = useAuth()
 
   if (loading) return null
 
@@ -11,8 +12,9 @@ export default function LogoutButton() {
     <button
       type="button"
       className="rounded-full bg-white/20 px-3 py-2 text-sm font-medium text-white transition hover:bg-white/30"
-      onClick={() => {
-        void signOut()
+      onClick={async () => {
+        await supabase.auth.signOut()
+        await refresh()
       }}
     >
       Log out

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -1,83 +1,18 @@
 "use client";
-
-import Link from "next/link";
-import { usePathname } from "next/navigation";
-import clsx from "clsx";
-
+import React from "react";
 import { useAuth } from "@/components/AuthProvider";
-import ClaimOwnerButton from "@/components/ClaimOwnerButton";
-
-const navLinks = [
-  { href: "/dashboard", label: "Dashboard" },
-  { href: "/calendar", label: "Calendar" },
-  { href: "/clients", label: "Clients" },
-  { href: "/employees", label: "Staff" },
-  { href: "/reports", label: "Reports" },
-  { href: "/messages", label: "Messages" },
-  { href: "/settings", label: "Settings" },
-];
 
 export default function TopNav() {
-  const pathname = usePathname();
-  const { loading, session, displayName, role, signOut } = useAuth();
+  const { loading, role, profile } = useAuth();
 
-  if (!session) return null;
-
-  const handleSignOut = () => {
-    if (loading) return;
-    void signOut();
-  };
+  const badge = loading ? "…" : role ?? "Guest";
+  const name = profile?.email ?? "User";
 
   return (
-    <header className="sticky top-0 z-40 flex justify-center px-4 pt-6">
-      <div className="glass-panel flex w-full max-w-6xl items-center justify-between px-6 py-4">
-        <Link href="/" className="group flex items-center gap-4 text-white">
-          <span className="grid h-12 w-12 place-items-center rounded-full bg-white/90 text-2xl shadow-inner ring-4 ring-white/40 transition-transform duration-300 group-hover:-rotate-12">
-            🐾
-          </span>
-          <div className="flex flex-col leading-tight">
-            <span className="text-xs font-semibold uppercase tracking-[0.4em] text-white/70">Scruffy</span>
-            <span className="text-2xl font-black text-white transition-colors duration-300 group-hover:text-brand-cream">
-              Butts
-            </span>
-          </div>
-        </Link>
-        <nav className="flex flex-wrap items-center justify-end gap-2 text-sm">
-          {navLinks.map((link) => {
-            const isActive = pathname?.startsWith(link.href);
-            return (
-              <Link
-                key={link.href}
-                href={link.href}
-                className={clsx(
-                  "nav-link",
-                  isActive
-                    ? "bg-white/25 text-white shadow-sm"
-                    : "text-white/80 hover:text-white"
-                )}
-              >
-                {link.label}
-              </Link>
-            );
-          })}
-        </nav>
-        <div className="flex items-center gap-3">
-          <div className="hidden text-right text-xs leading-tight text-white/80 sm:flex sm:flex-col sm:items-end">
-            {displayName && (
-              <span className="font-semibold text-white">{displayName}</span>
-            )}
-            {role && <span className="uppercase tracking-[0.22em] text-[11px] text-white/60">{role}</span>}
-          </div>
-          <ClaimOwnerButton />
-          <button
-            type="button"
-            onClick={handleSignOut}
-            className="rounded-full bg-white/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.25em] text-white transition hover:bg-white/30"
-            disabled={loading}
-          >
-            Log out
-          </button>
-        </div>
+    <header className="topnav">
+      <div className="right">
+        <span>{name}</span>
+        <span className="badge">{badge}</span>
       </div>
     </header>
   );

--- a/components/scheduling/AppointmentDetailDrawer.tsx
+++ b/components/scheduling/AppointmentDetailDrawer.tsx
@@ -89,7 +89,10 @@ export default function AppointmentDetailDrawer({
 
   const appointmentId = draft?.id ?? null;
   const allowedForActions = useMemo(
-    () => ["master", "admin", "senior_groomer", "receptionist"].includes(role),
+    () => {
+      const normalized = role?.toLowerCase() ?? "";
+      return ["master", "admin", "senior_groomer", "receptionist"].includes(normalized);
+    },
     [role]
   );
 

--- a/lib/auth/roles.ts
+++ b/lib/auth/roles.ts
@@ -1,0 +1,37 @@
+import { isFrontDeskRole, isGroomerRole, isManagerRole } from "@/lib/auth/access";
+import type { Role as LegacyRole } from "@/lib/auth/profile";
+
+export function toLegacyRole(role: string | null): LegacyRole | null {
+  if (!role) return null;
+  const normalized = role.toLowerCase();
+  if (normalized.includes("master")) return "master";
+  if (normalized.includes("admin")) return "admin";
+  if (normalized.includes("senior_groomer") || normalized.includes("senior groomer") || normalized.includes("manager")) {
+    return "senior_groomer";
+  }
+  if (normalized.includes("front desk") || normalized.includes("receptionist")) {
+    return "receptionist";
+  }
+  if (normalized.includes("groomer")) return "groomer";
+  if (normalized.includes("client")) return "client";
+  return null;
+}
+
+export function derivePermissionFlags(role: string | null) {
+  const legacy = toLegacyRole(role);
+  const manager = legacy ? isManagerRole(legacy) : false;
+  const frontDesk = legacy ? isFrontDeskRole(legacy) : false;
+  const groomer = legacy ? isGroomerRole(legacy) : false;
+
+  return {
+    canAccessSettings: manager,
+    canManageCalendar: manager || frontDesk || groomer,
+    canManageEmployees: manager,
+    canViewReports: manager || frontDesk,
+  };
+}
+
+export function canManageWorkspace(role: string | null): boolean {
+  const legacy = toLegacyRole(role);
+  return legacy ? isManagerRole(legacy) : false;
+}


### PR DESCRIPTION
## Summary
- add /api/me route that resolves the signed-in user's profile without defaulting to a client role
- replace the client AuthProvider with a Supabase-backed context and simplify the layout/nav to consume it
- introduce helpers for mapping human-readable roles to legacy permissions and update pages to respect the new auth data

## Testing
- npm run lint
- npm run test *(fails: ts-node cannot resolve the optional `server-only` package referenced by Supabase server client)*

------
https://chatgpt.com/codex/tasks/task_e_68d4bf55c5888324b95be63d9a39c83a