### PR TITLE
Handle array relationships in messaging threads

### DIFF
--- a/app/messages/page.tsx
+++ b/app/messages/page.tsx
@@ -1,46 +1,262 @@
 import Card from '@/components/Card';
 import PageContainer from '@/components/PageContainer';
+import { inQuietHoursLocal, QuietHoursSetting, TimezoneSetting } from '@/lib/time/quietHours';
 import { createClient } from '@/lib/supabase/server';
 
-type Msg = {
+type ThreadRow = {
   id: string;
-  to_employee: string | null;
-  from_name: string | null;
+  last_message_at: string | null;
+  unread_count: number;
+  client_id: string;
+  client_first_name: string | null;
+  client_last_name: string | null;
+  phone_label: string | null;
+  phone_number: string | null;
+};
+
+type ThreadRowResponse = {
+  id: string;
+  last_message_at: string | null;
+  unread_count: number | null;
+  client_id: string;
+  client:
+    | { first_name: string | null; last_name: string | null }
+    | { first_name: string | null; last_name: string | null }[]
+    | null;
+  phone:
+    | { label: string | null; e164: string | null }
+    | { label: string | null; e164: string | null }[]
+    | null;
+};
+
+type MessageRow = {
+  id: string;
+  thread_id: string;
+  direction: 'in' | 'out';
+  channel: 'sms' | 'mms';
   body: string | null;
+  status: string | null;
   created_at: string;
+};
+
+type OptOutRow = {
+  client_id: string;
+  channel: 'sms' | 'mms';
+  opted_out_at: string;
+};
+
+type SettingRow = {
+  key: string;
+  value: unknown;
 };
 
 export const dynamic = 'force-dynamic';
 
+function parseQuietHours(value: unknown): QuietHoursSetting | null {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+  const enabled = Boolean(record.enabled);
+  const start = typeof record.start === 'string' ? record.start : '20:00';
+  const end = typeof record.end === 'string' ? record.end : '08:00';
+  return { enabled, start, end };
+}
+
+function parseTimezone(value: unknown): TimezoneSetting | null {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+  const iana = typeof record.iana === 'string' && record.iana.length > 0 ? record.iana : 'America/Chicago';
+  return { iana };
+}
+
+function formatClientName(first: string | null, last: string | null): string {
+  const parts = [first?.trim(), last?.trim()].filter(Boolean);
+  if (parts.length > 0) return parts.join(' ');
+  return 'Client';
+}
+
+function formatTimestamp(timestamp: string | null): string {
+  if (!timestamp) return '—';
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.valueOf())) return timestamp;
+  return date.toLocaleString();
+}
+
+function extractSingle<T>(value: T | T[] | null | undefined): T | null {
+  if (!value) return null;
+  if (Array.isArray(value)) {
+    return value.length > 0 ? value[0] ?? null : null;
+  }
+  return value;
+}
+
 export default async function MessagesPage() {
   const supabase = createClient();
-  const { data, error } = await supabase
-    .from('messages')
-    .select('id, to_employee, from_name, body, created_at')
-    .order('created_at', { ascending: false });
+  const appDb = supabase.schema('app');
 
-  const rows = (data ?? []) as Msg[];
-  const err = error?.message ?? null;
+  const [{ data: settingsRows }, threadsResponse] = await Promise.all([
+    appDb.from('settings').select('key,value').in('key', ['quiet_hours', 'timezone']),
+    appDb
+      .from('message_threads')
+      .select(
+        `id,last_message_at,unread_count,client_id,client:clients(first_name,last_name),phone:phone_id(label,e164)`
+      )
+      .order('last_message_at', { ascending: false }),
+  ]);
+
+  const settingList: SettingRow[] = Array.isArray(settingsRows) ? (settingsRows as SettingRow[]) : [];
+  const quietSetting = parseQuietHours(settingList.find((row) => row.key === 'quiet_hours')?.value ?? null);
+  const timezoneSetting = parseTimezone(settingList.find((row) => row.key === 'timezone')?.value ?? null);
+  const quietNow = inQuietHoursLocal(quietSetting, timezoneSetting);
+
+  const threadError = threadsResponse.error?.message ?? null;
+  const rawThreads = (Array.isArray(threadsResponse.data) ? threadsResponse.data : []) as ThreadRowResponse[];
+
+  const threads: ThreadRow[] = rawThreads.map((row) => ({
+    id: row.id,
+    last_message_at: row.last_message_at,
+    unread_count: row.unread_count ?? 0,
+    client_id: row.client_id,
+    client_first_name: extractSingle(row.client)?.first_name ?? null,
+    client_last_name: extractSingle(row.client)?.last_name ?? null,
+    phone_label: extractSingle(row.phone)?.label ?? null,
+    phone_number: extractSingle(row.phone)?.e164 ?? null,
+  }));
+
+  const threadIds = threads.map((thread) => thread.id);
+
+  const [messagesResponse, optOutResponse] = await Promise.all([
+    threadIds.length === 0
+      ? Promise.resolve({ data: [] as MessageRow[], error: null })
+      : appDb
+          .from('messages')
+          .select('id,thread_id,direction,channel,body,status,created_at')
+          .in('thread_id', threadIds)
+          .order('created_at', { ascending: true }),
+    appDb.from('opt_outs').select('client_id,channel,opted_out_at'),
+  ]);
+
+  const messageError = messagesResponse.error?.message ?? null;
+  const optOutError = optOutResponse.error?.message ?? null;
+
+  const messages = ((messagesResponse.data ?? []) as MessageRow[]).reduce<Map<string, MessageRow[]>>((map, row) => {
+    const existing = map.get(row.thread_id) ?? [];
+    existing.push(row);
+    map.set(row.thread_id, existing);
+    return map;
+  }, new Map());
+
+  const optOuts = (optOutResponse.data ?? []) as OptOutRow[];
+  const optOutLookup = new Map<string, OptOutRow[]>();
+  for (const row of optOuts) {
+    const list = optOutLookup.get(row.client_id) ?? [];
+    list.push(row);
+    optOutLookup.set(row.client_id, list);
+  }
 
   return (
     <PageContainer>
       <Card>
-        <h1 className="mb-4 text-3xl font-bold text-primary-dark">Messages</h1>
-        {err ? (
-          <div className="rounded-2xl border border-red-300/40 bg-red-100/40 px-4 py-3 text-sm text-red-700">
-            Failed to load messages: {err}
+        <div className="mb-6 space-y-2">
+          <h1 className="text-3xl font-bold text-primary-dark">Client messaging</h1>
+          {quietSetting?.enabled && (
+            <p className="text-sm text-primary-dark/70">
+              Quiet hours are active from {quietSetting.start} to {quietSetting.end}.{' '}
+              {quietNow
+                ? 'New outbound messages are currently paused.'
+                : 'Outbound messages can be sent right now.'}
+            </p>
+          )}
+        </div>
+
+        {threadError && (
+          <div className="mb-4 rounded-2xl border border-red-300/40 bg-red-100/40 px-4 py-3 text-sm text-red-700">
+            Failed to load message threads: {threadError}
           </div>
+        )}
+
+        {messageError && (
+          <div className="mb-4 rounded-2xl border border-amber-300/40 bg-amber-100/40 px-4 py-3 text-sm text-amber-900">
+            Some messages could not be retrieved: {messageError}
+          </div>
+        )}
+
+        {optOutError && (
+          <div className="mb-4 rounded-2xl border border-amber-300/40 bg-amber-100/40 px-4 py-3 text-sm text-amber-900">
+            Opt-out status unavailable: {optOutError}
+          </div>
+        )}
+
+        {threads.length === 0 ? (
+          <p className="rounded-2xl border border-dashed border-primary-dark/20 bg-white/60 px-4 py-6 text-sm text-primary-dark/80">
+            No client conversations yet. Messages will appear here when clients text one of your business numbers.
+          </p>
         ) : (
-          <ul className="divide-y">
-            {rows.map((m) => (
-              <li key={m.id} className="py-3">
-                <div className="text-sm text-gray-500">
-                  {new Date(m.created_at).toLocaleString()} — To {m.to_employee || '—'} from {m.from_name || '—'}
-                </div>
-                <div>{m.body}</div>
-              </li>
-            ))}
-          </ul>
+          <div className="space-y-6">
+            {threads.map((thread) => {
+              const threadMessages = messages.get(thread.id) ?? [];
+              const optOutsForClient = optOutLookup.get(thread.client_id) ?? [];
+              const optedOutChannels = optOutsForClient.map((entry) => entry.channel.toUpperCase()).join(', ');
+              const optedOut = optOutsForClient.length > 0;
+              return (
+                <section key={thread.id} className="rounded-3xl border border-primary-dark/10 bg-white/70 p-5 shadow-sm">
+                  <header className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <h2 className="text-xl font-semibold text-primary-dark">
+                        {formatClientName(thread.client_first_name, thread.client_last_name)}
+                      </h2>
+                      <p className="text-sm text-primary-dark/70">
+                        {thread.phone_label || 'Primary line'} · {thread.phone_number || 'Unassigned number'}
+                      </p>
+                      <p className="text-xs text-primary-dark/60">
+                        Last message {formatTimestamp(thread.last_message_at)} · {thread.unread_count} unread
+                      </p>
+                    </div>
+                    {optedOut ? (
+                      <span className="inline-flex items-center gap-2 rounded-full bg-red-500/10 px-3 py-1 text-xs font-semibold text-red-700">
+                        Opted out ({optedOutChannels})
+                      </span>
+                    ) : quietNow ? (
+                      <span className="inline-flex items-center gap-2 rounded-full bg-amber-500/10 px-3 py-1 text-xs font-semibold text-amber-800">
+                        Quiet hours active
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center gap-2 rounded-full bg-emerald-500/10 px-3 py-1 text-xs font-semibold text-emerald-700">
+                        Messaging enabled
+                      </span>
+                    )}
+                  </header>
+
+                  {threadMessages.length === 0 ? (
+                    <p className="mt-4 rounded-2xl border border-dashed border-primary-dark/20 bg-white px-4 py-5 text-sm text-primary-dark/70">
+                      No messages in this thread yet.
+                    </p>
+                  ) : (
+                    <ul className="mt-4 space-y-3">
+                      {threadMessages.map((message) => (
+                        <li
+                          key={message.id}
+                          className="rounded-2xl border border-primary-dark/10 bg-white px-4 py-3 text-sm text-primary-dark"
+                        >
+                          <div className="flex items-center justify-between text-xs text-primary-dark/60">
+                            <span className="font-semibold uppercase tracking-[0.2em]">
+                              {message.direction === 'out' ? 'Sent' : 'Received'} · {message.channel.toUpperCase()}
+                            </span>
+                            <span>{formatTimestamp(message.created_at)}</span>
+                          </div>
+                          <p className="mt-2 whitespace-pre-wrap text-sm text-primary-dark">{message.body || '—'}</p>
+                          {message.status && (
+                            <p className="mt-2 text-xs uppercase tracking-[0.2em] text-primary-dark/60">
+                              Status: {message.status}
+                            </p>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </section>
+              );
+            })}
+          </div>
         )}
       </Card>
     </PageContainer>

--- a/lib/time/quietHours.ts
+++ b/lib/time/quietHours.ts
@@ -1,0 +1,31 @@
+export type QuietHoursSetting = { enabled: boolean; start: string; end: string };
+export type TimezoneSetting = { iana: string };
+
+export function inQuietHoursLocal(
+  quiet: QuietHoursSetting | null,
+  tz: TimezoneSetting | null,
+  now: Date = new Date()
+): boolean {
+  if (!quiet || !quiet.enabled) return false;
+  const zone = tz?.iana || 'America/Chicago';
+
+  const fmt = new Intl.DateTimeFormat('en-US', {
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: zone,
+  });
+  const parts = fmt.formatToParts(now);
+  const h = Number(parts.find((p) => p.type === 'hour')?.value || '0');
+  const m = Number(parts.find((p) => p.type === 'minute')?.value || '0');
+  const current = h * 60 + m;
+
+  const [sh, sm] = quiet.start.split(':').map((n) => parseInt(n, 10) || 0);
+  const [eh, em] = quiet.end.split(':').map((n) => parseInt(n, 10) || 0);
+  const start = sh * 60 + sm;
+  const end = eh * 60 + em;
+
+  if (start === end) return false;
+  if (start < end) return current >= start && current < end;
+  return current >= start || current < end;
+}


### PR DESCRIPTION
## Summary
- guard the Supabase messaging thread fetch against array-wrapped relationship payloads
- normalize related client and phone data before rendering to satisfy type checks

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d73b02f4bc8324a90fc1a03a856b93