### PR TITLE
Align role names with new capitalized titles

### DIFF
--- a/app/(app)/booking/BookingClient.tsx
+++ b/app/(app)/booking/BookingClient.tsx
@@ -43,21 +43,21 @@ const staffOptions: StaffOption[] = [
   {
     id: "sasha",
     name: "Sasha Taylor",
-    role: "Master Groomer",
+    role: "Manager",
     avatar: "https://avatars.dicebear.com/api/initials/ST.svg",
     bio: "Specialises in hand scissoring and anxious pups.",
   },
   {
     id: "myles",
     name: "Myles Chen",
-    role: "Senior Groomer",
+    role: "Groomer",
     avatar: "https://avatars.dicebear.com/api/initials/MC.svg",
     bio: "Loves double coats, creative colour and doodles.",
   },
   {
     id: "imani",
     name: "Imani Hart",
-    role: "Pet Stylist",
+    role: "Bather",
     avatar: "https://avatars.dicebear.com/api/initials/IH.svg",
     bio: "Speedy with bath & tidy packages and small breeds.",
   },
@@ -257,7 +257,8 @@ export default function BookingClient() {
       <div className="mx-auto max-w-2xl px-6 py-16 text-white/80">
         <h1 className="text-2xl font-semibold text-white">Booking unavailable</h1>
         <p className="mt-3 text-sm">
-          Your role does not allow access to the booking flow. Front desk, managers and administrators can book
+          Your role does not allow access to the booking flow. Front Desk, Managers, Admins, or the Master Account can
+          book
           appointments on behalf of clients.
         </p>
       </div>

--- a/app/(app)/calendar/page.tsx
+++ b/app/(app)/calendar/page.tsx
@@ -647,7 +647,7 @@ export default function CalendarPage() {
         <h1 className="text-2xl font-semibold text-white">Calendar unavailable</h1>
         <p className="mt-3 text-sm">
           Your profile does not have access to the scheduling calendar. If you believe this is a mistake, please
-          contact a manager or administrator.
+          contact a Manager, Admin, or the Master Account.
         </p>
       </div>
     );

--- a/app/api/admin/claim-owner/route.ts
+++ b/app/api/admin/claim-owner/route.ts
@@ -15,11 +15,11 @@ export async function POST() {
   const demote = await admin
     .from("profiles")
     .update({ role: "Manager" })
-    .eq("role", "Master Account")
+    .in("role", ["Master Account", "master"])
     .neq("id", uid);
   if (demote.error) return NextResponse.json({ error: demote.error.message }, { status: 400 });
 
-  // Ensure my profile exists & is Master Account
+  // Ensure my profile exists & is marked as master
   const upsertProfile = await admin
     .from("profiles")
     .upsert({ id: uid, full_name: session.user.email ?? "Owner", role: "Master Account" }, { onConflict: "id" });
@@ -29,7 +29,7 @@ export async function POST() {
   const upsertEmp = await admin
     .from("employees")
     .upsert(
-      { user_id: uid, name: "Owner", active: true, role: "Manager", app_permissions: { dashboard: true } },
+      { user_id: uid, name: "Owner", active: true, role: "Master Account", app_permissions: { dashboard: true } },
       { onConflict: "user_id" }
     );
   if (upsertEmp.error) return NextResponse.json({ error: upsertEmp.error.message }, { status: 400 });

--- a/app/api/staff/route.ts
+++ b/app/api/staff/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { normaliseRole } from "@/lib/auth/profile";
 import { z } from "zod";
 
 import { getSupabaseAdmin } from "@/lib/supabase/server";
@@ -208,7 +209,8 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: profileError.message }, { status: 500 });
   }
 
-  if (!me || !["master", "admin"].includes(me.role)) {
+  const resolvedRole = normaliseRole(me?.role ?? null);
+  if (!me || !["Master Account", "Admin"].includes(resolvedRole)) {
     return NextResponse.json({ error: "forbidden" }, { status: 403 });
   }
 

--- a/app/employees/[id]/EmployeeDetailClient.tsx
+++ b/app/employees/[id]/EmployeeDetailClient.tsx
@@ -209,7 +209,12 @@ export default function EmployeeDetailClient({ children, employee, goals }: Prop
       if (isTruthyFlag(flags.is_manager)) return true;
     }
     const role = viewer.role?.toLowerCase() ?? "";
-    return role.includes("manager") || role.includes("owner") || role.includes("admin");
+    return (
+      role.includes("manager") ||
+      role.includes("owner") ||
+      role.includes("admin") ||
+      role.includes("master")
+    );
   }, [permissions, viewer]);
 
   const viewerCanEditStaff = useMemo(() => {
@@ -225,7 +230,12 @@ export default function EmployeeDetailClient({ children, employee, goals }: Prop
       if (isTruthyFlag(flags.is_manager)) return true;
     }
     const role = viewer.role?.toLowerCase() ?? "";
-    return role.includes("manager") || role.includes("owner") || role.includes("admin");
+    return (
+      role.includes("manager") ||
+      role.includes("owner") ||
+      role.includes("admin") ||
+      role.includes("master")
+    );
   }, [isOwner, permissions, viewer]);
 
   const [toasts, setToasts] = useState<Toast[]>([]);

