### PR TITLE
Unify staff roles with profile permissions

### DIFF
--- a/app/api/admin/claim-owner/route.ts
+++ b/app/api/admin/claim-owner/route.ts
@@ -29,7 +29,7 @@ export async function POST() {
   const upsertEmp = await admin
     .from("employees")
     .upsert(
-      { user_id: uid, name: "Owner", active: true, role: "Manager", app_permissions: { dashboard: true } },
+      { user_id: uid, name: "Owner", active: true, app_permissions: { dashboard: true } },
       { onConflict: "user_id" }
     );
   if (upsertEmp.error) return NextResponse.json({ error: upsertEmp.error.message }, { status: 400 });

--- a/app/api/admin/transfer-master/route.ts
+++ b/app/api/admin/transfer-master/route.ts
@@ -31,10 +31,18 @@ export async function POST(request: Request) {
   if (promote.error) return NextResponse.json({ error: promote.error.message }, { status: 400 });
 
   // Ensure employees row for target
-  await supabase.from("employees").upsert({
-    user_id: targetUserId, name: "Owner", active: true, role: "Manager",
-    business_id: me.data.business_id, app_permissions: { dashboard: true }
-  }, { onConflict: "user_id" });
+  await supabase
+    .from("employees")
+    .upsert(
+      {
+        user_id: targetUserId,
+        name: "Owner",
+        active: true,
+        business_id: me.data.business_id,
+        app_permissions: { dashboard: true },
+      },
+      { onConflict: "user_id" },
+    );
 
   return NextResponse.json({ ok: true });
 }

--- a/app/employees/[id]/components/StaffHeader.tsx
+++ b/app/employees/[id]/components/StaffHeader.tsx
@@ -2,6 +2,8 @@
 
 import clsx from "clsx";
 
+import { roleDisplayName } from "@/lib/auth/access";
+
 import { useEmployeeDetail } from "../EmployeeDetailClient";
 
 type StaffHeaderProps = {
@@ -26,8 +28,9 @@ export default function StaffHeader({ onCall, onText, onEmail }: StaffHeaderProp
   const statusLabel = employee.status
     ? employee.status
     : employee.active === false
-    ? "Inactive"
-    : "Active";
+        ? "Inactive"
+        : "Active";
+  const roleLabel = employee.role ? roleDisplayName(employee.role) : null;
 
   const statusTone = clsx(
     "rounded-full border px-3 py-1 text-xs font-semibold capitalize",
@@ -63,7 +66,7 @@ export default function StaffHeader({ onCall, onText, onEmail }: StaffHeaderProp
               <h1 className="text-xl font-semibold text-brand-navy">{employee.name ?? "Staff member"}</h1>
               <span className={statusTone}>{statusLabel}</span>
             </div>
-            <div className="text-sm font-medium text-slate-500">{employee.role ?? "—"}</div>
+            <div className="text-sm font-medium text-slate-500">{roleLabel ?? "—"}</div>
             <div className="text-sm text-slate-400">{contactDetails || "No contact info"}</div>
           </div>
         </div>

--- a/app/employees/[id]/settings/page.tsx
+++ b/app/employees/[id]/settings/page.tsx
@@ -24,6 +24,8 @@ import {
   toStoredPlan,
 } from "@/lib/compensationPlan";
 import { supabase } from "@/lib/supabase/client";
+import { roleDisplayName } from "@/lib/auth/access";
+import type { Role } from "@/lib/auth/profile";
 
 type PermissionKey =
   | "can_view_reports"
@@ -41,6 +43,14 @@ const PERMISSION_OPTIONS: PermissionOption[] = [
 ];
 
 const STATUS_OPTIONS = ["Active", "Inactive", "On leave"];
+
+const ROLE_OPTIONS: { value: Role; label: string }[] = [
+  { value: "master", label: roleDisplayName("master") },
+  { value: "admin", label: roleDisplayName("admin") },
+  { value: "senior_groomer", label: roleDisplayName("senior_groomer") },
+  { value: "groomer", label: roleDisplayName("groomer") },
+  { value: "receptionist", label: roleDisplayName("receptionist") },
+];
 
 export default function EmployeeSettingsPage() {
   const { employee, goals, viewerCanEditStaff, pushToast } = useEmployeeDetail();
@@ -60,9 +70,22 @@ export default function EmployeeSettingsPage() {
     return base;
   }, [employee.app_permissions]);
 
-  const [profile, setProfile] = useState({
+  const [profile, setProfile] = useState<{
+    name: string;
+    role: Role;
+    email: string;
+    phone: string;
+    avatar_url: string;
+    status: string;
+    address_street: string;
+    address_city: string;
+    address_state: string;
+    address_zip: string;
+    emergency_contact_name: string;
+    emergency_contact_phone: string;
+  }>({
     name: employee.name ?? "",
-    role: employee.role ?? "",
+    role: employee.role ?? "groomer",
     email: employee.email ?? "",
     phone: employee.phone ?? "",
     avatar_url: employee.avatar_url ?? "",
@@ -199,7 +222,7 @@ export default function EmployeeSettingsPage() {
 
   const handleProfileSave = async () => {
     setSaving((s) => ({ ...s, profile: true }));
-    const result = await saveProfileAction(employee.id, profile);
+    const result = await saveProfileAction(employee.id, employee.user_id ?? null, profile);
     setSaving((s) => ({ ...s, profile: false }));
     if (!result.success) {
       pushToast(result.error ?? "Failed to save profile", "error");
@@ -207,6 +230,12 @@ export default function EmployeeSettingsPage() {
     }
     setEditing((e) => ({ ...e, profile: false }));
     pushToast("Profile updated", "success");
+    if (!result.roleUpdated && !employee.user_id) {
+      pushToast(
+        "Link this staff member to a user account to change their permissions.",
+        "info",
+      );
+    }
   };
 
   const savePlanAndPermissions = async (
@@ -298,11 +327,16 @@ export default function EmployeeSettingsPage() {
         <div className="mt-4 grid gap-4 md:grid-cols-2">
           <TextField label="Name" value={profile.name} onChange={(v) => setProfile((p) => ({ ...p, name: v }))}
             disabled={!editing.profile || saving.profile} />
-          <TextField label="Role" value={profile.role} onChange={(v) => setProfile((p) => ({ ...p, role: v }))}
+          <SelectField
+            label="Role"
+            value={profile.role}
+            options={ROLE_OPTIONS}
+            onChange={(v) => setProfile((p) => ({ ...p, role: v as Role }))}
+            disabled={!editing.profile || saving.profile || !employee.user_id}
+          />
+        <TextField label="Email" value={profile.email} onChange={(v) => setProfile((p) => ({ ...p, email: v }))}
             disabled={!editing.profile || saving.profile} />
-          <TextField label="Email" value={profile.email} onChange={(v) => setProfile((p) => ({ ...p, email: v }))}
-            disabled={!editing.profile || saving.profile} />
-          <TextField label="Phone" value={profile.phone} onChange={(v) => setProfile((p) => ({ ...p, phone: v }))}
+        <TextField label="Phone" value={profile.phone} onChange={(v) => setProfile((p) => ({ ...p, phone: v }))}
             disabled={!editing.profile || saving.profile} />
           <TextField label="Avatar URL" value={profile.avatar_url} onChange={(v) => setProfile((p) => ({ ...p, avatar_url: v }))}
             disabled={!editing.profile || saving.profile} />
@@ -325,6 +359,11 @@ export default function EmployeeSettingsPage() {
           <TextField label="Emergency Contact Phone" value={profile.emergency_contact_phone}
             onChange={(v) => setProfile((p) => ({ ...p, emergency_contact_phone: v }))} disabled={!editing.profile || saving.profile} />
         </div>
+        {!employee.user_id && (
+          <p className="mt-2 text-xs text-slate-500">
+            Connect this staff record to a user account before changing their role or permissions.
+          </p>
+        )}
       </section>
 
       {/* App permissions */}
@@ -870,7 +909,8 @@ function TextField({ label, value, onChange, disabled }: TextFieldProps) {
   );
 }
 
-type SelectFieldProps = { label: string; value: string; options: string[]; onChange: (v: string) => void; disabled?: boolean };
+type SelectOption = string | { value: string; label: string };
+type SelectFieldProps = { label: string; value: string; options: SelectOption[]; onChange: (v: string) => void; disabled?: boolean };
 function SelectField({ label, value, options, onChange, disabled }: SelectFieldProps) {
   return (
     <label className="flex flex-col gap-1 text-sm text-slate-600">
@@ -881,9 +921,15 @@ function SelectField({ label, value, options, onChange, disabled }: SelectFieldP
         disabled={disabled}
         className="rounded-lg border border-slate-300 px-3 py-2 text-sm disabled:bg-slate-100"
       >
-        {options.map((option) => (
-          <option key={option} value={option}>{option}</option>
-        ))}
+        {options.map((option) => {
+          const { value: optionValue, label: optionLabel } =
+            typeof option === "string" ? { value: option, label: option } : option;
+          return (
+            <option key={optionValue} value={optionValue}>
+              {optionLabel}
+            </option>
+          );
+        })}
       </select>
     </label>
   );

--- a/app/employees/new/page.tsx
+++ b/app/employees/new/page.tsx
@@ -10,6 +10,7 @@ import Card from "@/components/Card";
 import PageContainer from "@/components/PageContainer";
 import { useAuth } from "@/components/AuthProvider";
 import { derivePermissionFlags } from "@/lib/auth/roles";
+import { normaliseRole } from "@/lib/auth/profile";
 import {
   CompensationPlanDraft,
   defaultCompensationPlan,
@@ -234,6 +235,12 @@ export default function NewEmployeePage() {
       return;
     }
 
+    const canonicalRole = normaliseRole(trimmedRole);
+    if (canonicalRole === "client") {
+      setError("Choose a staff role to continue");
+      return;
+    }
+
     const draftResult = parseDraft(compensationDraft);
     if (draftResult.errors.length > 0) {
       setError(draftResult.errors.join(" "));
@@ -249,7 +256,7 @@ export default function NewEmployeePage() {
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           name: trimmedName,
-          role: trimmedRole,
+          role: canonicalRole,
           email: form.email.trim(),
           phone: form.phone,
           address_street: form.addressStreet.trim() || null,

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -6,6 +6,8 @@ import Link from 'next/link';
 import { useAuth } from '@/components/AuthProvider';
 import { supabase } from '@/lib/supabase/client';
 import { canManageWorkspace } from '@/lib/auth/roles';
+import { normaliseRole, type Role } from '@/lib/auth/profile';
+import { roleDisplayName } from '@/lib/auth/access';
 
 export const dynamic = 'force-dynamic';
 
@@ -13,7 +15,7 @@ type TeamMember = {
   id: number | null;
   name: string | null;
   email: string | null;
-  role: string | null;
+  role: Role | null;
   app_permissions: Record<string, unknown> | null;
 };
 
@@ -27,8 +29,7 @@ const configurationLinks = [
 ];
 
 function hasElevatedAccess(member: TeamMember): boolean {
-  const role = member.role?.toLowerCase() ?? '';
-  if (role.includes('owner') || role.includes('admin') || role.includes('manager')) {
+  if (member.role && ['master', 'admin', 'senior_groomer'].includes(member.role)) {
     return true;
   }
 
@@ -66,12 +67,20 @@ export default function SettingsPage() {
     try {
       const { data, error } = await supabase
         .from('employees')
-        .select('id,name,email,role,app_permissions')
+        .select('id,name,email,app_permissions,profile:profiles(role)')
         .order('name');
 
       if (error) throw error;
 
-      const rows = (data ?? []) as TeamMember[];
+      const rows = ((data ?? []) as Array<
+        TeamMember & { profile?: { role?: string | null } | null }
+      >).map((row) => ({
+        id: row.id,
+        name: row.name,
+        email: row.email,
+        app_permissions: row.app_permissions,
+        role: row.profile?.role ? normaliseRole(row.profile.role) : null,
+      }));
       setTeam(rows.filter(hasElevatedAccess));
     } catch (error: any) {
       setErr(error?.message || 'Unable to load team members.');
@@ -180,7 +189,7 @@ export default function SettingsPage() {
                     {member.name ?? member.email ?? `Team member #${member.id ?? '—'}`}
                   </p>
                   <p className="text-xs text-brand-navy/60">
-                    {member.email ?? '—'} • {member.role ?? 'Team member'}
+              {member.email ?? '—'} • {member.role ? roleDisplayName(member.role) : 'Team member'}
                   </p>
                 </li>
               ))}

--- a/lib/auth/profile.ts
+++ b/lib/auth/profile.ts
@@ -21,6 +21,7 @@ export function normaliseName(value: unknown): string | null {
 const roleAliases: Record<string, Role> = {
   master: 'master',
   'master account': 'master',
+  owner: 'master',
   admin: 'admin',
   administrator: 'admin',
   'senior groomer': 'senior_groomer',
@@ -30,6 +31,7 @@ const roleAliases: Record<string, Role> = {
   'front desk': 'receptionist',
   'front_desk': 'receptionist',
   receptionist: 'receptionist',
+  assistant: 'receptionist',
   client: 'client',
 };
 

--- a/supabase/migrations/20260216_staff_role_unification.sql
+++ b/supabase/migrations/20260216_staff_role_unification.sql
@@ -1,0 +1,37 @@
+-- Ensure employees link to profiles for role management
+begin;
+
+alter table public.employees
+  add column if not exists user_id uuid references public.profiles(id) on delete set null;
+
+create unique index if not exists employees_user_id_unique
+  on public.employees(user_id)
+  where user_id is not null;
+
+with mapped as (
+  select
+    e.user_id,
+    case
+      when e.role is null or length(trim(e.role)) = 0 then null
+      when lower(e.role) in ('master account', 'master') then 'master'
+      when lower(e.role) in ('owner') then 'master'
+      when lower(e.role) in ('admin', 'administrator') then 'admin'
+      when lower(e.role) in ('manager', 'senior groomer', 'senior_groomer') then 'senior_groomer'
+      when lower(e.role) in ('front desk', 'front_desk', 'receptionist') then 'receptionist'
+      when lower(e.role) like 'groomer%' then 'groomer'
+      else null
+    end as resolved_role
+  from public.employees e
+  where e.user_id is not null
+)
+update public.profiles p
+set role = mapped.resolved_role
+from mapped
+where mapped.user_id = p.id
+  and mapped.resolved_role is not null
+  and mapped.resolved_role <> p.role;
+
+alter table public.employees
+  drop column if exists role;
+
+commit;


### PR DESCRIPTION
## Summary
- add a migration that drops `employees.role`, enforces the `user_id` link to profiles, and backfills profile roles
- normalise role aliases and update admin/staff APIs plus the invite flow to write roles exclusively through `profiles.role`
- update staff UI (detail header, settings, creation flow, and settings overview) to read canonical roles and gate editing on linked user accounts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6d5f5accc8324a38d1fe5fc14c6a6