### PR TITLE
Add minimal admin settings screens and helpers

### DIFF
--- a/app/(admin)/settings/business/page.tsx
+++ b/app/(admin)/settings/business/page.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { useState } from 'react';
+import { createClient } from '@supabase/supabase-js';
+const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!);
+
+export default function BusinessSettings() {
+  const [rows, setRows] = useState([
+    { dow:1, opens:'08:00', closes:'18:00' },
+    { dow:2, opens:'08:00', closes:'18:00' },
+    { dow:3, opens:'08:00', closes:'18:00' },
+    { dow:4, opens:'08:00', closes:'18:00' },
+    { dow:5, opens:'08:00', closes:'18:00' },
+  ]);
+  async function save() {
+    setRows([...rows]);
+    const { error } = await supabase.from('shop_hours').upsert(rows, { onConflict: 'dow' });
+    if (error) alert(error.message); else alert('Saved');
+  }
+  return (
+    <div className="space-y-4">
+      <h2 className="font-semibold text-lg">Weekly Business Hours</h2>
+      <pre className="text-xs bg-neutral-50 p-3 rounded-md">{JSON.stringify(rows, null, 2)}</pre>
+      <button onClick={save} className="rounded bg-black text-white px-3 py-2">Save Hours</button>
+    </div>
+  );
+}

--- a/app/(admin)/settings/page.tsx
+++ b/app/(admin)/settings/page.tsx
@@ -1,0 +1,18 @@
+export default function SettingsHome() {
+  const cards = [
+    { href: '/settings/business', title: 'Business Settings', desc: 'Hours, closures, branding' },
+    { href: '/settings/roles', title: 'Roles & Permissions', desc: 'Roles, permissions, master' },
+    { href: '/settings/calendar', title: 'Appointments & Calendar', desc: 'Defaults, cancellations, reminders' },
+    { href: '/settings/system', title: 'System Preferences', desc: 'Theme, timezone, feature flags' },
+  ];
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      {cards.map(c => (
+        <a key={c.href} href={c.href} className="rounded-lg border p-4 hover:bg-neutral-50">
+          <h3 className="font-semibold">{c.title}</h3>
+          <p className="text-sm opacity-70">{c.desc}</p>
+        </a>
+      ))}
+    </div>
+  );
+}

--- a/app/(admin)/settings/roles/page.tsx
+++ b/app/(admin)/settings/roles/page.tsx
@@ -1,0 +1,48 @@
+'use client';
+import { useEffect, useState } from 'react';
+import { createClient } from '@supabase/supabase-js';
+const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!);
+type Role = { id:string; name:string; permissions:string[] };
+
+export default function RolesSettings() {
+  const [roles, setRoles] = useState<Role[]>([]);
+  const [name, setName] = useState('');
+  const [perms, setPerms] = useState<string>('[]');
+
+  async function load() {
+    const { data } = await supabase.from('roles').select('id,name,permissions').order('name');
+    setRoles(data || []);
+  }
+  useEffect(() => { load(); }, []);
+
+  async function add() {
+    const { error } = await supabase.from('roles').insert({ name, permissions: JSON.parse(perms) });
+    if (error) alert(error.message); else { setName(''); setPerms('[]'); load(); }
+  }
+  async function remove(id:string) {
+    const { error } = await supabase.from('roles').delete().eq('id', id);
+    if (error) alert(error.message); else load();
+  }
+
+  return (
+    <div className="space-y-4">
+      <h2 className="font-semibold text-lg">Roles & Permissions</h2>
+      <div className="flex gap-2">
+        <input placeholder="Role name" value={name} onChange={e=>setName(e.target.value)} className="border px-2 py-1 rounded w-40"/>
+        <input placeholder='["perm"]' value={perms} onChange={e=>setPerms(e.target.value)} className="border px-2 py-1 rounded flex-1"/>
+        <button onClick={add} className="rounded bg-black text-white px-3 py-2">Add</button>
+      </div>
+      <ul className="space-y-2">
+        {roles.map(r => (
+          <li key={r.id} className="border rounded p-3 flex items-center justify-between">
+            <div>
+              <div className="font-medium">{r.name}</div>
+              <div className="text-xs opacity-70">{JSON.stringify(r.permissions)}</div>
+            </div>
+            <button onClick={()=>remove(r.id)} className="text-red-600 text-sm">Delete</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/lib/auth/roles.ts
+++ b/lib/auth/roles.ts
@@ -1,6 +1,14 @@
 import { isFrontDeskRole, isGroomerRole, isManagerRole } from "@/lib/auth/access";
 import type { Role as LegacyRole } from "@/lib/auth/profile";
 
+export type RoleName = 'Admin' | 'Manager' | 'Groomer' | 'Bather' | 'Front Desk' | 'Client';
+export type Role = { id: string; name: RoleName; permissions: string[] };
+
+export function can(user: { is_master?: boolean; role?: Role }, perm: string) {
+  if (user?.is_master) return true;
+  return !!user?.role?.permissions?.includes(perm);
+}
+
 export function toLegacyRole(role: string | null): LegacyRole | null {
   if (!role) return null;
   const normalized = role.toLowerCase();

--- a/lib/bookingGuard.ts
+++ b/lib/bookingGuard.ts
@@ -1,0 +1,7 @@
+import { createClient } from '@supabase/supabase-js';
+const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!);
+export async function canBook(staffId: string, startsAt: string, endsAt: string) {
+  const { data, error } = await supabase.rpc('can_book', { _staff: staffId, _starts: startsAt, _ends: endsAt });
+  if (error) throw error;
+  return !!data;
+}


### PR DESCRIPTION
## Summary
- add an admin settings landing page with quick links
- implement minimal business hours and roles admin forms using Supabase
- add helper utilities for role-based checks and booking guard RPC calls

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68d5d024c3888324887e0b6b1f050892