### PR TITLE
Fix top navigation layout

### DIFF
--- a/components/TopNav.tsx
+++ b/components/TopNav.tsx
@@ -21,7 +21,7 @@ export default function TopNav() {
 
   return (
     <header className="flex w-full items-center justify-between gap-6">
-      <nav className="flex flex-wrap items-center gap-2">
+      <nav className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto whitespace-nowrap">
         {navItems.map((item) => {
           const isActive =
             pathname === item.href || pathname.startsWith(`${item.href}/`);
@@ -41,7 +41,7 @@ export default function TopNav() {
           );
         })}
       </nav>
-      <div className="flex items-center gap-3 text-sm">
+      <div className="flex flex-shrink-0 items-center gap-3 text-sm">
         <span className="truncate max-w-[12rem] text-white/90" title={name}>
           {name}
         </span>


### PR DESCRIPTION
## Summary
- update the top navigation container to stay on one line and scroll horizontally if needed
- ensure the account badge area stays pinned to the right without wrapping

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d62dbdcb7c8324b617bd7280e57347