### PR TITLE
Normalize roles to slugs and fix master login

### DIFF
--- a/app/(app)/booking/BookingClient.tsx
+++ b/app/(app)/booking/BookingClient.tsx
@@ -43,21 +43,21 @@ const staffOptions: StaffOption[] = [
   {
     id: "sasha",
     name: "Sasha Taylor",
-    role: "Master Groomer",
+    role: "Manager",
     avatar: "https://avatars.dicebear.com/api/initials/ST.svg",
     bio: "Specialises in hand scissoring and anxious pups.",
   },
   {
     id: "myles",
     name: "Myles Chen",
-    role: "Senior Groomer",
+    role: "Groomer",
     avatar: "https://avatars.dicebear.com/api/initials/MC.svg",
     bio: "Loves double coats, creative colour and doodles.",
   },
   {
     id: "imani",
     name: "Imani Hart",
-    role: "Pet Stylist",
+    role: "Bather",
     avatar: "https://avatars.dicebear.com/api/initials/IH.svg",
     bio: "Speedy with bath & tidy packages and small breeds.",
   },
@@ -257,7 +257,8 @@ export default function BookingClient() {
       <div className="mx-auto max-w-2xl px-6 py-16 text-white/80">
         <h1 className="text-2xl font-semibold text-white">Booking unavailable</h1>
         <p className="mt-3 text-sm">
-          Your role does not allow access to the booking flow. Front desk, managers and administrators can book
+          Your role does not allow access to the booking flow. Front Desk, Managers, Admins, or the Master Account can
+          book
           appointments on behalf of clients.
         </p>
       </div>

--- a/app/(app)/calendar/page.tsx
+++ b/app/(app)/calendar/page.tsx
@@ -647,7 +647,7 @@ export default function CalendarPage() {
         <h1 className="text-2xl font-semibold text-white">Calendar unavailable</h1>
         <p className="mt-3 text-sm">
           Your profile does not have access to the scheduling calendar. If you believe this is a mistake, please
-          contact a manager or administrator.
+          contact a Manager, Admin, or the Master Account.
         </p>
       </div>
     );

--- a/app/api/admin/claim-owner/route.ts
+++ b/app/api/admin/claim-owner/route.ts
@@ -14,22 +14,22 @@ export async function POST() {
   // Demote any existing master except me
   const demote = await admin
     .from("profiles")
-    .update({ role: "Manager" })
-    .eq("role", "Master Account")
+    .update({ role: "manager" })
+    .in("role", ["master", "Master Account"])
     .neq("id", uid);
   if (demote.error) return NextResponse.json({ error: demote.error.message }, { status: 400 });
 
-  // Ensure my profile exists & is Master Account
+  // Ensure my profile exists & is marked as master
   const upsertProfile = await admin
     .from("profiles")
-    .upsert({ id: uid, full_name: session.user.email ?? "Owner", role: "Master Account" }, { onConflict: "id" });
+    .upsert({ id: uid, full_name: session.user.email ?? "Owner", role: "master" }, { onConflict: "id" });
   if (upsertProfile.error) return NextResponse.json({ error: upsertProfile.error.message }, { status: 400 });
 
   // Ensure employees row with dashboard access
   const upsertEmp = await admin
     .from("employees")
     .upsert(
-      { user_id: uid, name: "Owner", active: true, role: "Manager", app_permissions: { dashboard: true } },
+      { user_id: uid, name: "Owner", active: true, role: "master", app_permissions: { dashboard: true } },
       { onConflict: "user_id" }
     );
   if (upsertEmp.error) return NextResponse.json({ error: upsertEmp.error.message }, { status: 400 });

--- a/app/api/admin/transfer-master/route.ts
+++ b/app/api/admin/transfer-master/route.ts
@@ -3,6 +3,7 @@ export const runtime = "nodejs";
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { normaliseRole } from "@/lib/auth/profile";
 
 export async function POST(request: Request) {
   const supabase = createRouteHandlerClient({ cookies });
@@ -11,26 +12,31 @@ export async function POST(request: Request) {
 
   const me = await supabase.from("profiles").select("id, role, business_id").eq("id", session.user.id).maybeSingle();
   if (me.error || !me.data?.business_id) return NextResponse.json({ error: "No business" }, { status: 403 });
-  if (String(me.data.role) !== "Master Account") return NextResponse.json({ error: "Only Master can transfer" }, { status: 403 });
+  if (normaliseRole(me.data.role) !== "master") {
+    return NextResponse.json({ error: "Only Master can transfer" }, { status: 403 });
+  }
 
   const { targetUserId } = await request.json().catch(() => ({}));
   if (!targetUserId) return NextResponse.json({ error: "Missing targetUserId" }, { status: 400 });
 
   // Demote any master in same business except target
-  const demote = await supabase.from("profiles").update({ role: "Manager" })
+  const demote = await supabase.from("profiles").update({ role: "manager" })
     .eq("business_id", me.data.business_id)
-    .eq("role", "Master Account")
+    .in("role", ["master", "Master Account"])
     .neq("id", targetUserId);
   if (demote.error) return NextResponse.json({ error: demote.error.message }, { status: 400 });
 
   // Promote target
-  const promote = await supabase.from("profiles").update({ role: "Master Account" })
+  const promote = await supabase.from("profiles").update({ role: "master" })
     .eq("id", targetUserId).eq("business_id", me.data.business_id);
   if (promote.error) return NextResponse.json({ error: promote.error.message }, { status: 400 });
 
   // Ensure employees row for target
   await supabase.from("employees").upsert({
-    user_id: targetUserId, name: "Owner", active: true, role: "Manager",
+    user_id: targetUserId,
+    name: "Owner",
+    active: true,
+    role: "master",
     business_id: me.data.business_id, app_permissions: { dashboard: true }
   }, { onConflict: "user_id" });
 

--- a/app/api/staff/accept-invite/route.ts
+++ b/app/api/staff/accept-invite/route.ts
@@ -3,6 +3,7 @@ export const runtime = "nodejs";
 import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { normaliseRole } from "@/lib/auth/profile";
 
 export async function POST(request: Request) {
   const supabase = createRouteHandlerClient({ cookies });
@@ -23,22 +24,32 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Invite email mismatch" }, { status: 403 });
   }
 
+  const inviteRole = normaliseRole(inv.role);
+
   // Link profile to business and role
-  const { error: upErr } = await supabase.from("profiles").update({
-    business_id: inv.business_id,
-    role: inv.role
-  }).eq("id", session.user.id);
+  const { error: upErr } = await supabase
+    .from("profiles")
+    .update({
+      business_id: inv.business_id,
+      role: inviteRole,
+    })
+    .eq("id", session.user.id);
   if (upErr) return NextResponse.json({ error: upErr.message }, { status: 400 });
 
   // Ensure employees row
-  const { error: empErr } = await supabase.from("employees").upsert({
-    user_id: session.user.id,
-    name: session.user.email ?? "Staff",
-    active: true,
-    role: inv.role,
-    business_id: inv.business_id,
-    app_permissions: inv.role === "Manager" ? { dashboard: true } : {}
-  }, { onConflict: "user_id" });
+  const { error: empErr } = await supabase
+    .from("employees")
+    .upsert(
+      {
+        user_id: session.user.id,
+        name: session.user.email ?? "Staff",
+        active: true,
+        role: inviteRole,
+        business_id: inv.business_id,
+        app_permissions: inviteRole === "manager" ? { dashboard: true } : {},
+      },
+      { onConflict: "user_id" }
+    );
   if (empErr) return NextResponse.json({ error: empErr.message }, { status: 400 });
 
   // Mark accepted

--- a/app/api/staff/invite/route.ts
+++ b/app/api/staff/invite/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from "next/server";
 import { cookies } from "next/headers";
 import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
 import { randomBytes } from "crypto";
+import { normaliseRole } from "@/lib/auth/profile";
 
 export async function POST(request: Request) {
   const supabase = createRouteHandlerClient({ cookies });
@@ -12,10 +13,19 @@ export async function POST(request: Request) {
 
   const me = await supabase.from("profiles").select("id, role, business_id").eq("id", session.user.id).maybeSingle();
   if (me.error || !me.data?.business_id) return NextResponse.json({ error: "No business" }, { status: 403 });
-  if (!["Master Account","Manager"].includes(String(me.data.role))) return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  const inviterRole = normaliseRole(me.data.role);
+  if (!['master', 'manager'].includes(inviterRole)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
 
   const { email, role } = await request.json().catch(() => ({}));
-  if (!email || !role || !["Manager","Front Desk","Groomer"].includes(role)) {
+  if (typeof email !== 'string' || typeof role !== 'string') {
+    return NextResponse.json({ error: "Invalid email/role" }, { status: 400 });
+  }
+
+  const inviteeRole = normaliseRole(role);
+  const allowedRoles: typeof inviteeRole[] = ['manager', 'front_desk', 'groomer', 'bather'];
+  if (!email || !allowedRoles.includes(inviteeRole)) {
     return NextResponse.json({ error: "Invalid email/role" }, { status: 400 });
   }
 
@@ -23,7 +33,7 @@ export async function POST(request: Request) {
   const { error } = await supabase.from("staff_invites").insert({
     business_id: me.data.business_id,
     email,
-    role,
+    role: inviteeRole,
     token,
     created_by: me.data.id
   });

--- a/app/employees/[id]/EmployeeDetailClient.tsx
+++ b/app/employees/[id]/EmployeeDetailClient.tsx
@@ -209,7 +209,12 @@ export default function EmployeeDetailClient({ children, employee, goals }: Prop
       if (isTruthyFlag(flags.is_manager)) return true;
     }
     const role = viewer.role?.toLowerCase() ?? "";
-    return role.includes("manager") || role.includes("owner") || role.includes("admin");
+    return (
+      role.includes("manager") ||
+      role.includes("owner") ||
+      role.includes("admin") ||
+      role.includes("master")
+    );
   }, [permissions, viewer]);
 
   const viewerCanEditStaff = useMemo(() => {
@@ -225,7 +230,12 @@ export default function EmployeeDetailClient({ children, employee, goals }: Prop
       if (isTruthyFlag(flags.is_manager)) return true;
     }
     const role = viewer.role?.toLowerCase() ?? "";
-    return role.includes("manager") || role.includes("owner") || role.includes("admin");
+    return (
+      role.includes("manager") ||
+      role.includes("owner") ||
+      role.includes("admin") ||
+      role.includes("master")
+    );
   }, [isOwner, permissions, viewer]);
 
   const [toasts, setToasts] = useState<Toast[]>([]);

--- a/app/employees/[id]/components/StaffHeader.tsx
+++ b/app/employees/[id]/components/StaffHeader.tsx
@@ -2,6 +2,8 @@
 
 import clsx from "clsx";
 
+import { describeRole } from "@/lib/auth/profile";
+
 import { useEmployeeDetail } from "../EmployeeDetailClient";
 
 type StaffHeaderProps = {
@@ -43,6 +45,7 @@ export default function StaffHeader({ onCall, onText, onEmail }: StaffHeaderProp
   );
 
   const contactDetails = [employee.email, employee.phone].filter(Boolean).join(" · ");
+  const displayRole = describeRole(employee.role) ?? "—";
 
   return (
     <div className="rounded-2xl border border-slate-200 bg-white shadow-sm">
@@ -63,7 +66,7 @@ export default function StaffHeader({ onCall, onText, onEmail }: StaffHeaderProp
               <h1 className="text-xl font-semibold text-brand-navy">{employee.name ?? "Staff member"}</h1>
               <span className={statusTone}>{statusLabel}</span>
             </div>
-            <div className="text-sm font-medium text-slate-500">{employee.role ?? "—"}</div>
+            <div className="text-sm font-medium text-slate-500">{displayRole}</div>
             <div className="text-sm text-slate-400">{contactDetails || "No contact info"}</div>
           </div>
         </div>

--- a/app/employees/new/page.tsx
+++ b/app/employees/new/page.tsx
@@ -10,6 +10,7 @@ import Card from "@/components/Card";
 import PageContainer from "@/components/PageContainer";
 import { useAuth } from "@/components/AuthProvider";
 import { derivePermissionFlags } from "@/lib/auth/roles";
+import { normaliseRole } from "@/lib/auth/profile";
 import {
   CompensationPlanDraft,
   defaultCompensationPlan,
@@ -234,6 +235,13 @@ export default function NewEmployeePage() {
       return;
     }
 
+    const roleSlug = normaliseRole(trimmedRole);
+    const staffRoleOptions: ReturnType<typeof normaliseRole>[] = ['manager', 'front_desk', 'groomer', 'bather'];
+    if (!staffRoleOptions.includes(roleSlug)) {
+      setError("Please choose a valid staff role");
+      return;
+    }
+
     const draftResult = parseDraft(compensationDraft);
     if (draftResult.errors.length > 0) {
       setError(draftResult.errors.join(" "));
@@ -249,7 +257,7 @@ export default function NewEmployeePage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           name: trimmedName,
-          role: trimmedRole,
+          role: roleSlug,
           email: form.email.trim(),
           phone: form.phone,
           address_street: form.addressStreet.trim() || null,
@@ -312,8 +320,8 @@ export default function NewEmployeePage() {
         <Card>
           <h1 className="text-2xl font-semibold text-brand-navy">Access restricted</h1>
           <p className="mt-2 text-sm text-brand-navy/70">
-            You do not have permission to add staff members. Ask an administrator to adjust your access if you
-            believe this is a mistake.
+            You do not have permission to add staff members. Ask the Master Account or an Admin to adjust your access if
+            you believe this is a mistake.
           </p>
         </Card>
       </PageContainer>

--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -3,9 +3,9 @@ import React from "react";
 import { useAuth } from "@/components/AuthProvider";
 
 export default function TopNav() {
-  const { loading, role, profile } = useAuth();
+  const { loading, roleLabel, profile } = useAuth();
 
-  const badge = loading ? "…" : role ?? "Guest";
+  const badge = loading ? "…" : roleLabel ?? "Guest";
   const name = profile?.email ?? "User";
 
   return (

--- a/components/scheduling/AppointmentDetailDrawer.tsx
+++ b/components/scheduling/AppointmentDetailDrawer.tsx
@@ -88,13 +88,10 @@ export default function AppointmentDetailDrawer({
   const [toast, setToast] = useState<DrawerToast | null>(null);
 
   const appointmentId = draft?.id ?? null;
-  const allowedForActions = useMemo(
-    () => {
-      const normalized = role?.toLowerCase() ?? "";
-      return ["master", "admin", "senior_groomer", "receptionist"].includes(normalized);
-    },
-    [role]
-  );
+  const allowedForActions = useMemo(() => {
+    if (!role || role === "guest") return false;
+    return ["master", "admin", "manager", "front_desk"].includes(role);
+  }, [role]);
 
   const {
     lastSent,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,9 @@
 # SB App Architecture (Bible)
 
 ## Roles
+- Stored roles are lowercase slugs (`master`, `admin`, `manager`, `front_desk`, `groomer`, `bather`, `client`). UI copy maps these to human labels like “Master Account” and “Front Desk”.
 - Master Account: one per business. Full control.
-- Manager, Front Desk, Groomer: invited by Master/Manager.
+- Manager, Front Desk, Groomer, Bather: invited by the Master Account or a Manager.
 - Client: default for new auth users unless invited as staff.
 
 ## Tenancy

--- a/lib/auth/access.ts
+++ b/lib/auth/access.ts
@@ -1,4 +1,4 @@
-import type { Role } from "./profile";
+import { roleLabel, type Role } from "./profile";
 
 export type AppRoute =
   | "dashboard"
@@ -10,9 +10,9 @@ export type AppRoute =
   | "messages"
   | "settings";
 
-const managerRoles: Role[] = ["master", "admin", "senior_groomer"];
-const frontDeskRoles: Role[] = ["receptionist"];
-const groomerRoles: Role[] = ["groomer"];
+const managerRoles: Role[] = ["master", "admin", "manager"];
+const frontDeskRoles: Role[] = ["front_desk"];
+const groomerRoles: Role[] = ["groomer", "bather"];
 const clientRoles: Role[] = ["client"];
 
 const routeAccess: Record<AppRoute, Role[]> = {
@@ -80,19 +80,5 @@ export function navItemsForRole(role: Role): NavItem[] {
 }
 
 export function roleDisplayName(role: Role): string {
-  switch (role) {
-    case "master":
-      return "Master Account";
-    case "admin":
-      return "Admin";
-    case "senior_groomer":
-      return "Manager";
-    case "groomer":
-      return "Groomer";
-    case "receptionist":
-      return "Front Desk";
-    case "client":
-    default:
-      return "Client";
-  }
+  return roleLabel(role);
 }

--- a/lib/auth/profile.ts
+++ b/lib/auth/profile.ts
@@ -1,4 +1,31 @@
-export type Role = 'master' | 'admin' | 'senior_groomer' | 'groomer' | 'receptionist' | 'client';
+export type Role =
+  | 'master'
+  | 'admin'
+  | 'manager'
+  | 'front_desk'
+  | 'groomer'
+  | 'bather'
+  | 'client';
+
+const roleLabels: Record<Role, string> = {
+  master: 'Master Account',
+  admin: 'Admin',
+  manager: 'Manager',
+  front_desk: 'Front Desk',
+  groomer: 'Groomer',
+  bather: 'Bather',
+  client: 'Client',
+};
+
+const canonicalRoles = new Set<Role>([
+  'master',
+  'admin',
+  'manager',
+  'front_desk',
+  'groomer',
+  'bather',
+  'client',
+]);
 
 export type UserProfile = {
   id: string;
@@ -18,23 +45,69 @@ export function normaliseName(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
+const roleAliases: Record<string, Role> = {
+  master: 'master',
+  'master account': 'master',
+  'master_account': 'master',
+  masteraccount: 'master',
+  admin: 'admin',
+  administrator: 'admin',
+  manager: 'manager',
+  'senior groomer': 'manager',
+  'senior_groomer': 'manager',
+  groomer: 'groomer',
+  bather: 'bather',
+  'front desk': 'front_desk',
+  'front_desk': 'front_desk',
+  frontdesk: 'front_desk',
+  receptionist: 'front_desk',
+  client: 'client',
+  clients: 'client',
+};
+
 export function normaliseRole(value: unknown): Role {
   if (typeof value === 'string') {
-    const trimmed = value.trim().toLowerCase();
-    if (isRole(trimmed)) return trimmed;
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      return 'client';
+    }
+    const alias = roleAliases[trimmed.toLowerCase()];
+    if (alias) return alias;
+    const lowered = trimmed.toLowerCase();
+    if (isRole(lowered)) return lowered;
   }
   return 'client';
 }
 
 function isRole(value: string): value is Role {
-  return [
-    'master',
-    'admin',
-    'senior_groomer',
-    'groomer',
-    'receptionist',
-    'client',
-  ].includes(value);
+  return (
+    value === 'master' ||
+    value === 'admin' ||
+    value === 'manager' ||
+    value === 'front_desk' ||
+    value === 'groomer' ||
+    value === 'bather' ||
+    value === 'client'
+  );
+}
+
+export function roleLabel(role: Role): string {
+  return roleLabels[role] ?? role;
+}
+
+export function describeRole(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const slug = normaliseRole(trimmed);
+  if (slug === 'client' && trimmed.toLowerCase() !== 'client') {
+    return trimmed;
+  }
+  return roleLabel(slug);
+}
+
+export function isCanonicalRole(value: Role): boolean {
+  return canonicalRoles.has(value);
 }
 
 export function mapProfileRow(row: RawProfileRow | null | undefined): UserProfile | null {

--- a/lib/auth/roles.ts
+++ b/lib/auth/roles.ts
@@ -1,20 +1,16 @@
 import { isFrontDeskRole, isGroomerRole, isManagerRole } from "@/lib/auth/access";
-import type { Role as LegacyRole } from "@/lib/auth/profile";
+import { normaliseRole, type Role as LegacyRole } from "@/lib/auth/profile";
 
-export function toLegacyRole(role: string | null): LegacyRole | null {
+export function toLegacyRole(role: string | LegacyRole | null): LegacyRole | null {
   if (!role) return null;
-  const normalized = role.toLowerCase();
-  if (normalized.includes("master")) return "master";
-  if (normalized.includes("admin")) return "admin";
-  if (normalized.includes("senior_groomer") || normalized.includes("senior groomer") || normalized.includes("manager")) {
-    return "senior_groomer";
+  if (typeof role === "string") {
+    const trimmed = role.trim();
+    if (!trimmed || trimmed.toLowerCase() === "guest") {
+      return null;
+    }
+    return normaliseRole(trimmed);
   }
-  if (normalized.includes("front desk") || normalized.includes("receptionist")) {
-    return "receptionist";
-  }
-  if (normalized.includes("groomer")) return "groomer";
-  if (normalized.includes("client")) return "client";
-  return null;
+  return role;
 }
 
 export function derivePermissionFlags(role: string | null) {

--- a/supabase/migrations/20251115_scheduling_tables.sql
+++ b/supabase/migrations/20251115_scheduling_tables.sql
@@ -6,6 +6,9 @@ DROP POLICY IF EXISTS appt_admin_all ON public.appointments;
 DROP POLICY IF EXISTS appt_senior_read_all ON public.appointments;
 DROP POLICY IF EXISTS appt_senior_insert ON public.appointments;
 DROP POLICY IF EXISTS appt_senior_update_own ON public.appointments;
+DROP POLICY IF EXISTS appt_manager_read_all ON public.appointments;
+DROP POLICY IF EXISTS appt_manager_insert ON public.appointments;
+DROP POLICY IF EXISTS appt_manager_update_own ON public.appointments;
 DROP POLICY IF EXISTS appt_recept_insert ON public.appointments;
 DROP POLICY IF EXISTS appt_recept_read_all ON public.appointments;
 DROP POLICY IF EXISTS appt_groomer_read_own ON public.appointments;
@@ -162,49 +165,49 @@ $$;
 CREATE POLICY appointments_management_all ON public.appointments
 FOR ALL
 USING (
-  public.has_role_ci(ARRAY['Manager','Admin','Master Account','manager','admin','master'])
+  public.has_role_ci(ARRAY['Master Account','Admin','Manager','master account','admin','manager','master'])
 )
 WITH CHECK (
-  public.has_role_ci(ARRAY['Manager','Admin','Master Account','manager','admin','master'])
+  public.has_role_ci(ARRAY['Master Account','Admin','Manager','master account','admin','manager','master'])
 );
 
 CREATE POLICY appointments_front_desk_select ON public.appointments
 FOR SELECT
 USING (
-  public.has_role_ci(ARRAY['Front Desk','receptionist'])
+  public.has_role_ci(ARRAY['Front Desk','receptionist','front desk','front_desk'])
 );
 
 CREATE POLICY appointments_front_desk_insert ON public.appointments
 FOR INSERT
 WITH CHECK (
-  public.has_role_ci(ARRAY['Front Desk','receptionist'])
+  public.has_role_ci(ARRAY['Front Desk','receptionist','front desk','front_desk'])
 );
 
 CREATE POLICY appointments_front_desk_update ON public.appointments
 FOR UPDATE
 USING (
-  public.has_role_ci(ARRAY['Front Desk','receptionist'])
+  public.has_role_ci(ARRAY['Front Desk','receptionist','front desk','front_desk'])
 )
 WITH CHECK (
-  public.has_role_ci(ARRAY['Front Desk','receptionist'])
+  public.has_role_ci(ARRAY['Front Desk','receptionist','front desk','front_desk'])
 );
 
 CREATE POLICY appointments_groomer_select ON public.appointments
 FOR SELECT
 USING (
   auth.uid() = staff_id
-  AND public.has_role_ci(ARRAY['Groomer','Senior Groomer','groomer','senior_groomer'])
+  AND public.has_role_ci(ARRAY['Groomer','Bather','Senior Groomer','groomer','bather','senior_groomer'])
 );
 
 CREATE POLICY appointments_groomer_update ON public.appointments
 FOR UPDATE
 USING (
   auth.uid() = staff_id
-  AND public.has_role_ci(ARRAY['Groomer','Senior Groomer','groomer','senior_groomer'])
+  AND public.has_role_ci(ARRAY['Groomer','Bather','Senior Groomer','groomer','bather','senior_groomer'])
 )
 WITH CHECK (
   auth.uid() = staff_id
-  AND public.has_role_ci(ARRAY['Groomer','Senior Groomer','groomer','senior_groomer'])
+  AND public.has_role_ci(ARRAY['Groomer','Bather','Senior Groomer','groomer','bather','senior_groomer'])
 );
 
 CREATE POLICY appointments_client_select ON public.appointments
@@ -218,10 +221,10 @@ USING (
 CREATE POLICY pets_management_all ON public.pets
 FOR ALL
 USING (
-  public.has_role_ci(ARRAY['Manager','Admin','Master Account','manager','admin','master'])
+  public.has_role_ci(ARRAY['Master Account','Admin','Manager','master account','admin','manager','master'])
 )
 WITH CHECK (
-  public.has_role_ci(ARRAY['Manager','Admin','Master Account','manager','admin','master'])
+  public.has_role_ci(ARRAY['Master Account','Admin','Manager','master account','admin','manager','master'])
 );
 
 CREATE POLICY pets_client_select ON public.pets
@@ -235,10 +238,10 @@ USING (
 CREATE POLICY pet_photos_management_all ON public.pet_photos
 FOR ALL
 USING (
-  public.has_role_ci(ARRAY['Manager','Admin','Master Account','manager','admin','master'])
+  public.has_role_ci(ARRAY['Master Account','Admin','Manager','master account','admin','manager','master'])
 )
 WITH CHECK (
-  public.has_role_ci(ARRAY['Manager','Admin','Master Account','manager','admin','master'])
+  public.has_role_ci(ARRAY['Master Account','Admin','Manager','master account','admin','manager','master'])
 );
 
 CREATE POLICY pet_photos_client_select ON public.pet_photos
@@ -255,7 +258,7 @@ USING (
 CREATE POLICY pet_photos_groomer_insert ON public.pet_photos
 FOR INSERT
 WITH CHECK (
-  public.has_role_ci(ARRAY['Groomer','Senior Groomer','groomer','senior_groomer'])
+  public.has_role_ci(ARRAY['Groomer','Bather','Senior Groomer','groomer','bather','senior_groomer'])
   AND EXISTS (
     SELECT 1
     FROM public.appointments a
@@ -268,10 +271,10 @@ WITH CHECK (
 CREATE POLICY availability_rules_management_all ON public.availability_rules
 FOR ALL
 USING (
-  public.has_role_ci(ARRAY['Manager','Admin','Master Account','manager','admin','master'])
+  public.has_role_ci(ARRAY['Master Account','Admin','Manager','master account','admin','manager','master'])
 )
 WITH CHECK (
-  public.has_role_ci(ARRAY['Manager','Admin','Master Account','manager','admin','master'])
+  public.has_role_ci(ARRAY['Master Account','Admin','Manager','master account','admin','manager','master'])
 );
 
 CREATE POLICY availability_rules_staff_select ON public.availability_rules
@@ -284,10 +287,10 @@ USING (
 CREATE POLICY blackout_dates_management_all ON public.blackout_dates
 FOR ALL
 USING (
-  public.has_role_ci(ARRAY['Manager','Admin','Master Account','manager','admin','master'])
+  public.has_role_ci(ARRAY['Master Account','Admin','Manager','master account','admin','manager','master'])
 )
 WITH CHECK (
-  public.has_role_ci(ARRAY['Manager','Admin','Master Account','manager','admin','master'])
+  public.has_role_ci(ARRAY['Master Account','Admin','Manager','master account','admin','manager','master'])
 );
 
 CREATE POLICY blackout_dates_staff_select ON public.blackout_dates

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,7 +1,7 @@
 -- Seed data for staff module
 insert into public.employees (id, name, email, phone, role, status, commission_rate, app_permissions)
 values
-  (1, 'Alex Groomer', 'alex@scruffybutts.test', '+1-555-0100', 'Senior Groomer', 'Active', 0.2, '{"is_manager": true, "can_manage_discounts": true}'::jsonb)
+  (1, 'Alex Groomer', 'alex@scruffybutts.test', '+1-555-0100', 'Manager', 'Active', 0.2, '{"is_manager": true, "can_manage_discounts": true}'::jsonb)
 on conflict (id) do update set
   name = excluded.name,
   email = excluded.email,


### PR DESCRIPTION
## Summary
- normalize roles across the app to lowercase slugs and expose helpers that render the canonical labels for UI copy
- update auth/session handling, staff APIs, and employee forms to read, write, and display the new slug roles while preserving compatibility with legacy values
- align Supabase onboarding SQL, RLS policies, and invite tables with slug storage and backfill existing rows so master accounts retain elevated access

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4d08e07848324a5ac746b0a88637e