### PR TITLE
Prevent logout button text wrapping

### DIFF
--- a/components/LogoutButton.tsx
+++ b/components/LogoutButton.tsx
@@ -11,7 +11,7 @@ export default function LogoutButton() {
   return (
     <button
       type="button"
-      className="rounded-full bg-white/20 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-white/30"
+      className="rounded-full bg-white/20 px-3 py-1.5 text-sm font-medium text-white transition hover:bg-white/30 whitespace-nowrap"
       onClick={async () => {
         await supabase.auth.signOut()
         await refresh()


### PR DESCRIPTION
## Summary
- ensure the logout button text stays on a single line by preventing wrapping

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d719bdcc908324b62caf73724435cd