### PR TITLE
Patch employees schema to include staff profile columns

### DIFF
--- a/app/(app)/booking/BookingClient.tsx
+++ b/app/(app)/booking/BookingClient.tsx
@@ -163,7 +163,7 @@ export default function BookingClient() {
       setLoadError(null);
       try {
         const [staffResp, servicesResp, sizeResp, addOnResp, petsResp, apptResp] = await Promise.all([
-          supabase.from("employees").select("*").order("name"),
+          supabase.from("v_staff_calendar").select("*").order("full_name"),
           supabase.from("services").select("*").order("name"),
           supabase
             .from("service_sizes")
@@ -233,7 +233,10 @@ export default function BookingClient() {
             .map((row, index) => {
               const baseId = coerceString(row.id, "");
               const id = baseId || `staff-${index + 1}`;
-              const name = coerceString(row.name, baseId ? `Staff #${baseId}` : `Staff #${index + 1}`);
+              const name = coerceString(
+                row.full_name ?? row.name,
+                baseId ? `Staff #${baseId}` : `Staff #${index + 1}`,
+              );
               const avatarFallback = `https://avatars.dicebear.com/api/initials/${encodeURIComponent(name)}.svg`;
               return {
                 id,

--- a/app/(app)/calendar/page.tsx
+++ b/app/(app)/calendar/page.tsx
@@ -238,7 +238,7 @@ export default function CalendarPage() {
         rangeEnd.setHours(23, 59, 59, 999);
 
         const [staffResp, serviceResp, sizeResp, addOnResp] = await Promise.all([
-          supabase.from("employees").select("*").order("name"),
+          supabase.from("v_staff_calendar").select("*").order("full_name"),
           supabase.from("services").select("*").order("name"),
           supabase
             .from("service_sizes")
@@ -352,7 +352,10 @@ export default function CalendarPage() {
           .filter((row) => inferIsActive(row))
           .map((row, index) => {
             const baseId = coerceString(row.id, "");
-            const name = coerceString(row.name, baseId ? `Staff #${baseId}` : `Staff #${index + 1}`);
+            const name = coerceString(
+              row.full_name ?? row.name,
+              baseId ? `Staff #${baseId}` : `Staff #${index + 1}`,
+            );
             const providedInitials =
               typeof row.initials === "string" && row.initials.trim().length > 0
                 ? row.initials.trim().slice(0, 2).toUpperCase()
@@ -364,7 +367,7 @@ export default function CalendarPage() {
               .join("")
               .slice(0, 2);
             const initials = providedInitials ?? (generatedInitials || name.slice(0, 2).toUpperCase());
-            const colorCandidates = [row.calendar_color_class, row.color_class].map((value) =>
+            const colorCandidates = [row.color_hex, row.calendar_color_class, row.color_class].map((value) =>
               typeof value === "string" && value.trim().length > 0 ? value.trim() : null
             );
             const colorClass =

--- a/supabase/migrations/20240709_v_staff_calendar.sql
+++ b/supabase/migrations/20240709_v_staff_calendar.sql
@@ -1,0 +1,17 @@
+create or replace view public.v_staff_calendar as
+select
+  e.id,
+  e.name,
+  e.name as full_name,
+  e.initials,
+  e.avatar_url,
+  e.calendar_color_class,
+  e.color_class,
+  coalesce(nullif(trim(e.calendar_color_class), ''), nullif(trim(e.color_class), '')) as color_hex,
+  e.role,
+  e.bio,
+  e.status,
+  e.active,
+  e.app_permissions
+from public.employees e
+where coalesce(lower(e.status), case when coalesce(e.active, false) then 'active' else 'inactive' end) = 'active';

--- a/supabase/migrations/20240927_patch_employee_columns.sql
+++ b/supabase/migrations/20240927_patch_employee_columns.sql
@@ -1,0 +1,77 @@
+-- Ensure employee schema matches application expectations for staff profile features
+
+alter table public.employees
+  add column if not exists status text,
+  add column if not exists initials text,
+  add column if not exists color_class text,
+  add column if not exists calendar_color_class text,
+  add column if not exists avatar_url text,
+  add column if not exists emergency_contact_name text,
+  add column if not exists emergency_contact_phone text,
+  add column if not exists address_street text,
+  add column if not exists address_city text,
+  add column if not exists address_state text,
+  add column if not exists address_zip text,
+  add column if not exists bio text,
+  add column if not exists app_permissions jsonb default '{}'::jsonb,
+  add column if not exists compensation_plan jsonb default '{}'::jsonb,
+  add column if not exists preferred_breeds text[] default '{}',
+  add column if not exists not_accepted_breeds text[] default '{}',
+  add column if not exists specialties text[] default '{}',
+  add column if not exists manager_notes text;
+
+alter table public.employees
+  alter column app_permissions set default '{}'::jsonb,
+  alter column preferred_breeds set default '{}',
+  alter column not_accepted_breeds set default '{}',
+  alter column specialties set default '{}',
+  alter column compensation_plan set default '{}'::jsonb,
+  alter column status set default 'active';
+
+-- Normalise status values to lowercase keywords
+update public.employees
+set status = case
+  when status is null and coalesce(active, false) then 'active'
+  when status is null and not coalesce(active, false) then 'inactive'
+  when lower(status) in ('active', 'inactive') then lower(status)
+  else null
+end
+where status is distinct from case
+  when status is null and coalesce(active, false) then 'active'
+  when status is null and not coalesce(active, false) then 'inactive'
+  when lower(status) in ('active', 'inactive') then lower(status)
+  else null
+end;
+
+-- Enforce allowed status values if the column exists
+alter table public.employees
+  drop constraint if exists employees_status_check;
+
+alter table public.employees
+  add constraint employees_status_check check (status is null or status in ('active','inactive'));
+
+-- Ensure goals table exists for staff preferences panel
+create table if not exists public.staff_goals (
+  staff_id bigint primary key references public.employees(id) on delete cascade,
+  weekly_revenue_target numeric,
+  desired_dogs_per_day int,
+  updated_at timestamptz not null default timezone('utc'::text, now())
+);
+
+alter table public.staff_goals enable row level security;
+
+create policy if not exists "staff_goals_read" on public.staff_goals
+  for select
+  using (
+    auth.role() = 'authenticated'
+    and (
+      coalesce((auth.jwt() ->> 'is_manager')::boolean, false)
+      or staff_id::text = coalesce(auth.jwt() ->> 'employee_id', '0')
+    )
+  );
+
+create policy if not exists "staff_goals_manage" on public.staff_goals
+  for all
+  using (coalesce((auth.jwt() ->> 'is_manager')::boolean, false))
+  with check (coalesce((auth.jwt() ->> 'is_manager')::boolean, false));
+


### PR DESCRIPTION
## Summary
- add a migration that ensures the `employees` table exposes the profile fields the app expects, including status and compensation metadata
- backfill status defaults, enforce the valid state list, and create the `staff_goals` table with RLS policies when missing

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6fba8be248324ba93f8911532e528