### PR TITLE
Add minimal permissions to prod smoke workflow

### DIFF
--- a/.github/workflows/prod-smoke.yml
+++ b/.github/workflows/prod-smoke.yml
@@ -1,5 +1,8 @@
 name: Prod Smoke (Minimal)
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
## Summary
- restrict the Prod Smoke (Minimal) workflow to read-only repository contents

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7dd2a292883248c4d4bb91fda7c83