### PR TITLE
Fix master login by querying existing profile columns

### DIFF
--- a/app/api/me/route.ts
+++ b/app/api/me/route.ts
@@ -16,15 +16,17 @@ export async function GET() {
     return NextResponse.json({ role: null, profile: null }, { status: 200 });
   }
 
-  const { data: profile, error: profErr } = await supabase
+  const { data: profileRow, error: profErr } = await supabase
     .from("profiles")
-    .select("id, email, role")
+    .select("id, role, full_name")
     .eq("id", session.user.id)
     .maybeSingle();
 
   if (profErr) {
     return NextResponse.json({ error: profErr.message }, { status: 500 });
   }
+
+  const profile = profileRow ? { ...profileRow, email: session.user.email ?? null } : null;
 
   return NextResponse.json({
     role: profile?.role ?? null,

--- a/components/AuthProvider.tsx
+++ b/components/AuthProvider.tsx
@@ -51,7 +51,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
       const { data: profileData, error: profileError } = await supabase
         .from("profiles")
-        .select("id, email, role")
+        .select("id, role, full_name")
         .eq("id", user.id)
         .maybeSingle();
 
@@ -64,7 +64,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       setRoleLabel(roleDisplayName(resolvedRole));
       setProfile({
         id: profileData?.id ?? user.id,
-        email: profileData?.email ?? user.email ?? null,
+        email: user.email ?? null,
         role: resolvedRole,
       });
     } catch (error) {


### PR DESCRIPTION
## Summary
- stop querying the non-existent `email` column from the `profiles` table in the auth provider and API
- rely on the authenticated user's email while still loading role information from `profiles`

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d5b68160d883248061e07cbc93ca15