### PR TITLE
Normalize master role slugs across onboarding and auth

### DIFF
--- a/app/api/admin/claim-owner/route.ts
+++ b/app/api/admin/claim-owner/route.ts
@@ -14,15 +14,15 @@ export async function POST() {
   // Demote any existing master except me
   const demote = await admin
     .from("profiles")
-    .update({ role: "Manager" })
-    .eq("role", "Master Account")
+    .update({ role: "senior_groomer" })
+    .eq("role", "master")
     .neq("id", uid);
   if (demote.error) return NextResponse.json({ error: demote.error.message }, { status: 400 });
 
-  // Ensure my profile exists & is Master Account
+  // Ensure my profile exists & is marked as master
   const upsertProfile = await admin
     .from("profiles")
-    .upsert({ id: uid, full_name: session.user.email ?? "Owner", role: "Master Account" }, { onConflict: "id" });
+    .upsert({ id: uid, full_name: session.user.email ?? "Owner", role: "master" }, { onConflict: "id" });
   if (upsertProfile.error) return NextResponse.json({ error: upsertProfile.error.message }, { status: 400 });
 
   // Ensure employees row with dashboard access

--- a/app/api/staff/invite/route.ts
+++ b/app/api/staff/invite/route.ts
@@ -12,7 +12,9 @@ export async function POST(request: Request) {
 
   const me = await supabase.from("profiles").select("id, role, business_id").eq("id", session.user.id).maybeSingle();
   if (me.error || !me.data?.business_id) return NextResponse.json({ error: "No business" }, { status: 403 });
-  if (!["Master Account","Manager"].includes(String(me.data.role))) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  if (!["master", "senior_groomer"].includes(String(me.data.role))) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
 
   const { email, role } = await request.json().catch(() => ({}));
   if (!email || !role || !["Manager","Front Desk","Groomer"].includes(role)) {

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -46,7 +46,7 @@ function hasElevatedAccess(member: TeamMember): boolean {
 }
 
 export default function SettingsPage() {
-  const { loading: authLoading, role, profile, refresh } = useAuth();
+  const { loading: authLoading, role, roleLabel, profile, refresh } = useAuth();
 
   const [team, setTeam] = useState<TeamMember[]>([]);
   const [loading, setLoading] = useState(false);
@@ -86,7 +86,7 @@ export default function SettingsPage() {
     }
   }, [authLoading, loadTeam, role]);
 
-  const roleLabel = useMemo(() => role ?? 'Guest', [role]);
+  const displayRole = useMemo(() => roleLabel ?? 'Guest', [roleLabel]);
 
   const userEmail = profile?.email ?? null;
 
@@ -126,7 +126,7 @@ export default function SettingsPage() {
           <p className="text-xs font-semibold uppercase tracking-[0.35em] text-brand-navy/60">Logged in as</p>
           <p className="text-2xl font-bold text-brand-navy">{userEmail ?? 'Team member'}</p>
           <p className="text-sm text-brand-navy/70">
-            Role: <span className="font-semibold text-brand-navy">{roleLabel}</span>
+            Role: <span className="font-semibold text-brand-navy">{displayRole}</span>
           </p>
           {userEmail && <p className="text-xs text-brand-navy/50">Email: {userEmail}</p>}
         </div>

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -3,9 +3,9 @@ import React from "react";
 import { useAuth } from "@/components/AuthProvider";
 
 export default function TopNav() {
-  const { loading, role, profile } = useAuth();
+  const { loading, roleLabel, profile } = useAuth();
 
-  const badge = loading ? "…" : role ?? "Guest";
+  const badge = loading ? "…" : roleLabel ?? "Guest";
   const name = profile?.email ?? "User";
 
   return (

--- a/lib/auth/profile.ts
+++ b/lib/auth/profile.ts
@@ -18,9 +18,26 @@ export function normaliseName(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+const roleAliases: Record<string, Role> = {
+  master: 'master',
+  'master account': 'master',
+  admin: 'admin',
+  administrator: 'admin',
+  'senior groomer': 'senior_groomer',
+  'senior_groomer': 'senior_groomer',
+  manager: 'senior_groomer',
+  groomer: 'groomer',
+  'front desk': 'receptionist',
+  'front_desk': 'receptionist',
+  receptionist: 'receptionist',
+  client: 'client',
+};
+
 export function normaliseRole(value: unknown): Role {
   if (typeof value === 'string') {
     const trimmed = value.trim().toLowerCase();
+    const alias = roleAliases[trimmed];
+    if (alias) return alias;
     if (isRole(trimmed)) return trimmed;
   }
   return 'client';

--- a/sql/2025-09-business-onboarding.sql
+++ b/sql/2025-09-business-onboarding.sql
@@ -30,7 +30,7 @@ CREATE OR REPLACE FUNCTION public.set_default_client_profile()
 RETURNS trigger AS $$
 BEGIN
   INSERT INTO public.profiles (id, role)
-  VALUES (NEW.id, 'Client'::role_t)
+  VALUES (NEW.id, 'client')
   ON CONFLICT (id) DO NOTHING;
   RETURN NEW;
 END;
@@ -54,7 +54,7 @@ BEGIN
     INSERT INTO public.businesses (name) VALUES (COALESCE(p_business_name,'My Grooming Business')) RETURNING id INTO v_bid;
 
     UPDATE public.profiles
-      SET role='Master Account'::role_t, business_id=v_bid
+      SET role='master', business_id=v_bid
       WHERE id = p_user;
 
     INSERT INTO public.employees (user_id, name, active, role, business_id, app_permissions)
@@ -97,7 +97,7 @@ FOR ALL USING (
     SELECT 1 FROM public.profiles p
     WHERE p.id = auth.uid()
       AND p.business_id = staff_invites.business_id
-      AND p.role::text IN ('Master Account','Manager')
+      AND p.role IN ('master','senior_groomer')
   )
 )
 WITH CHECK (
@@ -105,7 +105,7 @@ WITH CHECK (
     SELECT 1 FROM public.profiles p
     WHERE p.id = auth.uid()
       AND p.business_id = staff_invites.business_id
-      AND p.role::text IN ('Master Account','Manager')
+      AND p.role IN ('master','senior_groomer')
   )
 );
 


### PR DESCRIPTION
## Summary
- switch onboarding and admin SQL to persist the lowercase `master` slug and update invite policies to recognise manager slugs
- normalise Supabase roles inside the AuthProvider and expose a display label so the UI shows "Master Account" while logic uses slugs
- align admin APIs and top-level navigation/settings pages with the slug-based roles to keep privilege checks consistent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4d08e07848324a5ac746b0a88637e