### PR TITLE
Harden booking and calendar Supabase queries

### DIFF
--- a/app/(app)/booking/BookingClient.tsx
+++ b/app/(app)/booking/BookingClient.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
@@ -9,6 +9,7 @@ import clsx from "clsx";
 import { useAuth } from "@/components/AuthProvider";
 import { canAccessRoute } from "@/lib/auth/access";
 import { toLegacyRole } from "@/lib/auth/roles";
+import { supabase } from "@/lib/supabase/client";
 
 const currency = new Intl.NumberFormat(undefined, {
   style: "currency",
@@ -38,89 +39,6 @@ type SlotOption = {
   start: string;
   end: string;
 };
-
-const staffOptions: StaffOption[] = [
-  {
-    id: "sasha",
-    name: "Sasha Taylor",
-    role: "Master Groomer",
-    avatar: "https://avatars.dicebear.com/api/initials/ST.svg",
-    bio: "Specialises in hand scissoring and anxious pups.",
-  },
-  {
-    id: "myles",
-    name: "Myles Chen",
-    role: "Senior Groomer",
-    avatar: "https://avatars.dicebear.com/api/initials/MC.svg",
-    bio: "Loves double coats, creative colour and doodles.",
-  },
-  {
-    id: "imani",
-    name: "Imani Hart",
-    role: "Pet Stylist",
-    avatar: "https://avatars.dicebear.com/api/initials/IH.svg",
-    bio: "Speedy with bath & tidy packages and small breeds.",
-  },
-];
-
-const slotOptions: SlotOption[] = [
-  { id: "slot-9", label: "Today · 9:00am", start: "2024-04-05T09:00:00", end: "2024-04-05T10:30:00" },
-  { id: "slot-11", label: "Today · 11:30am", start: "2024-04-05T11:30:00", end: "2024-04-05T13:00:00" },
-  { id: "slot-14", label: "Tomorrow · 2:00pm", start: "2024-04-06T14:00:00", end: "2024-04-06T15:30:00" },
-  { id: "slot-16", label: "Saturday · 4:00pm", start: "2024-04-07T16:00:00", end: "2024-04-07T17:30:00" },
-];
-
-const serviceOptions: ServiceOption[] = [
-  {
-    id: "full-groom",
-    name: "Full Groom",
-    duration: 90,
-    basePrice: 85,
-    sizes: [
-      { id: "toy", label: "Toy", multiplier: 1 },
-      { id: "small", label: "Small", multiplier: 1.2 },
-      { id: "medium", label: "Medium", multiplier: 1.45 },
-      { id: "large", label: "Large", multiplier: 1.75 },
-    ],
-  },
-  {
-    id: "bath-tidy",
-    name: "Bath & Tidy",
-    duration: 70,
-    basePrice: 60,
-    sizes: [
-      { id: "toy", label: "Toy", multiplier: 1 },
-      { id: "small", label: "Small", multiplier: 1.1 },
-      { id: "medium", label: "Medium", multiplier: 1.25 },
-      { id: "large", label: "Large", multiplier: 1.5 },
-    ],
-  },
-  {
-    id: "paw-spa",
-    name: "Paw Spa Package",
-    duration: 45,
-    basePrice: 45,
-    sizes: [
-      { id: "toy", label: "Toy", multiplier: 1 },
-      { id: "small", label: "Small", multiplier: 1.15 },
-      { id: "medium", label: "Medium", multiplier: 1.3 },
-      { id: "large", label: "Large", multiplier: 1.5 },
-    ],
-  },
-];
-
-const addOns = [
-  { id: "teeth", name: "Teeth brushing", price: 12 },
-  { id: "blueberry", name: "Blueberry facial", price: 15 },
-  { id: "shed-guard", name: "Shed Guard", price: 20 },
-  { id: "pawdicure", name: "Pawdicure", price: 18 },
-];
-
-const pets = [
-  { id: "pet-1", name: "Mocha", breed: "Cockapoo" },
-  { id: "pet-2", name: "Nova", breed: "Husky" },
-  { id: "pet-3", name: "Frodo", breed: "Mini Labradoodle" },
-];
 
 const steps = [
   { id: "staff", label: "Choose staff" },
@@ -156,28 +74,261 @@ const defaultDraft: BookingDraft = {
   confirmed: false,
 };
 
+const INACTIVE_KEYWORDS = ["inactive", "archived", "disabled", "terminated", "deleted"];
+
+function inferIsActive(record: Record<string, unknown> | null | undefined) {
+  if (!record || typeof record !== "object") {
+    return true;
+  }
+
+  const candidateKeys = ["active", "is_active", "enabled", "is_enabled"] as const;
+  for (const key of candidateKeys) {
+    const value = (record as Record<string, unknown>)[key];
+    if (typeof value === "boolean") {
+      return value;
+    }
+  }
+
+  const status = (record as Record<string, unknown>).status;
+  if (typeof status === "string") {
+    const lowered = status.toLowerCase();
+    return !INACTIVE_KEYWORDS.some((flag) => lowered.includes(flag));
+  }
+
+  const archivedAt = (record as Record<string, unknown>).archived_at;
+  if (archivedAt !== null && archivedAt !== undefined) {
+    return false;
+  }
+
+  return true;
+}
+
+function coerceNumber(value: unknown, fallback: number) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+function coerceString(value: unknown, fallback: string) {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return fallback;
+}
+
+function extractBiography(record: Record<string, unknown>) {
+  const possibleKeys = ["manager_notes", "bio", "notes"] as const;
+  for (const key of possibleKeys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return "";
+}
+
 export default function BookingClient() {
   const { loading, role } = useAuth();
   const legacyRole = useMemo(() => toLegacyRole(role), [role]);
   const searchParams = useSearchParams();
   const clientId = searchParams.get("clientId") ?? null;
 
+  const [staffOptions, setStaffOptions] = useState<StaffOption[]>([]);
+  const [serviceOptions, setServiceOptions] = useState<ServiceOption[]>([]);
+  const [slotOptions, setSlotOptions] = useState<SlotOption[]>([]);
+  const [addOns, setAddOns] = useState<{ id: string; name: string; price: number }[]>([]);
+  const [pets, setPets] = useState<{ id: string; name: string; breed: string | null }[]>([]);
+  const [loadingData, setLoadingData] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
   const [activeStepIndex, setActiveStepIndex] = useState(0);
   const [draft, setDraft] = useState<BookingDraft>(defaultDraft);
   const [showCelebration, setShowCelebration] = useState(false);
 
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadData() {
+      setLoadingData(true);
+      setLoadError(null);
+      try {
+        const [staffResp, servicesResp, sizeResp, addOnResp, petsResp, apptResp] = await Promise.all([
+          supabase.from("employees").select("*").order("name"),
+          supabase.from("services").select("*").order("name"),
+          supabase
+            .from("service_sizes")
+            .select("id,service_id,label,multiplier,sort_order")
+            .order("sort_order"),
+          supabase.from("add_ons").select("*").order("name"),
+          clientId
+            ? supabase
+                .from("pets")
+                .select("id,name,breed,client_id")
+                .eq("client_id", clientId)
+                .order("name")
+            : supabase.from("pets").select("id,name,breed").order("name"),
+          supabase
+            .from("appointments")
+            .select("id,start_time,end_time,employee_id")
+            .gte("start_time", new Date().toISOString())
+            .order("start_time")
+            .limit(12),
+        ]);
+
+        if (staffResp.error) throw staffResp.error;
+        if (servicesResp.error) throw servicesResp.error;
+        if (sizeResp.error) throw sizeResp.error;
+        if (addOnResp.error) throw addOnResp.error;
+        if (petsResp.error) throw petsResp.error;
+        if (apptResp.error) throw apptResp.error;
+
+        if (cancelled) return;
+
+        const staffRows = (staffResp.data ?? []) as any[];
+        const serviceRows = (servicesResp.data ?? []) as any[];
+        const addOnRows = (addOnResp.data ?? []) as any[];
+
+        const sizeGroups = new Map<
+          string,
+          { id: string; label: string; multiplier: number; sortOrder: number }[]
+        >();
+        for (const raw of sizeResp.data ?? []) {
+          const serviceId = String(raw.service_id ?? "");
+          if (!serviceId) continue;
+          const entry = sizeGroups.get(serviceId) ?? [];
+          entry.push({
+            id: String(raw.id),
+            label: raw.label ?? "Size",
+            multiplier: Number(raw.multiplier ?? 1),
+            sortOrder: Number(raw.sort_order ?? entry.length),
+          });
+          sizeGroups.set(serviceId, entry);
+        }
+
+        for (const group of sizeGroups.values()) {
+          group.sort((a, b) => a.sortOrder - b.sortOrder || a.label.localeCompare(b.label));
+        }
+
+        setStaffOptions(
+          staffRows
+            .filter((row) => inferIsActive(row))
+            .map((row, index) => {
+              const baseId = coerceString(row.id, "");
+              const id = baseId || `staff-${index + 1}`;
+              const name = coerceString(row.name, baseId ? `Staff #${baseId}` : `Staff #${index + 1}`);
+              const avatarFallback = `https://avatars.dicebear.com/api/initials/${encodeURIComponent(name)}.svg`;
+              return {
+                id,
+                name,
+                role: coerceString(row.role, "Staff"),
+                avatar: coerceString(row.avatar_url, avatarFallback),
+                bio: extractBiography(row),
+              } satisfies StaffOption;
+            })
+        );
+
+        setServiceOptions(
+          serviceRows
+            .filter((row) => inferIsActive(row))
+            .map((row, index) => {
+              const rawId = coerceString(row.id, "");
+              const serviceId = rawId || `service-${index + 1}`;
+              const sizes = sizeGroups.get(serviceId) ?? [];
+              const sortedSizes = sizes.map(({ sortOrder: _s, ...rest }) => rest);
+              return {
+                id: serviceId,
+                name: coerceString(row.name, "Service"),
+                duration: coerceNumber(row.duration_min, 60),
+                basePrice: coerceNumber(row.base_price, 0),
+                sizes: sortedSizes.length > 0
+                  ? sortedSizes
+                  : [
+                      {
+                        id: `${serviceId}-default`,
+                        label: "Standard",
+                        multiplier: 1,
+                      },
+                    ],
+              } satisfies ServiceOption;
+            })
+        );
+
+        setAddOns(
+          addOnRows
+            .filter((row) => inferIsActive(row))
+            .map((row, index) => ({
+              id: coerceString(row.id, `addon-${index + 1}`),
+              name: coerceString(row.name, "Add-on"),
+              price: coerceNumber(row.price, 0),
+            }))
+        );
+
+        setPets(
+          (petsResp.data ?? []).map((row) => ({
+            id: String(row.id),
+            name: row.name ?? "Pet",
+            breed: row.breed ?? null,
+          }))
+        );
+
+        const slotFormatter = new Intl.DateTimeFormat(undefined, {
+          dateStyle: "medium",
+          timeStyle: "short",
+        });
+
+        setSlotOptions(
+          (apptResp.data ?? []).map((row) => {
+            const start = row.start_time as string;
+            const end = row.end_time as string;
+            const startDate = new Date(start);
+            return {
+              id: String(row.id),
+              label: slotFormatter.format(startDate),
+              start,
+              end,
+            } as SlotOption;
+          })
+        );
+      } catch (error: any) {
+        if (!cancelled) {
+          setLoadError(error?.message ?? "Failed to load booking data");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingData(false);
+        }
+      }
+    }
+
+    loadData();
+    return () => {
+      cancelled = true;
+    };
+  }, [clientId]);
+
+  useEffect(() => {
+    setDraft((prev) => ({
+      ...prev,
+      staffId: prev.staffId ?? staffOptions[0]?.id ?? null,
+      serviceId: prev.serviceId ?? serviceOptions[0]?.id ?? null,
+      sizeId: prev.sizeId ?? serviceOptions[0]?.sizes[0]?.id ?? null,
+    }));
+  }, [staffOptions, serviceOptions]);
+
   const activeStep = steps[activeStepIndex];
   const selectedStaff = useMemo(
     () => staffOptions.find((staff) => staff.id === draft.staffId) ?? null,
-    [draft.staffId]
+    [draft.staffId, staffOptions]
   );
   const selectedSlot = useMemo(
     () => slotOptions.find((slot) => slot.id === draft.slotId) ?? null,
-    [draft.slotId]
+    [draft.slotId, slotOptions]
   );
   const selectedService = useMemo(
     () => serviceOptions.find((service) => service.id === draft.serviceId) ?? null,
-    [draft.serviceId]
+    [draft.serviceId, serviceOptions]
   );
   const selectedSize = useMemo(() => {
     if (!selectedService || !draft.sizeId) return null;
@@ -185,7 +336,7 @@ export default function BookingClient() {
   }, [draft.sizeId, selectedService]);
   const selectedPet = useMemo(
     () => pets.find((pet) => pet.id === draft.petId) ?? null,
-    [draft.petId]
+    [draft.petId, pets]
   );
 
   const basePrice = useMemo(() => {
@@ -199,7 +350,7 @@ export default function BookingClient() {
         const addOn = addOns.find((item) => item.id === id);
         return total + (addOn?.price ?? 0);
       }, 0),
-    [draft.addOnIds]
+    [draft.addOnIds, addOns]
   );
 
   const subtotal = basePrice + addOnTotal;
@@ -309,6 +460,12 @@ export default function BookingClient() {
         })}
       </ol>
 
+      {loadingData ? (
+        <div className="rounded-3xl border border-white/30 bg-white/10 p-8 text-center text-white">Loading booking data…</div>
+      ) : loadError ? (
+        <div className="rounded-3xl border border-rose-400/60 bg-rose-500/10 p-8 text-center text-white">{loadError}</div>
+      ) : (
+        <>
       <section className="rounded-3xl border border-white/15 bg-white/5 p-6">
         {activeStep.id === "staff" && (
           <div className="grid gap-4 md:grid-cols-3">
@@ -672,6 +829,8 @@ export default function BookingClient() {
           )}
         </div>
       </footer>
+        </>
+      )}
 
       {showCelebration && (
         <div className="fixed inset-0 z-40 flex items-center justify-center bg-black/40 backdrop-blur">

--- a/app/(app)/calendar/page.tsx
+++ b/app/(app)/calendar/page.tsx
@@ -79,6 +79,60 @@ type Interaction =
       originalStart: number;
     };
 
+const STAFF_COLORS = [
+  "bg-brand-bubble/20 text-white",
+  "bg-emerald-400/20 text-emerald-950",
+  "bg-sky-400/20 text-sky-950",
+  "bg-amber-300/25 text-amber-900",
+  "bg-violet-400/25 text-violet-950",
+];
+
+const INACTIVE_KEYWORDS = ["inactive", "archived", "disabled", "terminated", "deleted"];
+
+function inferIsActive(record: Record<string, unknown> | null | undefined) {
+  if (!record || typeof record !== "object") {
+    return true;
+  }
+
+  const boolKeys = ["active", "is_active", "enabled", "is_enabled"] as const;
+  for (const key of boolKeys) {
+    const value = (record as Record<string, unknown>)[key];
+    if (typeof value === "boolean") {
+      return value;
+    }
+  }
+
+  const status = (record as Record<string, unknown>).status;
+  if (typeof status === "string") {
+    const lowered = status.toLowerCase();
+    if (INACTIVE_KEYWORDS.some((flag) => lowered.includes(flag))) {
+      return false;
+    }
+  }
+
+  const archivedAt = (record as Record<string, unknown>).archived_at;
+  if (archivedAt !== null && archivedAt !== undefined) {
+    return false;
+  }
+
+  return true;
+}
+
+function coerceString(value: unknown, fallback: string) {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return fallback;
+}
+
+function coerceNumber(value: unknown, fallback: number) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
 function addDays(base: Date, amount: number) {
   const next = new Date(base);
   next.setDate(next.getDate() + amount);
@@ -125,143 +179,7 @@ function formatTime(minutes: number) {
   return `${displayHour}:${String(mins).padStart(2, "0")} ${suffix}`;
 }
 
-const staffDirectory: StaffMember[] = [
-  {
-    id: "sasha",
-    name: "Sasha Taylor",
-    initials: "ST",
-    profileId: "staff-sasha",
-    colorClass: "bg-gradient-to-br from-amber-200/80 via-amber-300/70 to-amber-400/80 text-slate-900",
-  },
-  {
-    id: "myles",
-    name: "Myles Chen",
-    initials: "MC",
-    profileId: "staff-myles",
-    colorClass: "bg-gradient-to-br from-brand-bubble/80 via-brand-bubble/70 to-brand-lavender/80 text-slate-900",
-  },
-  {
-    id: "imani",
-    name: "Imani Hart",
-    initials: "IH",
-    profileId: "staff-imani",
-    colorClass: "bg-gradient-to-br from-emerald-300/80 via-emerald-400/70 to-emerald-500/80 text-slate-900",
-  },
-];
-
-const serviceCatalog: DrawerServiceOption[] = [
-  {
-    id: "full-groom",
-    name: "Full Groom",
-    basePrice: 85,
-    color: "bg-gradient-to-r from-brand-bubble/40 via-brand-bubble/25 to-transparent text-white",
-    sizes: [
-      { id: "toy", label: "Toy", multiplier: 1 },
-      { id: "small", label: "Small", multiplier: 1.15 },
-      { id: "medium", label: "Medium", multiplier: 1.35 },
-      { id: "large", label: "Large", multiplier: 1.6 },
-    ],
-  },
-  {
-    id: "bath-blowout",
-    name: "Bath & Blowout",
-    basePrice: 55,
-    color: "bg-gradient-to-r from-sky-400/40 via-sky-400/20 to-transparent text-white",
-    sizes: [
-      { id: "toy", label: "Toy", multiplier: 1 },
-      { id: "small", label: "Small", multiplier: 1.1 },
-      { id: "medium", label: "Medium", multiplier: 1.25 },
-      { id: "large", label: "Large", multiplier: 1.5 },
-    ],
-  },
-  {
-    id: "de-shed",
-    name: "De-shed Upgrade",
-    basePrice: 40,
-    color: "bg-gradient-to-r from-amber-400/50 via-amber-400/25 to-transparent text-white",
-    sizes: [
-      { id: "toy", label: "Toy", multiplier: 1 },
-      { id: "small", label: "Small", multiplier: 1.2 },
-      { id: "medium", label: "Medium", multiplier: 1.4 },
-      { id: "large", label: "Large", multiplier: 1.7 },
-    ],
-  },
-];
-
-const addOnCatalog: DrawerAddOnOption[] = [
-  { id: "teeth", name: "Teeth brushing", price: 12 },
-  { id: "pawdicure", name: "Pawdicure", price: 18 },
-  { id: "shed-guard", name: "Shed Guard Treatment", price: 20 },
-  { id: "blueberry", name: "Blueberry facial", price: 15 },
-];
-
-function seedAppointments(todayKey: string): Appointment[] {
-  const tomorrowKey = formatDateKey(addDays(new Date(), 1));
-  return [
-    {
-      id: "apt-1",
-      date: todayKey,
-      staffId: "sasha",
-      serviceId: "full-groom",
-      sizeId: "medium",
-      startMinutes: 9 * 60,
-      endMinutes: 10 * 60 + 30,
-      clientName: "Jordan Rivers",
-      petName: "Mocha",
-      addOnIds: ["teeth"],
-      discount: 0,
-      tax: 6,
-      status: "checked_in",
-      notes: "Prefers hypoallergenic shampoo",
-    },
-    {
-      id: "apt-2",
-      date: todayKey,
-      staffId: "myles",
-      serviceId: "bath-blowout",
-      sizeId: "small",
-      startMinutes: 10 * 60,
-      endMinutes: 11 * 60,
-      clientName: "Ritika Kaur",
-      petName: "Frodo",
-      addOnIds: ["pawdicure"],
-      discount: 5,
-      tax: 4,
-      status: "booked",
-      notes: "Owner will pick up early",
-    },
-    {
-      id: "apt-3",
-      date: todayKey,
-      staffId: "imani",
-      serviceId: "de-shed",
-      sizeId: "large",
-      startMinutes: 13 * 60 + 30,
-      endMinutes: 15 * 60,
-      clientName: "Chris Nolan",
-      petName: "Nova",
-      addOnIds: ["shed-guard", "blueberry"],
-      discount: 0,
-      tax: 9,
-      status: "booked",
-    },
-    {
-      id: "apt-4",
-      date: tomorrowKey,
-      staffId: "sasha",
-      serviceId: "bath-blowout",
-      sizeId: "toy",
-      startMinutes: 8 * 60 + 30,
-      endMinutes: 9 * 60 + 15,
-      clientName: "Elena Diaz",
-      petName: "Nala",
-      addOnIds: [],
-      discount: 0,
-      tax: 3,
-      status: "booked",
-    },
-  ];
-}
+import { supabase } from "@/lib/supabase/client";
 
 export default function CalendarPage() {
   const { loading, role, profile } = useAuth();
@@ -272,7 +190,12 @@ export default function CalendarPage() {
     return now;
   }, []);
   const todayKey = useMemo(() => formatDateKey(today), [today]);
-  const [appointments, setAppointments] = useState<Appointment[]>(() => seedAppointments(todayKey));
+  const [staffDirectory, setStaffDirectory] = useState<StaffMember[]>([]);
+  const [serviceCatalog, setServiceCatalog] = useState<DrawerServiceOption[]>([]);
+  const [addOnCatalog, setAddOnCatalog] = useState<DrawerAddOnOption[]>([]);
+  const [appointments, setAppointments] = useState<Appointment[]>([]);
+  const [loadingData, setLoadingData] = useState(true);
+  const [dataError, setDataError] = useState<string | null>(null);
   const [currentDate, setCurrentDate] = useState<Date>(today);
   const [view, setView] = useState<"day" | "week">("day");
   const [interaction, setInteraction] = useState<Interaction | null>(null);
@@ -285,8 +208,217 @@ export default function CalendarPage() {
   });
 
   useEffect(() => {
+    let cancelled = false;
+
+    async function loadData() {
+      setLoadingData(true);
+      setDataError(null);
+      try {
+        const baseStart = view === "week" ? startOfWeek(currentDate) : new Date(currentDate);
+        const baseEnd = view === "week" ? addDays(startOfWeek(currentDate), 6) : new Date(currentDate);
+        const rangeStart = new Date(baseStart);
+        rangeStart.setHours(0, 0, 0, 0);
+        const rangeEnd = new Date(baseEnd);
+        rangeEnd.setHours(23, 59, 59, 999);
+
+        const [staffResp, serviceResp, sizeResp, addOnResp, apptResp] = await Promise.all([
+          supabase.from("employees").select("*").order("name"),
+          supabase.from("services").select("*").order("name"),
+          supabase
+            .from("service_sizes")
+            .select("id,service_id,label,multiplier,sort_order")
+            .order("sort_order"),
+          supabase.from("add_ons").select("*").order("name"),
+          supabase
+            .from("appointments")
+            .select(
+              "id,employee_id,service_id,service_size_id,start_time,end_time,discount,tax,status,notes,client:clients(*),pet:pets(*),appointment_add_ons(add_on_id)"
+            )
+            .gte("start_time", rangeStart.toISOString())
+            .lte("start_time", rangeEnd.toISOString())
+            .order("start_time"),
+        ]);
+
+        if (staffResp.error) throw staffResp.error;
+        if (serviceResp.error) throw serviceResp.error;
+        if (sizeResp.error) throw sizeResp.error;
+        if (addOnResp.error) throw addOnResp.error;
+        if (apptResp.error) throw apptResp.error;
+        if (cancelled) return;
+
+        const staffRows = (staffResp.data ?? []) as any[];
+        const serviceRows = (serviceResp.data ?? []) as any[];
+        const addOnRows = (addOnResp.data ?? []) as any[];
+
+        const staffData: StaffMember[] = staffRows
+          .filter((row) => inferIsActive(row))
+          .map((row, index) => {
+            const baseId = coerceString(row.id, "");
+            const name = coerceString(row.name, baseId ? `Staff #${baseId}` : `Staff #${index + 1}`);
+            const providedInitials =
+              typeof row.initials === "string" && row.initials.trim().length > 0
+                ? row.initials.trim().slice(0, 2).toUpperCase()
+                : null;
+            const generatedInitials = name
+              .split(/\s+/)
+              .filter(Boolean)
+              .map((part) => part[0]?.toUpperCase() ?? "")
+              .join("")
+              .slice(0, 2);
+            const initials = providedInitials ?? (generatedInitials || name.slice(0, 2).toUpperCase());
+            const colorCandidates = [row.calendar_color_class, row.color_class].map((value) =>
+              typeof value === "string" && value.trim().length > 0 ? value.trim() : null
+            );
+            const colorClass =
+              colorCandidates.find((value) => value) ?? STAFF_COLORS[index % STAFF_COLORS.length];
+            const id = baseId || `staff-${index + 1}`;
+            return {
+              id,
+              name,
+              initials,
+              profileId: id,
+              colorClass,
+            } satisfies StaffMember;
+          });
+        setStaffDirectory(staffData);
+
+        const sizeGroups = new Map<
+          string,
+          { id: string; label: string; multiplier: number; sortOrder: number }[]
+        >();
+        for (const size of sizeResp.data ?? []) {
+          const serviceId = String(size.service_id ?? "");
+          if (!serviceId) continue;
+          const entry = sizeGroups.get(serviceId) ?? [];
+          entry.push({
+            id: String(size.id),
+            label: size.label ?? "Size",
+            multiplier: Number(size.multiplier ?? 1),
+            sortOrder: Number(size.sort_order ?? entry.length),
+          });
+          sizeGroups.set(serviceId, entry);
+        }
+        for (const group of sizeGroups.values()) {
+          group.sort((a, b) => a.sortOrder - b.sortOrder || a.label.localeCompare(b.label));
+        }
+
+        const serviceData: DrawerServiceOption[] = serviceRows
+          .filter((row) => inferIsActive(row))
+          .map((row, index) => {
+            const serviceId = coerceString(row.id, `service-${index + 1}`);
+            const sizes = sizeGroups.get(serviceId) ?? [];
+            const fallbackColor = STAFF_COLORS[index % STAFF_COLORS.length] ?? "bg-brand-bubble/20 text-white";
+            const colorCandidates = [row.color_class, row.color, row.calendar_color_class].map((value) =>
+              typeof value === "string" && value.trim().length > 0 ? value.trim() : null
+            );
+            return {
+              id: serviceId,
+              name: coerceString(row.name, "Service"),
+              basePrice: coerceNumber(row.base_price, 0),
+              color: colorCandidates.find((value) => value) ?? fallbackColor,
+              sizes:
+                sizes.length > 0
+                  ? sizes.map(({ sortOrder: _s, ...rest }) => rest)
+                  : [
+                      {
+                        id: `${serviceId}-default`,
+                        label: "Standard",
+                        multiplier: 1,
+                      },
+                    ],
+            } satisfies DrawerServiceOption;
+          });
+        setServiceCatalog(serviceData);
+
+        setAddOnCatalog(
+          addOnRows
+            .filter((row) => inferIsActive(row))
+            .map((row, index) => ({
+              id: coerceString(row.id, `addon-${index + 1}`),
+              name: coerceString(row.name, "Add-on"),
+              price: coerceNumber(row.price, 0),
+            }))
+        );
+
+        const serviceMap = new Map(serviceData.map((svc) => [svc.id, svc]));
+        const staffFallback = staffData[0]?.id ?? "";
+
+        const appointmentData: Appointment[] = (apptResp.data ?? []).map((row) => {
+          const start = new Date(row.start_time as string);
+          const end = new Date((row.end_time as string) ?? row.start_time);
+          const serviceId = row.service_id ? String(row.service_id) : serviceData[0]?.id ?? "";
+          const service = serviceMap.get(serviceId) ?? null;
+          const sizeId = row.service_size_id
+            ? String(row.service_size_id)
+            : service?.sizes[0]?.id ?? serviceData[0]?.sizes[0]?.id ?? "";
+          const client = row.client as
+            | {
+                full_name?: string | null;
+                first_name?: string | null;
+                last_name?: string | null;
+                name?: string | null;
+              }
+            | null;
+          const pet = row.pet as { name?: string | null } | null;
+          const structuredName = client
+            ? [client.first_name ?? "", client.last_name ?? ""].filter(Boolean).join(" ").trim()
+            : "";
+          const fallbackName = client
+            ? (client.full_name && client.full_name.trim().length > 0
+                ? client.full_name.trim()
+                : client.name && client.name.trim().length > 0
+                ? client.name.trim()
+                : "")
+            : "";
+          const clientName = client
+            ? (structuredName || fallbackName || "Client").trim() || "Client"
+            : "Walk-in client";
+          const petName =
+            pet && typeof pet.name === "string" && pet.name.trim().length > 0
+              ? pet.name.trim()
+              : "Unassigned";
+          const startMinutesRaw = start.getHours() * 60 + start.getMinutes();
+          const endMinutesRaw = end.getHours() * 60 + end.getMinutes();
+          const startMinutes = clamp(snapMinutes(startMinutesRaw), DAY_START_MINUTES, DAY_END_MINUTES - STEP_MINUTES);
+          const endMinutes = clamp(snapMinutes(endMinutesRaw), startMinutes + STEP_MINUTES, DAY_END_MINUTES);
+          return {
+            id: String(row.id),
+            date: formatDateKey(start),
+            staffId: row.employee_id != null ? String(row.employee_id) : staffFallback,
+            serviceId,
+            sizeId,
+            startMinutes,
+            endMinutes,
+            clientName,
+            petName,
+            addOnIds: ((row.appointment_add_ons as any[]) ?? []).map((entry) => String(entry.add_on_id)),
+            discount: Number(row.discount ?? 0),
+            tax: Number(row.tax ?? 0),
+            status: ((row.status as string) ?? "booked") as AppointmentDraft["status"],
+            notes: row.notes ?? undefined,
+          } satisfies Appointment;
+        });
+        setAppointments(appointmentData);
+      } catch (error: any) {
+        if (!cancelled) {
+          setDataError(error?.message ?? "Failed to load calendar data");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoadingData(false);
+        }
+      }
+    }
+
+    loadData();
+    return () => {
+      cancelled = true;
+    };
+  }, [currentDate, view]);
+
+  useEffect(() => {
     interactionRef.current = interaction;
-  }, [interaction]);
+  }, [interaction, serviceCatalog]);
 
   useEffect(() => {
     function handleMove(event: PointerEvent) {
@@ -369,8 +501,12 @@ export default function CalendarPage() {
         const safeStart = clamp(snapMinutes(start), DAY_START_MINUTES, DAY_END_MINUTES - STEP_MINUTES);
         const safeEnd = clamp(snapMinutes(end), safeStart + STEP_MINUTES, DAY_END_MINUTES);
 
+        if (serviceCatalog.length === 0) {
+          cleanupInteraction();
+          return;
+        }
         const defaultService = serviceCatalog[0];
-        const defaultSize = defaultService.sizes[0];
+        const defaultSize = defaultService.sizes[0] ?? { id: defaultService.id, label: "Standard", multiplier: 1 };
         const id = `apt-${Date.now()}`;
         const fresh: Appointment = {
           id,
@@ -428,7 +564,7 @@ export default function CalendarPage() {
       window.removeEventListener("pointerup", handleUp);
       window.removeEventListener("pointercancel", handleCancel);
     };
-  }, [interaction]);
+  }, [interaction, serviceCatalog]);
 
   function staffIdFromPointer(clientX: number) {
     const entries = Object.entries(columnRefs.current);
@@ -601,6 +737,7 @@ export default function CalendarPage() {
   }, [appointmentForDrawer]);
 
   const staffForViewer = useMemo(() => {
+    if (staffDirectory.length === 0) return [] as StaffMember[];
     if (!legacyRole) return staffDirectory;
     if (!isGroomerRole(legacyRole)) return staffDirectory;
     const viewerId = profile?.id;
@@ -609,7 +746,7 @@ export default function CalendarPage() {
       : null;
     if (match) return [match];
     return [staffDirectory[0]];
-  }, [legacyRole, profile?.id]);
+  }, [legacyRole, profile?.id, staffDirectory]);
 
   const currentDateKey = useMemo(() => formatDateKey(currentDate), [currentDate]);
 
@@ -720,198 +857,210 @@ export default function CalendarPage() {
         <span className="rounded-full border border-white/15 bg-white/10 px-3 py-1">Click to edit details</span>
       </div>
 
-      {view === "day" ? (
-        <div className="overflow-hidden rounded-3xl border border-white/15 bg-white/5">
-          <div
-            className="grid"
-            style={{ gridTemplateColumns: `80px repeat(${staffForViewer.length}, minmax(200px, 1fr))` }}
-          >
-            <div className="border-b border-white/10 bg-white/5 p-3 text-xs font-semibold uppercase tracking-[0.2em] text-white/60">
-              Time
-            </div>
-            {staffForViewer.map((staff) => (
-              <div key={staff.id} className="border-b border-white/10 bg-white/5 p-3">
-                <div className="flex items-center gap-2">
-                  <span className="grid h-8 w-8 place-items-center rounded-full bg-white/10 text-xs font-semibold uppercase tracking-[0.2em]">
-                    {staff.initials}
-                  </span>
-                  <div className="flex flex-col text-sm">
-                    <span className="font-semibold text-white">{staff.name}</span>
-                    <span className="text-white/60">{appointments.filter((appt) => appt.date === currentDateKey && appt.staffId === staff.id).length} appointments</span>
-                  </div>
+      {loadingData ? (
+        <div className="rounded-3xl border border-white/15 bg-white/10 p-6 text-center text-sm text-white/70">
+          Loading schedule…
+        </div>
+      ) : dataError ? (
+        <div className="rounded-3xl border border-rose-400/60 bg-rose-500/10 p-6 text-center text-sm text-white">
+          {dataError}
+        </div>
+      ) : (
+        <>
+          {view === "day" ? (
+            <div className="overflow-hidden rounded-3xl border border-white/15 bg-white/5">
+              <div
+                className="grid"
+                style={{ gridTemplateColumns: `80px repeat(${staffForViewer.length}, minmax(200px, 1fr))` }}
+              >
+                <div className="border-b border-white/10 bg-white/5 p-3 text-xs font-semibold uppercase tracking-[0.2em] text-white/60">
+                  Time
                 </div>
-              </div>
-            ))}
-          </div>
-
-          <div
-            className="grid"
-            style={{ gridTemplateColumns: `80px repeat(${staffForViewer.length}, minmax(200px, 1fr))` }}
-          >
-            <div className="relative" style={{ height: COLUMN_HEIGHT }}>
-              {Array.from({ length: DAY_END_MINUTES / 60 - DAY_START_MINUTES / 60 + 1 }, (_, index) => {
-                const hour = Math.floor(DAY_START_MINUTES / 60) + index;
-                return (
-                  <div key={hour} className="absolute left-0 right-0" style={{ top: minutesToOffset(hour * 60) }}>
-                    <div className="h-px w-full bg-white/10" />
-                    <span className="-mt-2 block px-3 text-xs text-white/60">{formatTime(hour * 60)}</span>
+                {staffForViewer.map((staff) => (
+                  <div key={staff.id} className="border-b border-white/10 bg-white/5 p-3">
+                    <div className="flex items-center gap-2">
+                      <span className="grid h-8 w-8 place-items-center rounded-full bg-white/10 text-xs font-semibold uppercase tracking-[0.2em]">
+                        {staff.initials}
+                      </span>
+                      <div className="flex flex-col text-sm">
+                        <span className="font-semibold text-white">{staff.name}</span>
+                        <span className="text-white/60">{appointments.filter((appt) => appt.date === currentDateKey && appt.staffId === staff.id).length} appointments</span>
+                      </div>
+                    </div>
                   </div>
-                );
-              })}
-            </div>
-            {staffForViewer.map((staff) => {
-              const columnAppointments = dayAppointments
-                .filter((appointment) => appointment.staffId === staff.id)
-                .sort((a, b) => a.startMinutes - b.startMinutes);
-              return (
-                <div
-                  key={staff.id}
-                  ref={(node) => {
-                    columnRefs.current[staff.id] = node;
-                  }}
-                  style={{ height: COLUMN_HEIGHT }}
-                  className="relative border-l border-white/10 bg-white/[0.04]"
-                  onPointerDown={(event) => beginCreate(staff.id, currentDateKey, event)}
-                >
-                  {columnAppointments.map((appointment) => {
-                    const top = minutesToOffset(appointment.startMinutes);
-                    const height = durationToHeight(appointment.endMinutes - appointment.startMinutes);
+                ))}
+              </div>
+
+              <div
+                className="grid"
+                style={{ gridTemplateColumns: `80px repeat(${staffForViewer.length}, minmax(200px, 1fr))` }}
+              >
+                <div className="relative" style={{ height: COLUMN_HEIGHT }}>
+                  {Array.from({ length: DAY_END_MINUTES / 60 - DAY_START_MINUTES / 60 + 1 }, (_, index) => {
+                    const hour = Math.floor(DAY_START_MINUTES / 60) + index;
                     return (
-                      <div
-                        key={appointment.id}
-                        data-appointment-id={appointment.id}
-                        className={clsx(
-                          "absolute left-1 right-1 cursor-grab overflow-hidden rounded-2xl border border-white/20 shadow-lg shadow-black/30 transition", // base
-                          staff.colorClass
-                        )}
-                        style={{ top, height }}
-                        onPointerDown={(event) => beginMove(appointment, event)}
-                        onClick={() => openDrawer(appointment.id)}
-                      >
-                        <div className="px-3 py-2 text-xs">
-                          <p className="text-[0.7rem] uppercase tracking-[0.3em] text-white/70">
-                            {serviceCatalog.find((service) => service.id === appointment.serviceId)?.name ?? "Service"}
-                          </p>
-                          <p className="text-sm font-semibold text-white">{appointment.petName}</p>
-                          <p className="text-xs text-white/80">
-                            {formatTime(appointment.startMinutes)} – {formatTime(appointment.endMinutes)}
-                          </p>
-                          <p className="mt-1 text-[0.7rem] uppercase tracking-[0.3em] text-white/70">{appointment.status.replace(/_/g, " ")}</p>
-                        </div>
-                        <div
-                          role="presentation"
-                          data-role="resize-handle"
-                          onPointerDown={(event) => beginResize(appointment, "start", event)}
-                          className="absolute left-0 right-0 top-0 h-2 cursor-ns-resize"
-                        />
-                        <div
-                          role="presentation"
-                          data-role="resize-handle"
-                          onPointerDown={(event) => beginResize(appointment, "end", event)}
-                          className="absolute bottom-0 left-0 right-0 h-2 cursor-ns-resize"
-                        />
+                      <div key={hour} className="absolute left-0 right-0" style={{ top: minutesToOffset(hour * 60) }}>
+                        <div className="h-px w-full bg-white/10" />
+                        <span className="-mt-2 block px-3 text-xs text-white/60">{formatTime(hour * 60)}</span>
                       </div>
                     );
                   })}
-
-                  {interaction?.type === "create" && interaction.staffId === staff.id && (
-                    <div
-                      className="absolute left-1 right-1 rounded-2xl border border-dashed border-white/40 bg-white/20"
-                      style={{
-                        top: minutesToOffset(Math.min(interaction.startMinutes, interaction.endMinutes)),
-                        height: durationToHeight(
-                          Math.max(
-                            STEP_MINUTES,
-                            Math.abs(interaction.endMinutes - interaction.startMinutes)
-                          )
-                        ),
-                      }}
-                    />
-                  )}
                 </div>
-              );
-            })}
-          </div>
-        </div>
-      ) : (
-        <div className="grid gap-4 lg:grid-cols-2">
-          {weekDays.map((day) => {
-            const key = formatDateKey(day);
-            const dayEntries = weekAppointments.get(key) ?? [];
-            return (
-              <section key={key} className="space-y-3 rounded-3xl border border-white/15 bg-white/5 p-5">
-                <header className="flex items-center justify-between">
-                  <div>
-                    <p className="text-xs uppercase tracking-[0.3em] text-white/60">
-                      {day.toLocaleDateString(undefined, { weekday: "short" })}
-                    </p>
-                    <h2 className="text-lg font-semibold text-white">
-                      {day.toLocaleDateString(undefined, { month: "long", day: "numeric" })}
-                    </h2>
-                  </div>
-                  <span className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs text-white/70">
-                    {dayEntries.length} booked
-                  </span>
-                </header>
-                {dayEntries.length === 0 ? (
-                  <p className="rounded-2xl border border-dashed border-white/15 bg-white/5 px-4 py-6 text-sm text-white/60">
-                    No appointments scheduled.
-                  </p>
-                ) : (
-                  <ul className="space-y-3">
-                    {dayEntries.map((appointment) => {
-                      const staff = staffDirectory.find((member) => member.id === appointment.staffId);
-                      const service = serviceCatalog.find((svc) => svc.id === appointment.serviceId);
-                      return (
-                        <li
-                          key={appointment.id}
-                          className="rounded-2xl border border-white/15 bg-white/10 p-4 text-sm transition hover:border-white/30 hover:bg-white/20"
-                        >
-                          <div className="flex items-start justify-between gap-3">
-                            <div>
-                              <p className="text-sm font-semibold text-white">{appointment.petName}</p>
-                              <p className="text-xs text-white/70">{appointment.clientName}</p>
-                              <p className="mt-2 text-xs font-semibold uppercase tracking-[0.25em] text-white/60">
-                                {service?.name ?? "Service"}
-                              </p>
-                            </div>
-                            <div className="text-right text-xs text-white/70">
-                              <p>{formatTime(appointment.startMinutes)}</p>
-                              <p>{formatTime(appointment.endMinutes)}</p>
-                              <p className="mt-2 inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-3 py-1 text-[0.65rem] uppercase tracking-[0.3em]">
-                                {staff?.initials ?? "--"}
-                                <span>{appointment.status.replace(/_/g, " ")}</span>
-                              </p>
-                            </div>
-                          </div>
-                          <button
-                            type="button"
+                {staffForViewer.map((staff) => {
+                  const columnAppointments = dayAppointments
+                    .filter((appointment) => appointment.staffId === staff.id)
+                    .sort((a, b) => a.startMinutes - b.startMinutes);
+                  return (
+                    <div
+                      key={staff.id}
+                      ref={(node) => {
+                        columnRefs.current[staff.id] = node;
+                      }}
+                      style={{ height: COLUMN_HEIGHT }}
+                      className="relative border-l border-white/10 bg-white/[0.04]"
+                      onPointerDown={(event) => beginCreate(staff.id, currentDateKey, event)}
+                    >
+                      {columnAppointments.map((appointment) => {
+                        const top = minutesToOffset(appointment.startMinutes);
+                        const height = durationToHeight(appointment.endMinutes - appointment.startMinutes);
+                        return (
+                          <div
+                            key={appointment.id}
+                            data-appointment-id={appointment.id}
+                            className={clsx(
+                              "absolute left-1 right-1 cursor-grab overflow-hidden rounded-2xl border border-white/20 shadow-lg shadow-black/30 transition",
+                              staff.colorClass
+                            )}
+                            style={{ top, height }}
+                            onPointerDown={(event) => beginMove(appointment, event)}
                             onClick={() => openDrawer(appointment.id)}
-                            className="mt-4 inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-white/70 transition hover:border-white/30 hover:text-white"
                           >
-                            Edit details
-                          </button>
-                        </li>
-                      );
-                    })}
-                  </ul>
-                )}
-              </section>
-            );
-          })}
-        </div>
-      )}
+                            <div className="px-3 py-2 text-xs">
+                              <p className="text-[0.7rem] uppercase tracking-[0.3em] text-white/70">
+                                {serviceCatalog.find((service) => service.id === appointment.serviceId)?.name ?? "Service"}
+                              </p>
+                              <p className="text-sm font-semibold text-white">{appointment.petName}</p>
+                              <p className="text-xs text-white/80">
+                                {formatTime(appointment.startMinutes)} – {formatTime(appointment.endMinutes)}
+                              </p>
+                              <p className="mt-1 text-[0.7rem] uppercase tracking-[0.3em] text-white/70">{appointment.status.replace(/_/g, " ")}</p>
+                            </div>
+                            <div
+                              role="presentation"
+                              data-role="resize-handle"
+                              onPointerDown={(event) => beginResize(appointment, "start", event)}
+                              className="absolute left-0 right-0 top-0 h-2 cursor-ns-resize"
+                            />
+                            <div
+                              role="presentation"
+                              data-role="resize-handle"
+                              onPointerDown={(event) => beginResize(appointment, "end", event)}
+                              className="absolute bottom-0 left-0 right-0 h-2 cursor-ns-resize"
+                            />
+                          </div>
+                        );
+                      })}
 
-      <AppointmentDetailDrawer
-        open={drawerState.open && !!drawerValue}
-        staff={staffForViewer}
-        services={serviceCatalog}
-        addOns={addOnCatalog}
-        value={drawerValue}
-        onClose={closeDrawer}
-        onSubmit={handleDrawerSubmit}
-        onDelete={handleDrawerDelete}
-      />
+                      {interaction?.type === "create" && interaction.staffId === staff.id && (
+                        <div
+                          className="absolute left-1 right-1 rounded-2xl border border-dashed border-white/40 bg-white/20"
+                          style={{
+                            top: minutesToOffset(Math.min(interaction.startMinutes, interaction.endMinutes)),
+                            height: durationToHeight(
+                              Math.max(
+                                STEP_MINUTES,
+                                Math.abs(interaction.endMinutes - interaction.startMinutes)
+                              )
+                            ),
+                          }}
+                        />
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          ) : (
+            <div className="grid gap-4 lg:grid-cols-2">
+              {weekDays.map((day) => {
+                const key = formatDateKey(day);
+                const dayEntries = weekAppointments.get(key) ?? [];
+                return (
+                  <section key={key} className="space-y-3 rounded-3xl border border-white/15 bg-white/5 p-5">
+                    <header className="flex items-center justify-between">
+                      <div>
+                        <p className="text-xs uppercase tracking-[0.3em] text-white/60">
+                          {day.toLocaleDateString(undefined, { weekday: "short" })}
+                        </p>
+                        <h2 className="text-lg font-semibold text-white">
+                          {day.toLocaleDateString(undefined, { month: "long", day: "numeric" })}
+                        </h2>
+                      </div>
+                      <span className="rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs text-white/70">
+                        {dayEntries.length} booked
+                      </span>
+                    </header>
+                    {dayEntries.length === 0 ? (
+                      <p className="rounded-2xl border border-dashed border-white/15 bg-white/5 px-4 py-6 text-sm text-white/60">
+                        No appointments scheduled.
+                      </p>
+                    ) : (
+                      <ul className="space-y-3">
+                        {dayEntries.map((appointment) => {
+                          const staff = staffDirectory.find((member) => member.id === appointment.staffId);
+                          const service = serviceCatalog.find((svc) => svc.id === appointment.serviceId);
+                          return (
+                            <li
+                              key={appointment.id}
+                              className="rounded-2xl border border-white/15 bg-white/10 p-4 text-sm transition hover:border-white/30 hover:bg-white/20"
+                            >
+                              <div className="flex items-start justify-between gap-3">
+                                <div>
+                                  <p className="text-sm font-semibold text-white">{appointment.petName}</p>
+                                  <p className="text-xs text-white/70">{appointment.clientName}</p>
+                                  <p className="mt-2 text-xs font-semibold uppercase tracking-[0.25em] text-white/60">
+                                    {service?.name ?? "Service"}
+                                  </p>
+                                </div>
+                                <div className="text-right text-xs text-white/70">
+                                  <p>{formatTime(appointment.startMinutes)}</p>
+                                  <p>{formatTime(appointment.endMinutes)}</p>
+                                  <p className="mt-2 inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-3 py-1 text-[0.65rem] uppercase tracking-[0.3em]">
+                                    {staff?.initials ?? "--"}
+                                    <span>{appointment.status.replace(/_/g, " ")}</span>
+                                  </p>
+                                </div>
+                              </div>
+                              <button
+                                type="button"
+                                onClick={() => openDrawer(appointment.id)}
+                                className="mt-4 inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.3em] text-white/70 transition hover:border-white/30 hover:text-white"
+                              >
+                                Edit details
+                              </button>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                    )}
+                  </section>
+                );
+              })}
+            </div>
+          )}
+
+          <AppointmentDetailDrawer
+            open={drawerState.open && !!drawerValue}
+            staff={staffForViewer}
+            services={serviceCatalog}
+            addOns={addOnCatalog}
+            value={drawerValue}
+            onClose={closeDrawer}
+            onSubmit={handleDrawerSubmit}
+            onDelete={handleDrawerDelete}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/app/api/payroll/export/route.ts
+++ b/app/api/payroll/export/route.ts
@@ -79,7 +79,7 @@ export async function GET(request: Request) {
     const rate = typeof line.commission_rate === "number" ? line.commission_rate : Number(line.commission_rate ?? 0);
     return {
       date: line.start_time,
-      service: line.service ?? "",
+      service: line.service_name ?? line.service ?? "",
       base,
       commissionRate: rate,
       commissionAmount,

--- a/app/api/staff/[id]/history/route.ts
+++ b/app/api/staff/[id]/history/route.ts
@@ -19,7 +19,10 @@ export async function GET(req: Request, { params }: { params: { id: string } }) 
   const { data: ok } = await supabase.rpc('has_perm', { _uid: uid, _perm: 'manage_staff' });
   if (!ok && uid !== sid) return NextResponse.json({ error: 'forbidden' }, { status: 403 });
 
-  let q = supabase.from('appointments').select('id,starts_at,ends_at,service_id,status,total_price,tip').eq('staff_id', sid);
+  let q = supabase
+    .from('appointments')
+    .select('id,starts_at,ends_at,service_id,services(name),status,total_price,tip')
+    .eq('staff_id', sid);
   if (from) q = q.gte('starts_at', from);
   if (to) q = q.lte('starts_at', to);
   if (status && status !== 'all') q = q.eq('status', status);

--- a/app/api/staff/[id]/overview/route.ts
+++ b/app/api/staff/[id]/overview/route.ts
@@ -26,7 +26,7 @@ export async function GET(_: Request, { params }: { params: { id: string } }) {
 
   const { data: recent } = await supabase
     .from('appointments')
-    .select('id,starts_at,ends_at,client_id,service_id,status,total_price')
+    .select('id,starts_at,ends_at,client_id,service_id,services(name),status,total_price')
     .eq('staff_id', sid).order('starts_at', { ascending: false }).limit(8);
 
   return NextResponse.json({ today: await k(d0,d1), week: await k(w0,w1), month: await k(m0,m1), recent: recent ?? [] });

--- a/app/employees/[id]/EmployeeDetailClient.tsx
+++ b/app/employees/[id]/EmployeeDetailClient.tsx
@@ -16,6 +16,7 @@ import PageContainer from "@/components/PageContainer";
 import { supabase } from "@/lib/supabase/client";
 import { useAuth } from "@/components/AuthProvider";
 import { canManageWorkspace, derivePermissionFlags } from "@/lib/auth/roles";
+import { readMoney } from "./data-helpers";
 
 import StaffHeader from "./components/StaffHeader";
 import StaffTabs from "./components/StaffTabs";
@@ -62,7 +63,7 @@ export type ViewerRecord = {
 
 export type AppointmentDiscount = {
   id: number;
-  appointment_id?: number;
+  appointment_id?: string;
   amount: number;
   reason: string;
   created_at?: string;
@@ -70,11 +71,12 @@ export type AppointmentDiscount = {
 };
 
 export type AppointmentDetail = {
-  id: number;
+  id: string;
   start_time: string | null;
   end_time: string | null;
   status: string | null;
   service: string | null;
+  service_id?: string | null;
   price: number | null;
   notes: string | null;
   vaccine_flag?: boolean | null;
@@ -89,7 +91,7 @@ export type AppointmentDetail = {
 };
 
 type DiscountDraft = {
-  appointmentId: number;
+  appointmentId: string;
   amount: number;
   reason: string;
   discountId?: number | null;
@@ -110,7 +112,7 @@ type EmployeeDetailContextValue = {
   appointmentDetail: AppointmentDetail | null;
   appointmentLoading: boolean;
   refreshKey: number;
-  openAppointmentDrawer: (appointmentId: number) => void;
+  openAppointmentDrawer: (appointmentId: string) => void;
   closeDrawer: () => void;
   openDiscountModal: (draft: DiscountDraft) => void;
   refreshAppointmentDetail: () => Promise<void>;
@@ -192,7 +194,7 @@ export default function EmployeeDetailClient({ children, employee, goals }: Prop
     };
   }, [email]);
 
-  const [drawerAppointmentId, setDrawerAppointmentId] = useState<number | null>(null);
+  const [drawerAppointmentId, setDrawerAppointmentId] = useState<string | null>(null);
   const [appointmentDetail, setAppointmentDetail] = useState<AppointmentDetail | null>(null);
   const [appointmentLoading, setAppointmentLoading] = useState(false);
   const [discountDraft, setDiscountDraft] = useState<DiscountDraft | null>(null);
@@ -245,67 +247,159 @@ export default function EmployeeDetailClient({ children, employee, goals }: Prop
     if (!drawerAppointmentId) return;
     setAppointmentLoading(true);
     try {
+      const baseSelect =
+        "id,start_time,end_time,starts_at,ends_at,status,notes,note,service,service_id,service_name,price,price_cents,price_amount,price_amount_cents,owner_name,owner_email,owner_phone,pet_name,pet_breed,client_id,pet_id,services(name),clients:client_id(first_name,last_name,full_name,email,phone),pets:pet_id(name,breed),appointment_add_ons(add_on:add_ons(name))";
+
+      let record: any = null;
       const { data, error } = await supabase
         .from("appointments")
-        .select("*")
+        .select(baseSelect)
         .eq("id", drawerAppointmentId)
         .maybeSingle();
 
       if (error || !data) {
-        pushToast("Unable to load appointment", "error");
-        setAppointmentDetail(null);
-        setAppointmentLoading(false);
-        return;
+        const { data: fallbackData, error: fallbackError } = await supabase
+          .from("appointments")
+          .select("*")
+          .eq("id", drawerAppointmentId)
+          .maybeSingle();
+        if (fallbackError || !fallbackData) {
+          pushToast("Unable to load appointment", "error");
+          setAppointmentDetail(null);
+          setAppointmentLoading(false);
+          return;
+        }
+        record = fallbackData;
+      } else {
+        record = data;
       }
 
-      const detail: AppointmentDetail = {
-        id: data.id,
-        start_time: data.start_time ?? null,
-        end_time: data.end_time ?? null,
-        status: data.status ?? null,
-        service: data.service ?? null,
-        price: typeof data.price === "number" ? data.price : data.price_cents ? data.price_cents / 100 : null,
-        notes: data.notes ?? data.note ?? null,
-        vaccine_flag: data.vaccine_flag ?? data.requires_vaccine ?? null,
-        owner_name: data.owner_name ?? null,
-        owner_email: data.owner_email ?? null,
-        owner_phone: data.owner_phone ?? null,
-        pet_name: data.pet_name ?? null,
-        pet_breed: data.pet_breed ?? null,
-        services: Array.isArray(data.services) ? data.services : data.service ? [data.service] : [],
+      const normaliseIso = (value: unknown): string | null => {
+        if (!value) return null;
+        if (typeof value === "string") return value;
+        if (value instanceof Date) return value.toISOString();
+        if (typeof value === "number") {
+          const parsed = new Date(value);
+          return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+        }
+        return String(value);
       };
 
-      if (!detail.owner_name && data.client_id) {
+      const serviceNameDirect =
+        typeof record.service === "string" && record.service.trim().length > 0
+          ? record.service.trim()
+          : "";
+      const serviceNameFallbackField =
+        typeof record.service_name === "string" && record.service_name.trim().length > 0
+          ? record.service_name.trim()
+          : "";
+      const serviceNameFromRelation =
+        record.services &&
+        typeof record.services === "object" &&
+        typeof record.services?.name === "string" &&
+        record.services.name.trim().length > 0
+          ? record.services.name.trim()
+          : "";
+      const serviceName =
+        serviceNameDirect || serviceNameFallbackField || serviceNameFromRelation || null;
+
+      const clientRecord =
+        record.clients ?? record.client ?? record.customer ?? record.owner ?? null;
+      const fullNameFromField =
+        clientRecord &&
+        typeof clientRecord.full_name === "string" &&
+        clientRecord.full_name.trim().length > 0
+          ? clientRecord.full_name.trim()
+          : "";
+      const concatenatedName = [clientRecord?.first_name, clientRecord?.last_name]
+        .filter((part): part is string => typeof part === "string" && part.trim().length > 0)
+        .map((part) => part.trim())
+        .join(" ")
+        .trim();
+      const clientFullName = fullNameFromField || concatenatedName || null;
+
+      const petRecord = record.pets ?? record.pet ?? null;
+      const addOnNames = Array.isArray(record.appointment_add_ons)
+        ? (record.appointment_add_ons as any[])
+            .map((item) => {
+              if (!item) return null;
+              const source = item.add_on ?? item.addOn ?? item;
+              return typeof source?.name === "string" && source.name.trim().length > 0
+                ? source.name.trim()
+                : null;
+            })
+            .filter((name): name is string => Boolean(name))
+        : [];
+
+      const detail: AppointmentDetail = {
+        id: record.id ? String(record.id) : drawerAppointmentId,
+        start_time: normaliseIso(
+          record.start_time ?? record.starts_at ?? record.start ?? record.scheduled_at ?? record.start_date ?? record.date ?? null
+        ),
+        end_time: normaliseIso(record.end_time ?? record.ends_at ?? record.end ?? record.ends_on ?? null),
+        status: record.status ?? null,
+        service: serviceName ?? null,
+        service_id: record.service_id ? String(record.service_id) : null,
+        price: readMoney(record, ["price", "price_cents", "price_amount", "price_amount_cents"]),
+        notes: record.notes ?? record.note ?? null,
+        vaccine_flag: record.vaccine_flag ?? record.requires_vaccine ?? null,
+        owner_name: record.owner_name ?? clientFullName ?? null,
+        owner_email: record.owner_email ?? clientRecord?.email ?? null,
+        owner_phone: record.owner_phone ?? clientRecord?.phone ?? null,
+        pet_name:
+          (typeof record.pet_name === "string" && record.pet_name.trim().length > 0 ? record.pet_name.trim() : null) ??
+          (petRecord && typeof petRecord.name === "string" ? petRecord.name : null),
+        pet_breed:
+          (typeof record.pet_breed === "string" && record.pet_breed.trim().length > 0 ? record.pet_breed.trim() : null) ??
+          (petRecord && typeof petRecord.breed === "string" ? petRecord.breed : null),
+        services: [serviceName, ...addOnNames].filter((name): name is string => Boolean(name)),
+      };
+
+      if (!detail.owner_name && record.client_id) {
         const { data: client } = await supabase
           .from("clients")
-          .select("full_name,email,phone")
-          .eq("id", data.client_id)
+          .select("first_name,last_name,full_name,email,phone")
+          .eq("id", record.client_id)
           .maybeSingle();
         if (client) {
-          detail.owner_name = client.full_name ?? null;
-          detail.owner_email = client.email ?? null;
-          detail.owner_phone = client.phone ?? null;
+          const fallbackName =
+            (typeof client.full_name === "string" && client.full_name.trim().length > 0
+              ? client.full_name.trim()
+              : null) ??
+            [client.first_name, client.last_name].filter(Boolean).join(" ").trim();
+          detail.owner_name = fallbackName || detail.owner_name;
+          detail.owner_email = client.email ?? detail.owner_email ?? null;
+          detail.owner_phone = client.phone ?? detail.owner_phone ?? null;
         }
       }
 
-      if (!detail.pet_name && data.pet_id) {
+      if (!detail.pet_name && record.pet_id) {
         const { data: pet } = await supabase
           .from("pets")
           .select("name,breed")
-          .eq("id", data.pet_id)
+          .eq("id", record.pet_id)
           .maybeSingle();
         if (pet) {
-          detail.pet_name = pet.name ?? null;
-          detail.pet_breed = pet.breed ?? null;
+          detail.pet_name = pet.name ?? detail.pet_name ?? null;
+          detail.pet_breed = pet.breed ?? detail.pet_breed ?? null;
         }
       }
 
       const { data: discounts } = await supabase
         .from("appointment_discounts")
-        .select("id,amount,reason,created_at,created_by")
+        .select("id,amount,amount_cents,reason,created_at,created_by,appointment_id")
         .eq("appointment_id", drawerAppointmentId)
         .order("created_at", { ascending: true });
-      detail.appointment_discounts = (discounts ?? []) as AppointmentDiscount[];
+      detail.appointment_discounts = Array.isArray(discounts)
+        ? (discounts as any[]).map((discount) => ({
+            id: discount.id,
+            appointment_id: discount.appointment_id ? String(discount.appointment_id) : drawerAppointmentId,
+            amount: readMoney(discount, ["amount", "amount_cents"]) ?? 0,
+            reason: discount.reason ?? "",
+            created_at: discount.created_at ?? null,
+            created_by: discount.created_by ?? null,
+          }))
+        : [];
 
       try {
         const { data: photos } = await supabase
@@ -336,7 +430,7 @@ export default function EmployeeDetailClient({ children, employee, goals }: Prop
     }
   }, [drawerAppointmentId, fetchAppointmentDetail]);
 
-  const openAppointmentDrawer = useCallback((appointmentId: number) => {
+  const openAppointmentDrawer = useCallback((appointmentId: string) => {
     setDrawerAppointmentId(appointmentId);
   }, []);
 

--- a/app/employees/[id]/components/RecentJobs.tsx
+++ b/app/employees/[id]/components/RecentJobs.tsx
@@ -3,7 +3,7 @@
 import clsx from "clsx";
 
 export type RecentJobRow = {
-  id: number;
+  id: string;
   start: string;
   pet: string | null;
   service: string | null;
@@ -14,7 +14,7 @@ export type RecentJobRow = {
 type RecentJobsProps = {
   loading: boolean;
   rows: RecentJobRow[];
-  onSelect: (id: number) => void;
+  onSelect: (id: string) => void;
 };
 
 function formatCurrency(value: number | null) {

--- a/hooks/useCalendarData.ts
+++ b/hooks/useCalendarData.ts
@@ -3,20 +3,87 @@
 import { useEffect, useMemo, useState } from "react";
 import { supabase } from "@/lib/supabaseClient";
 
-export interface Employee { id: string; name: string; }
-export interface Service  { id: string; name: string; minutes: number; }
+const STAFF_COLOR_CLASSES = [
+  "bg-brand-bubble/20 text-white",
+  "bg-emerald-400/20 text-emerald-950",
+  "bg-sky-400/20 text-sky-950",
+  "bg-amber-300/30 text-amber-900",
+  "bg-violet-400/25 text-violet-950",
+];
+
+const INACTIVE_KEYWORDS = ["inactive", "archived", "disabled", "terminated", "deleted"];
+
+function inferIsActive(record: Record<string, unknown> | null | undefined) {
+  if (!record || typeof record !== "object") {
+    return true;
+  }
+
+  const boolKeys = ["active", "is_active", "enabled", "is_enabled"] as const;
+  for (const key of boolKeys) {
+    const value = (record as Record<string, unknown>)[key];
+    if (typeof value === "boolean") {
+      return value;
+    }
+  }
+
+  const status = (record as Record<string, unknown>).status;
+  if (typeof status === "string") {
+    const lowered = status.toLowerCase();
+    if (INACTIVE_KEYWORDS.some((flag) => lowered.includes(flag))) {
+      return false;
+    }
+  }
+
+  const archivedAt = (record as Record<string, unknown>).archived_at;
+  if (archivedAt !== null && archivedAt !== undefined) {
+    return false;
+  }
+
+  return true;
+}
+
+function coerceString(value: unknown, fallback: string) {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim();
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return fallback;
+}
+
+function coerceNumber(value: unknown, fallback: number) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+export interface Employee {
+  id: string;
+  name: string;
+  initials?: string | null;
+  colorClass?: string | null;
+}
+export interface Service  {
+  id: string;
+  name: string;
+  minutes: number;
+}
 export interface Appt {
   id: string;
-  employee_id: string;     // bigint -> string in JS
+  employee_id: string;
   client_id?: string | null;
   pet_id?: string | null;
-  service_id: string;      // int -> string in JS
+  service_id: string | null;
+  service_size_id?: string | null;
   service?: string | null;
   price?: number | null;
+  price_addons?: number | null;
+  discount?: number | null;
+  tax?: number | null;
   status?: string | null;
   notes?: string | null;
-  start_time: string;      // ISO
-  end_time:   string;      // ISO
+  start_time: string;
+  end_time:   string;
 }
 
 type View = "day" | "week" | "month";
@@ -55,13 +122,39 @@ export function useCalendarData(currentDate: Date, view: View) {
       try {
         setLoading(true);
         // employees
-        const { data: emps, error: e1 } = await supabase.from("employees").select("id,name,active").order("name");
+        const { data: emps, error: e1 } = await supabase.from("employees").select("*").order("name");
         if (e1) throw e1;
-        const active = (emps || []).filter((e:any) => e.active !== false).map((e:any) => ({ id: String(e.id), name: e.name || `#${e.id}` }));
-        // services from service_catalog
-        const { data: svcs, error: e2 } = await supabase.from("service_catalog").select("id,name,default_minutes").order("id");
+        const rows = (emps ?? []) as any[];
+        const active = rows
+          .filter((record) => inferIsActive(record))
+          .map((record, index: number) => {
+            const id = coerceString(record.id, `staff-${index + 1}`);
+            const name = coerceString(record.name, id ? `#${id}` : `#${index + 1}`);
+            const initials = name
+              .split(/\s+/)
+              .filter(Boolean)
+              .map((part) => part[0]?.toUpperCase() ?? "")
+              .join("")
+              .slice(0, 2) || name.slice(0, 2).toUpperCase();
+            const colorClass = STAFF_COLOR_CLASSES[index % STAFF_COLOR_CLASSES.length];
+            return {
+              id,
+              name,
+              initials,
+              colorClass,
+            };
+          });
+        // services
+        const { data: svcs, error: e2 } = await supabase.from("services").select("*").order("name");
         if (e2) throw e2;
-        const svc = (svcs || []).map((s:any) => ({ id: String(s.id), name: s.name, minutes: Number(s.default_minutes || 60) }));
+        const svcRows = (svcs ?? []) as any[];
+        const svc = svcRows
+          .filter((record) => inferIsActive(record))
+          .map((s: any, index: number) => ({
+            id: coerceString(s.id, `service-${index + 1}`),
+            name: coerceString(s.name, "Service"),
+            minutes: coerceNumber(s.duration_min, 60),
+          }));
         if (!cancelled) { setEmployees(active); setServices(svc); }
       } catch (e:any) {
         if (!cancelled) setErr(e.message || String(e));
@@ -80,15 +173,18 @@ export function useCalendarData(currentDate: Date, view: View) {
         setLoading(true);
         const { data, error } = await supabase
           .from("appointments")
-          .select("id,employee_id,client_id,pet_id,service_id,price,status,notes,start_time,end_time")
+          .select(
+            "id,employee_id,client_id,pet_id,service_id,service_size_id,price,price_addons,discount,tax,status,notes,start_time,end_time"
+          )
           .lt("start_time", toISO)
           .gt("end_time", fromISO);
         if (error) throw error;
         const mapped: Appt[] = (data || []).map((a:any) => ({
           ...a,
           id: String(a.id),
-          employee_id: String(a.employee_id),
-          service_id: String(a.service_id),
+          employee_id: a.employee_id != null ? String(a.employee_id) : "",
+          service_id: a.service_id ? String(a.service_id) : null,
+          service_size_id: a.service_size_id ? String(a.service_size_id) : null,
           start_time: a.start_time,
           end_time: a.end_time,
         }));
@@ -126,14 +222,16 @@ export function useCalendarData(currentDate: Date, view: View) {
 
   // helpers
   async function checkConflict(employee_id: string, startISO: string, endISO: string, excludeId?: string) {
-    const { data, error } = await supabase.rpc("find_conflicts", {
-      p_staff_id: Number(employee_id),          // RPC arg uses bigint
-      p_start: startISO,
-      p_end: endISO,
-      p_exclude_appointment_id: excludeId ? Number(excludeId) : null
-    });
+    const query = supabase
+      .from("appointments")
+      .select("id,start_time,end_time")
+      .eq("employee_id", Number(employee_id))
+      .lt("start_time", endISO)
+      .gt("end_time", startISO);
+    if (excludeId) query.neq("id", excludeId);
+    const { data, error } = await query;
     if (error) throw error;
-    return Boolean(data);
+    return (data ?? []).length > 0;
   }
 
   function durationForService(service_id: string) {
@@ -149,11 +247,25 @@ export function useCalendarData(currentDate: Date, view: View) {
     if (conflict) return { error: "Time conflict for selected staff." };
     const { data, error } = await supabase
       .from("appointments")
-      .insert([{ employee_id: Number(input.employee_id), service_id: Number(input.service_id), start_time: input.start_time, end_time: endISO, notes: input.notes ?? null }])
+      .insert([
+        {
+          employee_id: Number(input.employee_id),
+          service_id: input.service_id,
+          start_time: input.start_time,
+          end_time: endISO,
+          notes: input.notes ?? null,
+        },
+      ])
       .select()
       .single();
     if (error) return { error: error.message };
-    const ap: Appt = { ...data, id: String(data.id), employee_id: String(data.employee_id), service_id: String(data.service_id) };
+    const ap: Appt = {
+      ...data,
+      id: String(data.id),
+      employee_id: data.employee_id != null ? String(data.employee_id) : "",
+      service_id: data.service_id ? String(data.service_id) : null,
+      service_size_id: data.service_size_id ? String(data.service_size_id) : null,
+    };
     setAppointments(prev => [...prev, ap]);
     return { error: null };
   }
@@ -173,22 +285,28 @@ export function useCalendarData(currentDate: Date, view: View) {
       .from("appointments")
       .update({
         employee_id: Number(newEmp),
-        service_id: Number(newServiceId),
+        service_id: newServiceId,
         start_time: newStart,
         end_time: newEnd,
         notes: input.notes ?? cur?.notes ?? null
       })
-      .eq("id", Number(id))
+      .eq("id", id)
       .select()
       .single();
     if (error) return { error: error.message };
-    const ap: Appt = { ...data, id: String(data.id), employee_id: String(data.employee_id), service_id: String(data.service_id) };
+    const ap: Appt = {
+      ...data,
+      id: String(data.id),
+      employee_id: data.employee_id != null ? String(data.employee_id) : "",
+      service_id: data.service_id ? String(data.service_id) : null,
+      service_size_id: data.service_size_id ? String(data.service_size_id) : null,
+    };
     setAppointments(prev => prev.map(x => x.id === ap.id ? ap : x));
     return { error: null };
   }
 
   async function deleteAppt(id: string) {
-    const { error } = await supabase.from("appointments").delete().eq("id", Number(id));
+    const { error } = await supabase.from("appointments").delete().eq("id", id);
     if (error) return { error: error.message };
     setAppointments(prev => prev.filter(x => x.id !== id));
     return { error: null };

--- a/supabase/migrations/20250601_core_entities.sql
+++ b/supabase/migrations/20250601_core_entities.sql
@@ -1,0 +1,204 @@
+-- Core entity tables for scheduling & booking
+create extension if not exists pgcrypto;
+
+-- Staff enhancements
+alter table if exists public.employees
+  add column if not exists initials text,
+  add column if not exists bio text,
+  add column if not exists calendar_color_class text,
+  add column if not exists profile_slug text;
+
+-- Clients
+create table if not exists public.clients (
+  id uuid primary key default gen_random_uuid(),
+  first_name text not null,
+  last_name text not null,
+  email text,
+  phone text,
+  notes text,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+-- Pets
+create table if not exists public.pets (
+  id uuid primary key default gen_random_uuid(),
+  client_id uuid references public.clients(id) on delete cascade,
+  name text not null,
+  breed text,
+  birthdate date,
+  notes text,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+-- Services & configuration
+create table if not exists public.services (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  description text,
+  duration_min int not null default 60,
+  base_price numeric(10,2) not null default 0,
+  buffer_pre_min int not null default 0,
+  buffer_post_min int not null default 0,
+  color_class text,
+  active boolean not null default true,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists public.service_sizes (
+  id uuid primary key default gen_random_uuid(),
+  service_id uuid not null references public.services(id) on delete cascade,
+  label text not null,
+  multiplier numeric(6,3) not null default 1,
+  sort_order int not null default 0
+);
+
+create table if not exists public.add_ons (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  description text,
+  price numeric(10,2) not null default 0,
+  active boolean not null default true,
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists public.service_add_ons (
+  service_id uuid not null references public.services(id) on delete cascade,
+  add_on_id uuid not null references public.add_ons(id) on delete cascade,
+  primary key (service_id, add_on_id)
+);
+
+-- Appointments
+create table if not exists public.appointments (
+  id uuid primary key default gen_random_uuid(),
+  employee_id bigint references public.employees(id) on delete set null,
+  client_id uuid references public.clients(id) on delete set null,
+  pet_id uuid references public.pets(id) on delete set null,
+  service_id uuid references public.services(id) on delete set null,
+  service_size_id uuid references public.service_sizes(id) on delete set null,
+  start_time timestamptz not null,
+  end_time timestamptz not null,
+  price numeric(10,2),
+  price_addons numeric(10,2) default 0,
+  discount numeric(10,2) default 0,
+  tax numeric(10,2) default 0,
+  status text not null default 'booked' check (status in ('booked','checked_in','in_progress','completed','canceled','no_show')),
+  notes text,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists public.appointment_add_ons (
+  appointment_id uuid not null references public.appointments(id) on delete cascade,
+  add_on_id uuid not null references public.add_ons(id) on delete cascade,
+  price numeric(10,2) not null default 0,
+  primary key (appointment_id, add_on_id)
+);
+
+-- Updated timestamp trigger helper
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = timezone('utc', now());
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_clients_updated on public.clients;
+create trigger trg_clients_updated
+before update on public.clients
+for each row execute procedure public.set_updated_at();
+
+drop trigger if exists trg_pets_updated on public.pets;
+create trigger trg_pets_updated
+before update on public.pets
+for each row execute procedure public.set_updated_at();
+
+drop trigger if exists trg_services_updated on public.services;
+create trigger trg_services_updated
+before update on public.services
+for each row execute procedure public.set_updated_at();
+
+drop trigger if exists trg_appointments_updated on public.appointments;
+create trigger trg_appointments_updated
+before update on public.appointments
+for each row execute procedure public.set_updated_at();
+
+-- Helpful indexes
+create index if not exists idx_pets_client on public.pets(client_id);
+create index if not exists idx_service_sizes_service on public.service_sizes(service_id, sort_order);
+create index if not exists idx_appointments_staff_time on public.appointments(employee_id, start_time);
+create index if not exists idx_appointments_client_time on public.appointments(client_id, start_time);
+create index if not exists idx_appointments_pet_time on public.appointments(pet_id, start_time);
+
+-- Enable RLS & simple policies
+alter table public.clients enable row level security;
+alter table public.pets enable row level security;
+alter table public.services enable row level security;
+alter table public.service_sizes enable row level security;
+alter table public.add_ons enable row level security;
+alter table public.service_add_ons enable row level security;
+alter table public.appointments enable row level security;
+alter table public.appointment_add_ons enable row level security;
+
+create policy if not exists clients_authenticated_read on public.clients
+  for select
+  using (auth.role() = 'authenticated');
+create policy if not exists clients_authenticated_write on public.clients
+  for all
+  using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');
+
+create policy if not exists pets_authenticated_read on public.pets
+  for select
+  using (auth.role() = 'authenticated');
+create policy if not exists pets_authenticated_write on public.pets
+  for all
+  using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');
+
+create policy if not exists services_authenticated_read on public.services
+  for select
+  using (auth.role() = 'authenticated');
+create policy if not exists services_authenticated_write on public.services
+  for all
+  using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');
+
+create policy if not exists service_sizes_authenticated_read on public.service_sizes
+  for select
+  using (auth.role() = 'authenticated');
+create policy if not exists service_sizes_authenticated_write on public.service_sizes
+  for all
+  using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');
+
+create policy if not exists add_ons_authenticated_read on public.add_ons
+  for select
+  using (auth.role() = 'authenticated');
+create policy if not exists add_ons_authenticated_write on public.add_ons
+  for all
+  using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');
+
+create policy if not exists service_add_ons_authenticated on public.service_add_ons
+  for all
+  using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');
+
+create policy if not exists appointments_authenticated_read on public.appointments
+  for select
+  using (auth.role() = 'authenticated');
+create policy if not exists appointments_authenticated_write on public.appointments
+  for all
+  using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');
+
+create policy if not exists appointment_add_ons_authenticated on public.appointment_add_ons
+  for all
+  using (auth.role() = 'authenticated')
+  with check (auth.role() = 'authenticated');

--- a/supabase/migrations/20251219_update_payroll_view_service.sql
+++ b/supabase/migrations/20251219_update_payroll_view_service.sql
@@ -1,0 +1,29 @@
+-- Align payroll view with normalized services table
+create or replace view public.payroll_lines_view as
+select
+  a.id as appointment_id,
+  a.employee_id as staff_id,
+  a.start_time,
+  a.end_time,
+  svc.name as service,
+  svc.name as service_name,
+  coalesce(a.price, 0)::numeric as base_price,
+  coalesce(e.commission_rate, 0)::numeric as commission_rate,
+  coalesce(a.price, 0)::numeric * coalesce(e.commission_rate, 0)::numeric as commission_amount,
+  -coalesce(d.total_discount, 0)::numeric as adjustment_amount,
+  d.reasons as adjustment_reason,
+  coalesce(a.price, 0)::numeric + coalesce(a.price, 0)::numeric * coalesce(e.commission_rate, 0)::numeric - coalesce(d.total_discount, 0)::numeric as final_earnings,
+  case
+    when coalesce(a.start_time, a.starts_at) is null then null
+    else ((floor((extract(doy from coalesce(a.start_time, a.starts_at)) - 1) / 7)::int % 2) + 1)
+  end as week_index
+from public.appointments a
+join public.employees e on e.id = a.employee_id
+left join public.services svc on svc.id = a.service_id
+left join lateral (
+  select
+    coalesce(sum(amount), 0) as total_discount,
+    string_agg(reason, '; ' order by created_at) as reasons
+  from public.appointment_discounts ad
+  where ad.appointment_id = a.id
+) d on true;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,7 +1,11 @@
--- Seed data for staff module
-insert into public.employees (id, name, email, phone, role, status, commission_rate, app_permissions)
+-- Seed data for core scheduling entities
+
+-- Staff
+insert into public.employees (id, name, email, phone, role, status, commission_rate, app_permissions, initials, bio, calendar_color_class, profile_slug)
 values
-  (1, 'Alex Groomer', 'alex@scruffybutts.test', '+1-555-0100', 'Senior Groomer', 'Active', 0.2, '{"is_manager": true, "can_manage_discounts": true}'::jsonb)
+  (1, 'Sasha Taylor', 'sasha@scruffybutts.test', '+1-555-0101', 'Master Groomer', 'Active', 0.25, '{"is_manager": true}'::jsonb, 'ST', 'Specialises in hand scissoring and anxious pups.', 'bg-gradient-to-br from-amber-200/80 via-amber-300/70 to-amber-400/80 text-slate-900', 'sasha-taylor'),
+  (2, 'Myles Chen', 'myles@scruffybutts.test', '+1-555-0102', 'Senior Groomer', 'Active', 0.2, '{}'::jsonb, 'MC', 'Loves double coats, creative colour and doodles.', 'bg-gradient-to-br from-brand-bubble/80 via-brand-bubble/70 to-brand-lavender/80 text-slate-900', 'myles-chen'),
+  (3, 'Imani Hart', 'imani@scruffybutts.test', '+1-555-0103', 'Pet Stylist', 'Active', 0.18, '{}'::jsonb, 'IH', 'Speedy with bath & tidy packages and small breeds.', 'bg-gradient-to-br from-emerald-300/80 via-emerald-400/70 to-emerald-500/80 text-slate-900', 'imani-hart')
 on conflict (id) do update set
   name = excluded.name,
   email = excluded.email,
@@ -9,24 +13,120 @@ on conflict (id) do update set
   role = excluded.role,
   status = excluded.status,
   commission_rate = excluded.commission_rate,
-  app_permissions = excluded.app_permissions;
+  app_permissions = excluded.app_permissions,
+  initials = excluded.initials,
+  bio = excluded.bio,
+  calendar_color_class = excluded.calendar_color_class,
+  profile_slug = excluded.profile_slug;
 
-insert into public.staff_goals (staff_id, weekly_revenue_target, desired_dogs_per_day)
+-- Clients
+insert into public.clients (id, first_name, last_name, email, phone, notes)
 values
-  (1, 1500, 6)
-on conflict (staff_id) do update set
-  weekly_revenue_target = excluded.weekly_revenue_target,
-  desired_dogs_per_day = excluded.desired_dogs_per_day;
+  ('6fa3c4c2-6a93-4f63-8f7d-57fdc3b6b001', 'Jordan', 'Rivers', 'jordan@scruffybutts.test', '+1-555-0201', 'Prefers morning drop-offs'),
+  ('7c8aa5ef-146c-4a3b-97dc-237ff0d4f8e2', 'Ritika', 'Kaur', 'ritika@scruffybutts.test', '+1-555-0202', 'Always books Frodo for blueberry facials')
+on conflict (id) do update set
+  first_name = excluded.first_name,
+  last_name = excluded.last_name,
+  email = excluded.email,
+  phone = excluded.phone,
+  notes = excluded.notes;
 
-insert into public.appointments (id, employee_id, start_time, end_time, service, price, status, pet_name)
+-- Pets
+insert into public.pets (id, client_id, name, breed, notes)
 values
-  (1001, 1, timezone('utc', now()) - interval '1 day', timezone('utc', now()) - interval '1 day' + interval '1 hour', 'Full Groom', 85, 'completed', 'Biscuit'),
-  (1002, 1, timezone('utc', now()) + interval '1 day', timezone('utc', now()) + interval '1 day' + interval '1 hour', 'Bath & Brush', 45, 'scheduled', 'Mochi')
+  ('93f1d7c1-2aa0-4a5e-9f9f-8fb4d6f2b101', '6fa3c4c2-6a93-4f63-8f7d-57fdc3b6b001', 'Mocha', 'Cockapoo', 'Loves hypoallergenic shampoo'),
+  ('6c7a4c15-53d4-4ef5-8e57-17cd8e719eab', '7c8aa5ef-146c-4a3b-97dc-237ff0d4f8e2', 'Frodo', 'Mini Labradoodle', 'Owner picks up early'),
+  ('5d3ce79b-b3d3-428c-a0d7-7f5d5054f4f9', '7c8aa5ef-146c-4a3b-97dc-237ff0d4f8e2', 'Nova', 'Husky', null)
+on conflict (id) do update set
+  client_id = excluded.client_id,
+  name = excluded.name,
+  breed = excluded.breed,
+  notes = excluded.notes;
+
+-- Services
+insert into public.services (id, name, description, duration_min, base_price, buffer_pre_min, buffer_post_min, color_class)
+values
+  ('3a4cf0ed-a46c-4b22-9021-4b0dc6cc1001', 'Full Groom', 'Full groom including haircut, bath and nail trim.', 90, 85, 10, 15, 'bg-gradient-to-r from-brand-bubble/40 via-brand-bubble/25 to-transparent text-white'),
+  ('c5c8d942-a497-4b09-86d7-6a46f6d98202', 'Bath & Blowout', 'Deep clean bath with blowout finish.', 70, 60, 5, 10, 'bg-gradient-to-r from-sky-400/40 via-sky-400/20 to-transparent text-white'),
+  ('0d69b37a-1f47-4460-966d-2fa1e2c5b003', 'Paw Spa Package', 'Quick pamper session for paws and coat.', 45, 45, 0, 5, 'bg-gradient-to-r from-emerald-400/40 via-emerald-300/25 to-transparent text-white')
+on conflict (id) do update set
+  name = excluded.name,
+  description = excluded.description,
+  duration_min = excluded.duration_min,
+  base_price = excluded.base_price,
+  buffer_pre_min = excluded.buffer_pre_min,
+  buffer_post_min = excluded.buffer_post_min,
+  color_class = excluded.color_class;
+
+-- Service sizes
+insert into public.service_sizes (id, service_id, label, multiplier, sort_order)
+values
+  ('8823f6c5-54a0-4faf-97ae-75f1ba1a7001', '3a4cf0ed-a46c-4b22-9021-4b0dc6cc1001', 'Toy', 1.00, 0),
+  ('3d793488-5b38-4a26-9fbb-4d9b92c07002', '3a4cf0ed-a46c-4b22-9021-4b0dc6cc1001', 'Small', 1.20, 1),
+  ('9c68a469-cce1-40d9-8e5e-2b2946b8f003', '3a4cf0ed-a46c-4b22-9021-4b0dc6cc1001', 'Medium', 1.45, 2),
+  ('9b44d48d-44b9-4d95-8903-2c1c65898004', '3a4cf0ed-a46c-4b22-9021-4b0dc6cc1001', 'Large', 1.75, 3),
+  ('f4fa32c1-e5f2-4337-9f8f-96d5f77b6005', 'c5c8d942-a497-4b09-86d7-6a46f6d98202', 'Toy', 1.00, 0),
+  ('f89841b6-2751-4f3a-9b78-d3db142f9006', 'c5c8d942-a497-4b09-86d7-6a46f6d98202', 'Small', 1.10, 1),
+  ('838b1be6-8448-4c42-a602-9cfce8db1007', 'c5c8d942-a497-4b09-86d7-6a46f6d98202', 'Medium', 1.25, 2),
+  ('662674e4-9c1f-489b-a9b3-6b5ec3a3c008', 'c5c8d942-a497-4b09-86d7-6a46f6d98202', 'Large', 1.50, 3),
+  ('a1ed7bdc-58f5-4ca4-8bdf-19b4ae5e5009', '0d69b37a-1f47-4460-966d-2fa1e2c5b003', 'Toy', 1.00, 0),
+  ('f71bd419-7de1-4a5f-9582-8d408079c010', '0d69b37a-1f47-4460-966d-2fa1e2c5b003', 'Small', 1.15, 1),
+  ('d351a943-e9d5-4d7b-9c58-31710c825011', '0d69b37a-1f47-4460-966d-2fa1e2c5b003', 'Medium', 1.30, 2),
+  ('fb9f00b3-5c5a-44ee-8db6-5a692243f012', '0d69b37a-1f47-4460-966d-2fa1e2c5b003', 'Large', 1.50, 3)
+on conflict (id) do update set
+  label = excluded.label,
+  multiplier = excluded.multiplier,
+  sort_order = excluded.sort_order;
+
+-- Add-ons
+insert into public.add_ons (id, name, description, price)
+values
+  ('72932ce3-2d3f-4c46-83a4-3f8d667a9001', 'Teeth brushing', 'Gentle teeth brushing with enzymatic toothpaste.', 12),
+  ('8447f1c5-5d36-4a69-aacd-2a40145a6002', 'Blueberry facial', 'Brightening facial treatment for the muzzle.', 15),
+  ('7f91c0f3-0470-4a1f-8304-3e9f6fcb4003', 'Shed Guard', 'De-shedding treatment for heavy coats.', 20),
+  ('ce4f2237-9f5a-44b3-8454-97f12b6c6004', 'Pawdicure', 'Nail trim, file, and pad balm.', 18)
+on conflict (id) do update set
+  name = excluded.name,
+  description = excluded.description,
+  price = excluded.price;
+
+-- Service add-on availability
+insert into public.service_add_ons (service_id, add_on_id)
+values
+  ('3a4cf0ed-a46c-4b22-9021-4b0dc6cc1001', '72932ce3-2d3f-4c46-83a4-3f8d667a9001'),
+  ('3a4cf0ed-a46c-4b22-9021-4b0dc6cc1001', '7f91c0f3-0470-4a1f-8304-3e9f6fcb4003'),
+  ('c5c8d942-a497-4b09-86d7-6a46f6d98202', 'ce4f2237-9f5a-44b3-8454-97f12b6c6004'),
+  ('c5c8d942-a497-4b09-86d7-6a46f6d98202', '8447f1c5-5d36-4a69-aacd-2a40145a6002'),
+  ('0d69b37a-1f47-4460-966d-2fa1e2c5b003', '8447f1c5-5d36-4a69-aacd-2a40145a6002'),
+  ('0d69b37a-1f47-4460-966d-2fa1e2c5b003', '72932ce3-2d3f-4c46-83a4-3f8d667a9001')
+on conflict do nothing;
+
+-- Appointments
+insert into public.appointments (id, employee_id, client_id, pet_id, service_id, service_size_id, start_time, end_time, price, price_addons, discount, tax, status, notes)
+values
+  ('b38f558f-3df4-4b81-9cf5-6f1a36517001', 1, '6fa3c4c2-6a93-4f63-8f7d-57fdc3b6b001', '93f1d7c1-2aa0-4a5e-9f9f-8fb4d6f2b101', '3a4cf0ed-a46c-4b22-9021-4b0dc6cc1001', '9c68a469-cce1-40d9-8e5e-2b2946b8f003', timezone('utc', now()) - interval '1 day', timezone('utc', now()) - interval '1 day' + interval '90 minutes', 123, 12, 0, 8, 'completed', 'Prefers hypoallergenic shampoo'),
+  ('cd29caa6-f4a4-4f9a-8ce3-6acf91a6a002', 2, '7c8aa5ef-146c-4a3b-97dc-237ff0d4f8e2', '6c7a4c15-53d4-4ef5-8e57-17cd8e719eab', 'c5c8d942-a497-4b09-86d7-6a46f6d98202', 'f89841b6-2751-4f3a-9b78-d3db142f9006', timezone('utc', now()) + interval '1 day', timezone('utc', now()) + interval '1 day' + interval '70 minutes', 72, 18, 5, 6, 'booked', 'Owner will pick up early'),
+  ('f7f4dd7e-96a9-4e59-9cc8-3f2a8a14b003', 3, '7c8aa5ef-146c-4a3b-97dc-237ff0d4f8e2', '5d3ce79b-b3d3-428c-a0d7-7f5d5054f4f9', '0d69b37a-1f47-4460-966d-2fa1e2c5b003', 'fb9f00b3-5c5a-44ee-8db6-5a692243f012', timezone('utc', now()) + interval '2 days', timezone('utc', now()) + interval '2 days' + interval '45 minutes', 68, 15, 0, 5, 'booked', null)
 on conflict (id) do update set
   employee_id = excluded.employee_id,
+  client_id = excluded.client_id,
+  pet_id = excluded.pet_id,
+  service_id = excluded.service_id,
+  service_size_id = excluded.service_size_id,
   start_time = excluded.start_time,
   end_time = excluded.end_time,
-  service = excluded.service,
   price = excluded.price,
+  price_addons = excluded.price_addons,
+  discount = excluded.discount,
+  tax = excluded.tax,
   status = excluded.status,
-  pet_name = excluded.pet_name;
+  notes = excluded.notes;
+
+-- Appointment add-ons
+insert into public.appointment_add_ons (appointment_id, add_on_id, price)
+values
+  ('b38f558f-3df4-4b81-9cf5-6f1a36517001', '72932ce3-2d3f-4c46-83a4-3f8d667a9001', 12),
+  ('cd29caa6-f4a4-4f9a-8ce3-6acf91a6a002', 'ce4f2237-9f5a-44b3-8454-97f12b6c6004', 18),
+  ('cd29caa6-f4a4-4f9a-8ce3-6acf91a6a002', '8447f1c5-5d36-4a69-aacd-2a40145a6002', 15),
+  ('f7f4dd7e-96a9-4e59-9cc8-3f2a8a14b003', '8447f1c5-5d36-4a69-aacd-2a40145a6002', 15)
+on conflict do nothing;


### PR DESCRIPTION
## Summary
- fetch booking wizard staff, services, and add-ons without schema-specific filters and infer active flags locally so legacy tables don’t break
- update the calendar data loader to rely on schema-agnostic helpers for staff/service/add-on hydration, including color and initials fallbacks
- teach the shared calendar hook and employees list to derive active status from multiple fields instead of selecting missing columns

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d62d6360ec8324b247584cb8e41b0c