--- a/app/employees/new/page.tsx
+++ b/app/employees/new/page.tsx
@@ -312,8 +312,8 @@ export default function NewEmployeePage() {
         <Card>
           <h1 className="text-2xl font-semibold text-brand-navy">Access restricted</h1>
           <p className="mt-2 text-sm text-brand-navy/70">
-            You do not have permission to add staff members. Ask an administrator to adjust your access if you
-            believe this is a mistake.
+            You do not have permission to add staff members. Ask the Master Account or an Admin to adjust your access if
+            you believe this is a mistake.
           </p>
         </Card>
       </PageContainer>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,9 +22,9 @@ export default async function Home() {
     .maybeSingle();
 
   const profile = mapProfileRow(data) ?? null;
-  const role = profile?.role ?? "client";
+  const role = profile?.role ?? "Client";
 
-  if (role === "client") {
+  if (role === "Client") {
     redirect("/client");
   }
 

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -27,7 +27,7 @@ const configurationLinks = [
 
 function hasElevatedAccess(member: TeamMember): boolean {
   const role = member.role?.toLowerCase() ?? '';
-  if (role.includes('owner') || role.includes('admin') || role.includes('manager')) {
+  if (role.includes('owner') || role.includes('admin') || role.includes('manager') || role.includes('master')) {
     return true;
   }
 
@@ -46,7 +46,7 @@ function hasElevatedAccess(member: TeamMember): boolean {
 }
 
 export default function SettingsPage() {
-  const { loading: authLoading, role, profile, refresh } = useAuth();
+  const { loading: authLoading, role, roleLabel, profile, refresh } = useAuth();
 
   const [team, setTeam] = useState<TeamMember[]>([]);
   const [loading, setLoading] = useState(false);
@@ -86,7 +86,7 @@ export default function SettingsPage() {
     }
   }, [authLoading, loadTeam, role]);
 
-  const roleLabel = useMemo(() => role ?? 'Guest', [role]);
+  const displayRole = useMemo(() => roleLabel ?? 'Guest', [roleLabel]);
 
   const userEmail = profile?.email ?? null;
 
@@ -108,7 +108,8 @@ export default function SettingsPage() {
       <div className="space-y-3 p-6">
         <h1 className="text-2xl font-semibold">Settings</h1>
         <p className="text-sm text-white/80">
-          You do not currently have access to this page. Please contact an administrator if you believe this is an error.
+          You do not currently have access to this page. Please contact the Master Account or an Admin if you believe this
+          is an error.
         </p>
       </div>
     );
@@ -126,7 +127,7 @@ export default function SettingsPage() {
           <p className="text-xs font-semibold uppercase tracking-[0.35em] text-brand-navy/60">Logged in as</p>
           <p className="text-2xl font-bold text-brand-navy">{userEmail ?? 'Team member'}</p>
           <p className="text-sm text-brand-navy/70">
-            Role: <span className="font-semibold text-brand-navy">{roleLabel}</span>
+            Role: <span className="font-semibold text-brand-navy">{displayRole}</span>
           </p>
           {userEmail && <p className="text-xs text-brand-navy/50">Email: {userEmail}</p>}
         </div>

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -3,9 +3,9 @@ import React from "react";
 import { useAuth } from "@/components/AuthProvider";
 
 export default function TopNav() {
-  const { loading, role, profile } = useAuth();
+  const { loading, roleLabel, profile } = useAuth();
 
-  const badge = loading ? "…" : role ?? "Guest";
+  const badge = loading ? "…" : roleLabel ?? "Guest";
   const name = profile?.email ?? "User";
 
   return (

--- a/components/scheduling/AppointmentDetailDrawer.tsx
+++ b/components/scheduling/AppointmentDetailDrawer.tsx
@@ -91,7 +91,7 @@ export default function AppointmentDetailDrawer({
   const allowedForActions = useMemo(
     () => {
       const normalized = role?.toLowerCase() ?? "";
-      return ["master", "admin", "senior_groomer", "receptionist"].includes(normalized);
+      return ["master account", "admin", "manager", "front desk"].includes(normalized);
     },
     [role]
   );

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 ## Roles
 - Master Account: one per business. Full control.
-- Manager, Front Desk, Groomer: invited by Master/Manager.
+- Manager, Front Desk, Groomer, Bather: invited by the Master Account or a Manager.
 - Client: default for new auth users unless invited as staff.
 
 ## Tenancy

--- a/lib/auth/access.ts
+++ b/lib/auth/access.ts
@@ -10,10 +10,10 @@ export type AppRoute =
   | "messages"
   | "settings";
 
-const managerRoles: Role[] = ["master", "admin", "senior_groomer"];
-const frontDeskRoles: Role[] = ["receptionist"];
-const groomerRoles: Role[] = ["groomer"];
-const clientRoles: Role[] = ["client"];
+const managerRoles: Role[] = ["Master Account", "Admin", "Manager"];
+const frontDeskRoles: Role[] = ["Front Desk"];
+const groomerRoles: Role[] = ["Groomer", "Bather"];
+const clientRoles: Role[] = ["Client"];
 
 const routeAccess: Record<AppRoute, Role[]> = {
   dashboard: managerRoles,
@@ -80,19 +80,5 @@ export function navItemsForRole(role: Role): NavItem[] {
 }
 
 export function roleDisplayName(role: Role): string {
-  switch (role) {
-    case "master":
-      return "Master Account";
-    case "admin":
-      return "Admin";
-    case "senior_groomer":
-      return "Manager";
-    case "groomer":
-      return "Groomer";
-    case "receptionist":
-      return "Front Desk";
-    case "client":
-    default:
-      return "Client";
-  }
+  return role;
 }

--- a/lib/auth/profile.ts
+++ b/lib/auth/profile.ts
@@ -1,4 +1,11 @@
-export type Role = 'master' | 'admin' | 'senior_groomer' | 'groomer' | 'receptionist' | 'client';
+export type Role =
+  | 'Master Account'
+  | 'Admin'
+  | 'Manager'
+  | 'Front Desk'
+  | 'Groomer'
+  | 'Bather'
+  | 'Client';
 
 export type UserProfile = {
   id: string;
@@ -18,23 +25,49 @@ export function normaliseName(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+const roleAliases: Record<string, Role> = {
+  master: 'Master Account',
+  'master account': 'Master Account',
+  'master_account': 'Master Account',
+  masteraccount: 'Master Account',
+  admin: 'Admin',
+  administrator: 'Admin',
+  manager: 'Manager',
+  'senior groomer': 'Manager',
+  'senior_groomer': 'Manager',
+  groomer: 'Groomer',
+  bather: 'Bather',
+  'front desk': 'Front Desk',
+  'front_desk': 'Front Desk',
+  frontdesk: 'Front Desk',
+  receptionist: 'Front Desk',
+  client: 'Client',
+  clients: 'Client',
+};
+
 export function normaliseRole(value: unknown): Role {
   if (typeof value === 'string') {
-    const trimmed = value.trim().toLowerCase();
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      return 'Client';
+    }
+    const alias = roleAliases[trimmed.toLowerCase()];
+    if (alias) return alias;
     if (isRole(trimmed)) return trimmed;
   }
-  return 'client';
+  return 'Client';
 }
 
 function isRole(value: string): value is Role {
-  return [
-    'master',
-    'admin',
-    'senior_groomer',
-    'groomer',
-    'receptionist',
-    'client',
-  ].includes(value);
+  return (
+    value === 'Master Account' ||
+    value === 'Admin' ||
+    value === 'Manager' ||
+    value === 'Front Desk' ||
+    value === 'Groomer' ||
+    value === 'Bather' ||
+    value === 'Client'
+  );
 }
 
 export function mapProfileRow(row: RawProfileRow | null | undefined): UserProfile | null {

--- a/lib/auth/roles.ts
+++ b/lib/auth/roles.ts
@@ -1,20 +1,16 @@
 import { isFrontDeskRole, isGroomerRole, isManagerRole } from "@/lib/auth/access";
-import type { Role as LegacyRole } from "@/lib/auth/profile";
+import { normaliseRole, type Role as LegacyRole } from "@/lib/auth/profile";
 
-export function toLegacyRole(role: string | null): LegacyRole | null {
+export function toLegacyRole(role: string | LegacyRole | null): LegacyRole | null {
   if (!role) return null;
-  const normalized = role.toLowerCase();
-  if (normalized.includes("master")) return "master";
-  if (normalized.includes("admin")) return "admin";
-  if (normalized.includes("senior_groomer") || normalized.includes("senior groomer") || normalized.includes("manager")) {
-    return "senior_groomer";
+  if (typeof role === "string") {
+    const trimmed = role.trim();
+    if (!trimmed || trimmed.toLowerCase() === "guest") {
+      return null;
+    }
+    return normaliseRole(trimmed);
   }
-  if (normalized.includes("front desk") || normalized.includes("receptionist")) {
-    return "receptionist";
-  }
-  if (normalized.includes("groomer")) return "groomer";
-  if (normalized.includes("client")) return "client";
-  return null;
+  return role;
 }
 
 export function derivePermissionFlags(role: string | null) {

--- a/sql/2025-09-business-onboarding.sql
+++ b/sql/2025-09-business-onboarding.sql
@@ -30,7 +30,7 @@ CREATE OR REPLACE FUNCTION public.set_default_client_profile()
 RETURNS trigger AS $$
 BEGIN
   INSERT INTO public.profiles (id, role)
-  VALUES (NEW.id, 'Client'::role_t)
+  VALUES (NEW.id, 'Client')
   ON CONFLICT (id) DO NOTHING;
   RETURN NEW;
 END;
@@ -54,11 +54,11 @@ BEGIN
     INSERT INTO public.businesses (name) VALUES (COALESCE(p_business_name,'My Grooming Business')) RETURNING id INTO v_bid;
 
     UPDATE public.profiles
-      SET role='Master Account'::role_t, business_id=v_bid
+      SET role='Master Account', business_id=v_bid
       WHERE id = p_user;
 
     INSERT INTO public.employees (user_id, name, active, role, business_id, app_permissions)
-    VALUES (p_user, 'Owner', true, 'Manager', v_bid, '{"dashboard":true}'::jsonb)
+    VALUES (p_user, 'Owner', true, 'Master Account', v_bid, '{"dashboard":true}'::jsonb)
     ON CONFLICT (user_id) DO UPDATE
       SET business_id=EXCLUDED.business_id,
           active=true,
@@ -77,7 +77,7 @@ CREATE TABLE IF NOT EXISTS public.staff_invites (
   id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   business_id  uuid NOT NULL REFERENCES public.businesses(id) ON DELETE CASCADE,
   email        text NOT NULL,
-  role         text NOT NULL CHECK (role IN ('Manager','Front Desk','Groomer')),
+  role         text NOT NULL CHECK (role IN ('Master Account','Manager','Front Desk','Groomer','Bather')),
   token        text UNIQUE NOT NULL,
   created_by   uuid REFERENCES public.profiles(id),
   created_at   timestamptz NOT NULL DEFAULT now(),
@@ -97,7 +97,7 @@ FOR ALL USING (
     SELECT 1 FROM public.profiles p
     WHERE p.id = auth.uid()
       AND p.business_id = staff_invites.business_id
-      AND p.role::text IN ('Master Account','Manager')
+      AND p.role IN ('Master Account','Manager')
   )
 )
 WITH CHECK (
@@ -105,7 +105,7 @@ WITH CHECK (
     SELECT 1 FROM public.profiles p
     WHERE p.id = auth.uid()
       AND p.business_id = staff_invites.business_id
-      AND p.role::text IN ('Master Account','Manager')
+      AND p.role IN ('Master Account','Manager')
   )
 );
 

--- a/supabase/migrations/20251115_scheduling_tables.sql
+++ b/supabase/migrations/20251115_scheduling_tables.sql
@@ -6,6 +6,9 @@ DROP POLICY IF EXISTS appt_admin_all ON public.appointments;
 DROP POLICY IF EXISTS appt_senior_read_all ON public.appointments;
 DROP POLICY IF EXISTS appt_senior_insert ON public.appointments;
 DROP POLICY IF EXISTS appt_senior_update_own ON public.appointments;
+DROP POLICY IF EXISTS appt_manager_read_all ON public.appointments;
+DROP POLICY IF EXISTS appt_manager_insert ON public.appointments;
+DROP POLICY IF EXISTS appt_manager_update_own ON public.appointments;
 DROP POLICY IF EXISTS appt_recept_insert ON public.appointments;
 DROP POLICY IF EXISTS appt_recept_read_all ON public.appointments;
 DROP POLICY IF EXISTS appt_groomer_read_own ON public.appointments;
@@ -162,49 +165,49 @@ $$;
 CREATE POLICY appointments_management_all ON public.appointments
 FOR ALL
 USING (
-  public.has_role_ci(ARRAY['Manager','Admin','Master Account','manager','admin','master'])
+  public.has_role_ci(ARRAY['Master Account','Admin','Manager','master account','admin','manager','master'])
 )
 WITH CHECK (
-  public.has_role_ci(ARRAY['Manager','Admin','Master Account','manager','admin','master'])
+  public.has_role_ci(ARRAY['Master Account','Admin','Manager','master account','admin','manager','master'])
 );
 
 CREATE POLICY appointments_front_desk_select ON public.appointments
 FOR SELECT
 USING (
-  public.has_role_ci(ARRAY['Front Desk','receptionist'])
+  public.has_role_ci(ARRAY['Front Desk','receptionist','front desk'])
 );
 
 CREATE POLICY appointments_front_desk_insert ON public.appointments
 FOR INSERT
 WITH CHECK (
-  public.has_role_ci(ARRAY['Front Desk','receptionist'])
+  public.has_role_ci(ARRAY['Front Desk','receptionist','front desk'])
 );
 
 CREATE POLICY appointments_front_desk_update ON public.appointments
 FOR UPDATE
 USING (
-  public.has_role_ci(ARRAY['Front Desk','receptionist'])
+  public.has_role_ci(ARRAY['Front Desk','receptionist','front desk'])
 )
 WITH CHECK (
-  public.has_role_ci(ARRAY['Front Desk','receptionist'])
+  public.has_role_ci(ARRAY['Front Desk','receptionist','front desk'])
 );
 
 CREATE POLICY appointments_groomer_select ON public.appointments
 FOR SELECT
 USING (
   auth.uid() = staff_id
-  AND public.has_role_ci(ARRAY['Groomer','Senior Groomer','groomer','senior_groomer'])
+  AND public.has_role_ci(ARRAY['Groomer','Bather','Senior Groomer','groomer','bather','senior_groomer'])
 );
 
 CREATE POLICY appointments_groomer_update ON public.appointments
 FOR UPDATE
 USING (
   auth.uid() = staff_id
-  AND public.has_role_ci(ARRAY['Groomer','Senior Groomer','groomer','senior_groomer'])
+  AND public.has_role_ci(ARRAY['Groomer','Bather','Senior Groomer','groomer','bather','senior_groomer'])
 )
 WITH CHECK (
   auth.uid() = staff_id
-  AND public.has_role_ci(ARRAY['Groomer','Senior Groomer','groomer','senior_groomer'])
+  AND public.has_role_ci(ARRAY['Groomer','Bather','Senior Groomer','groomer','bather','senior_groomer'])
 );
 
 CREATE POLICY appointments_client_select ON public.appointments
@@ -218,10 +221,10 @@ USING (
 CREATE POLICY pets_management_all ON public.pets
 FOR ALL
 USING (
-  public.has_role_ci(ARRAY['Manager','Admin','Master Account','manager','admin','master'])
+  public.has_role_ci(ARRAY['Master Account','Admin','Manager','master account','admin','manager','master'])
 )
 WITH CHECK (
-  public.has_role_ci(ARRAY['Manager','Admin','Master Account','manager','admin','master'])
+  public.has_role_ci(ARRAY['Master Account','Admin','Manager','master account','admin','manager','master'])
 );
 
 CREATE POLICY pets_client_select ON public.pets
@@ -235,10 +238,10 @@ USING (
 CREATE POLICY pet_photos_management_all ON public.pet_photos
 FOR ALL
 USING (
-  public.has_role_ci(ARRAY['Manager','Admin','Master Account','manager','admin','master'])
+  public.has_role_ci(ARRAY['Master Account','Admin','Manager','master account','admin','manager','master'])
 )
 WITH CHECK (
-  public.has_role_ci(ARRAY['Manager','Admin','Master Account','manager','admin','master'])
+  public.has_role_ci(ARRAY['Master Account','Admin','Manager','master account','admin','manager','master'])
 );
 
 CREATE POLICY pet_photos_client_select ON public.pet_photos
@@ -255,7 +258,7 @@ USING (
 CREATE POLICY pet_photos_groomer_insert ON public.pet_photos
 FOR INSERT
 WITH CHECK (
-  public.has_role_ci(ARRAY['Groomer','Senior Groomer','groomer','senior_groomer'])
+  public.has_role_ci(ARRAY['Groomer','Bather','Senior Groomer','groomer','bather','senior_groomer'])
   AND EXISTS (
     SELECT 1
     FROM public.appointments a
@@ -268,10 +271,10 @@ WITH CHECK (
 CREATE POLICY availability_rules_management_all ON public.availability_rules
 FOR ALL
 USING (
-  public.has_role_ci(ARRAY['Manager','Admin','Master Account','manager','admin','master'])
+  public.has_role_ci(ARRAY['Master Account','Admin','Manager','master account','admin','manager','master'])
 )
 WITH CHECK (
-  public.has_role_ci(ARRAY['Manager','Admin','Master Account','manager','admin','master'])
+  public.has_role_ci(ARRAY['Master Account','Admin','Manager','master account','admin','manager','master'])
 );
 
 CREATE POLICY availability_rules_staff_select ON public.availability_rules
@@ -284,10 +287,10 @@ USING (
 CREATE POLICY blackout_dates_management_all ON public.blackout_dates
 FOR ALL
 USING (
-  public.has_role_ci(ARRAY['Manager','Admin','Master Account','manager','admin','master'])
+  public.has_role_ci(ARRAY['Master Account','Admin','Manager','master account','admin','manager','master'])
 )
 WITH CHECK (
-  public.has_role_ci(ARRAY['Manager','Admin','Master Account','manager','admin','master'])
+  public.has_role_ci(ARRAY['Master Account','Admin','Manager','master account','admin','manager','master'])
 );
 
 CREATE POLICY blackout_dates_staff_select ON public.blackout_dates

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,7 +1,7 @@
 -- Seed data for staff module
 insert into public.employees (id, name, email, phone, role, status, commission_rate, app_permissions)
 values
-  (1, 'Alex Groomer', 'alex@scruffybutts.test', '+1-555-0100', 'Senior Groomer', 'Active', 0.2, '{"is_manager": true, "can_manage_discounts": true}'::jsonb)
+  (1, 'Alex Groomer', 'alex@scruffybutts.test', '+1-555-0100', 'Manager', 'Active', 0.2, '{"is_manager": true, "can_manage_discounts": true}'::jsonb)
 on conflict (id) do update set
   name = excluded.name,
   email = excluded.email,


### PR DESCRIPTION
## Summary
- switch the application role model to capitalized titles (Master Account, Manager, Front Desk, Groomer, Bather, Admin, Client) and normalise old slugs via the auth profile utilities
- update UI gating, messaging, and API handlers to respect the new role set, including invite options, transfer/claim flows, and navigation permissions
- revise onboarding SQL, Supabase migrations, and seeds so stored roles and RLS policies accept the capitalised titles and extend groomer-level access to Bathers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4d08e07848324a5ac746b0a88637e